### PR TITLE
temporarily disable i18n-sync check

### DIFF
--- a/.github/workflows/i18n-sync.yml
+++ b/.github/workflows/i18n-sync.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-i18n-sync:
+    if: false # Temporarily disable this job until experiments, solvers and runtimes stablize
     runs-on: ubuntu-latest
     # Non-blocking: failures in this job must not block CI
     continue-on-error: true


### PR DESCRIPTION
Disable the i18n-sync GitHub Actions workflow temporarily to stop automated reminder issues.

Fixes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled the internationalization synchronization automation in the continuous integration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->