### PR TITLE
feat: add Dependabot configuration for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,25 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot version updates configuration.
+# See docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

Configures Dependabot version updates for the repository to keep Python dependencies and GitHub Actions up to date with minimal noise.

## Changes

- **pip**: monthly grouped updates with \+versioning-strategy: increase\+ and a limit of 3 open PRs.
- **GitHub Actions**: monthly grouped updates with a limit of 3 open PRs.

## Rationale

- Grouped updates reduce PR noise for a benchmark\/research repository.
- Monthly interval avoids frequent distractions.
- Capping open PRs to 3 prevents update backlogs.
- `versioning-strategy: increase` ensures open-ended ranges in `pyproject.toml` (e.g., `>=1.2.0`) are actively bumped to the latest version, rather than silently satisfied.

## Checklist

- [x] Dependabot settings enabled on the repository side.
- [x] `.github\/dependabot.yml` configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Dependabot to create monthly automated updates for Python packages and GitHub Actions. Updates are grouped by ecosystem and use an increase versioning strategy for Python. Concurrent open pull requests are limited to 3 per ecosystem group to reduce noise and simplify review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->