### PR TITLE
feat(issue-80): Add aeossp_standard greedy/LNS reproduced solver

### DIFF
--- a/experiments/main_solver/config.yaml
+++ b/experiments/main_solver/config.yaml
@@ -5,3 +5,4 @@ solvers:
   - satnet_milp_claudet2022
   - satnet_rl_ppo_goh2021
   - aeossp_standard_mwis_conflict_graph
+  - aeossp_standard_greedy_lns

--- a/experiments/main_solver/solvers/aeossp_standard_greedy_lns.yaml
+++ b/experiments/main_solver/solvers/aeossp_standard_greedy_lns.yaml
@@ -1,0 +1,29 @@
+id: aeossp_standard_greedy_lns
+benchmark: aeossp_standard
+solver: greedy_lns
+solver_path: solvers/aeossp_standard/greedy_lns
+evidence_type: reproduced_solver
+runnable: true
+setup_script: setup.sh
+solve_script: solve.sh
+solution_filename: solution.json
+cases:
+  - id: test/case_0001
+    case_dir: benchmarks/aeossp_standard/dataset/cases/test/case_0001
+  - id: test/case_0002
+    case_dir: benchmarks/aeossp_standard/dataset/cases/test/case_0002
+  - id: test/case_0003
+    case_dir: benchmarks/aeossp_standard/dataset/cases/test/case_0003
+  - id: test/case_0004
+    case_dir: benchmarks/aeossp_standard/dataset/cases/test/case_0004
+  - id: test/case_0005
+    case_dir: benchmarks/aeossp_standard/dataset/cases/test/case_0005
+verifier:
+  command:
+    - uv
+    - run
+    - python
+    - -m
+    - benchmarks.aeossp_standard.verifier.run
+    - "{case_dir}"
+    - "{solution_path}"

--- a/solvers/aeossp_standard/greedy_lns/README.md
+++ b/solvers/aeossp_standard/greedy_lns/README.md
@@ -1,0 +1,190 @@
+# AEOSSP Greedy-LNS Solver
+
+This solver is a runnable reproduced solver for `aeossp_standard`.
+
+It follows the acquisition-planning method described by Vincent Antuori, Damien Wojtowicz, and Emmanuel Hebrard in "Solving the Agile Earth Observation Satellite Scheduling Problem with CP and Local Search", adapted to the benchmark's public case and solution contract.
+
+## Citation
+
+```bibtex
+@inproceedings{antuori2025solving,
+  title={Solving the Agile Earth Observation Satellite Scheduling Problem with CP and Local Search},
+  author={Antuori, Vincent and Wojtowicz, Damien and Hebrard, Emmanuel},
+  booktitle={31st International Conference on Principles and Practice of Constraint Programming (CP 2025)},
+  series={Leibniz International Proceedings in Informatics},
+  volume={340},
+  pages={3:1--3:18},
+  year={2025},
+  doi={10.4230/LIPIcs.CP.2025.3}
+}
+```
+
+The solver is standalone. It reads benchmark case files and writes a benchmark solution JSON, but it does not import or execute benchmark, experiment, runtime, or other solver internals.
+
+## Method Summary
+
+The paper decomposes agile Earth-observation scheduling into acquisition planning and download planning. This reproduction keeps the acquisition side and adapts it to `aeossp_standard`:
+
+- **Candidate**: one grid-aligned `(satellite_id, task_id, start_time, end_time)` observation that satisfies sensor matching, task window, geometry, and initial slew feasibility.
+- **Utility**: task `weight / duration` by default, with deterministic tie-breaks for higher weight, earlier due time, lower transition increment, and candidate id.
+- **Greedy insertion**: candidates are processed in descending utility order; each candidate is inserted into its satellite's schedule if it does not overlap an existing action, violate transition gaps, or duplicate an already scheduled task.
+- **Connected-component local search**: the solver builds a same-satellite dependence graph from overlap and transition edges, extracts connected components, and repeatedly attempts to improve the incumbent by removing all selected candidates in one component and reinserting them via marginal-profit greedy ordering against the current global selection.
+- **Repair**: solver-local validation checks the final schedule for overlap, transition, initial slew, duplicate task, and battery issues; any violations are resolved by iteratively removing the lowest-utility violating candidate.
+
+## Benchmark Adaptation
+
+The benchmark differs from the paper in a few important ways:
+
+- The benchmark ranks by valid first, then `WCR`, `CR`, `TAT`, and `PC`, so the solver uses weighted selection rather than pure collect count.
+- Observation actions must be exactly aligned to the public action grid and must match each task's exact duration.
+- Slew feasibility uses the benchmark's scalar bang-coast-bang plus settling semantics rather than the paper's time-independent transition matrix.
+- Battery is not naturally pairwise, so it is not encoded in the dependence graph. Instead, the solver performs solver-local validation and bounded repair after greedy insertion and local search.
+- The benchmark is observation-only; download and memory planning are out of scope.
+
+That means this solver reproduces the paper's greedy construction and connected-component local-search approach, while remaining faithful to the benchmark's public validity contract.
+
+## Solver Contract
+
+```bash
+./setup.sh
+./solve.sh <case_dir> [config_dir] [solution_dir]
+```
+
+`setup.sh` is effectively a no-op when using the project environment.
+
+`solve.sh` writes:
+
+- `solution.json`: primary benchmark solution
+- `status.json`: solver summary, timings, reproduction notes, and local validation details
+- `debug/*`: optional debug artifacts when `debug: true`
+
+The primary solution artifact is one JSON object with a top-level `actions` array of `observation` actions.
+
+## Pipeline
+
+The solver pipeline is:
+
+1. Load `mission.yaml`, `satellites.yaml`, and `tasks.yaml`.
+2. Generate grid-aligned observation candidates that satisfy sensor matching, task windows, observation geometry, and first-action slew feasibility.
+3. Build a deterministic greedy schedule by inserting candidates in descending utility order.
+4. Improve the schedule with first-improving connected-component local search using marginal-profit recomputation.
+5. Run solver-local validation and bounded repair to remove any remaining issues, especially battery depletion risk.
+
+The repair stage is intentionally conservative. It keeps the solver standalone and reduces official verifier failures without claiming that battery feasibility is fully proven by the greedy/LNS core.
+
+## Configuration
+
+The solver reads optional config from either:
+
+- `<config_dir>/config.yaml`
+- `<config_dir>/config.yml`
+- `<config_dir>/config.json`
+- `<config_dir>/greedy_lns.yaml`
+- `<config_dir>/greedy_lns.yml`
+- `<config_dir>/greedy_lns.json`
+
+See [config.example.yaml](./config.example.yaml) for a commented example.
+
+Key knobs:
+
+- `candidate_stride_multiplier`
+- `max_candidates`
+- `max_candidates_per_task`
+- `minimize_transition_increment`
+- `max_local_search_iterations`
+- `max_local_search_time_s`
+- `restart_count`
+- `random_seed`
+- `stochastic_ordering`
+- `max_repair_iterations`
+- `debug`
+
+`max_local_search_time_s` only bounds the local-search loop. It does not cap candidate generation or local validation. If the time budget is reached, the solver returns the best incumbent found so far and still performs local validation and repair.
+
+## Debug Artifacts
+
+When `debug: true`, the solver writes:
+
+- `debug/candidate_summary.json`
+- `debug/candidates.json`
+- `debug/insertion_stats.json`
+- `debug/local_search_stats.json`
+- `debug/component_summary.json`
+- `debug/validation_summary.json`
+- `debug/repair_log.json`
+- `debug/repaired_candidates.json`
+
+These are useful for answering:
+
+- why a task has zero candidates
+- how many candidates were greedily inserted and why others were skipped
+- how dense the per-satellite dependence graph is
+- which local-search moves were accepted or rejected
+- whether a time budget stopped search
+- why a candidate was removed during local repair
+- how local validity changed from pre-repair to post-repair
+
+## Running It
+
+Direct setup:
+
+```bash
+./solvers/aeossp_standard/greedy_lns/setup.sh
+```
+
+Direct solve on a public smoke case:
+
+```bash
+./solvers/aeossp_standard/greedy_lns/solve.sh \
+  benchmarks/aeossp_standard/dataset/cases/test/case_0001
+```
+
+Direct solve with a config directory:
+
+```bash
+./solvers/aeossp_standard/greedy_lns/solve.sh \
+  benchmarks/aeossp_standard/dataset/cases/test/case_0001 \
+  /path/to/config_dir \
+  /tmp/aeossp_greedy_lns_solution
+```
+
+Official smoke verification through `main_solver`:
+
+```bash
+uv run python experiments/main_solver/run.py \
+  --benchmark aeossp_standard \
+  --solver aeossp_standard_greedy_lns \
+  --case test/case_0001
+```
+
+Aggregate experiment results:
+
+```bash
+uv run python experiments/main_solver/aggregate.py
+```
+
+## Sanity Baseline
+
+The paper reports profit gaps against upper bounds, not benchmark `WCR`, `CR`, `TAT`, or `PC`. Acquisition-only Greedy/LS-tempo averaged roughly a 0.115 gap on the authors' generated instances. For this benchmark, the closest sanity check
+is whether the solver produces valid solutions with plausible candidate counts and weighted completion ratios.
+
+What matters here is:
+
+- official verification passes
+- candidate counts are plausible
+- repair does not collapse the schedule
+- weighted completion remains reasonable on public cases
+
+If raw greedy/local-search selection looks strong but repair removes many actions, inspect the local battery model, transition gap logic, and candidate generation before tuning search parameters.
+
+## Known Limitations
+
+- This is a reproduction of the paper's acquisition-planning method, not a claim to reproduce every runtime or every table from the paper.
+- The solver does not include the paper's Tempo CP-SAT TSPTW fallback, which is a proprietary dependency.
+- Battery feasibility is handled by solver-local validation and repair instead of being fully encoded inside the greedy/LNS core.
+- Candidate generation is currently unoptimized and dominates runtime on larger cases. A future issue may address efficiency.
+- Download and memory scheduling are omitted because the benchmark is observation-only.
+
+## Evidence Type
+
+This solver is registered in `experiments/main_solver` with `evidence_type: reproduced_solver`.

--- a/solvers/aeossp_standard/greedy_lns/config.example.yaml
+++ b/solvers/aeossp_standard/greedy_lns/config.example.yaml
@@ -1,0 +1,52 @@
+# Example configuration for the aeossp_standard greedy-LNS solver.
+# Copy or rename this file to config.yaml (or config.json) in your
+# config directory and adjust values as needed.
+
+# --- Candidate generation ---
+# Stride multiplier for candidate start-time grid.  1 = every grid step,
+# 2 = every second grid step, etc.  Larger values reduce candidate count.
+candidate_stride_multiplier: 1
+
+# Hard cap on total candidates across all satellites and tasks.
+# null = no limit.
+max_candidates: null
+
+# Hard cap on candidates per individual task.
+# null = no limit.
+max_candidates_per_task: null
+
+# --- Greedy insertion ---
+# When true, evaluate all feasible insertion positions and choose the one
+# with minimum transition-time increment (Antuori et al. Section 4.1.1).
+# For fixed grid-aligned times this typically resolves to the time-ordered
+# position, but the code structure is preserved for paper fidelity.
+minimize_transition_increment: false
+
+# --- Local search ---
+# Maximum number of first-improving descent iterations.
+max_local_search_iterations: 1000
+
+# Optional wall-clock time budget for local search in seconds.
+# null = no time limit.
+max_local_search_time_s: null
+
+# Number of restarts after reaching a local minimum.
+# 0 = no restarts (deterministic single run).
+restart_count: 0
+
+# Random seed for stochastic ordering and restart perturbation.
+# null = use system time (non-deterministic).
+# Only matters when restart_count > 0 or stochastic_ordering is true.
+random_seed: null
+
+# When true, shuffle component order randomly each iteration.
+# Default is deterministic ordering.
+stochastic_ordering: false
+
+# --- Repair ---
+# Maximum number of repair removal iterations.
+max_repair_iterations: 200
+
+# --- Debug ---
+# When true, write additional debug artifacts to solution_dir/debug/.
+debug: false

--- a/solvers/aeossp_standard/greedy_lns/setup.sh
+++ b/solvers/aeossp_standard/greedy_lns/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${MPLCONFIGDIR:=/tmp/astroreason-matplotlib}"
+export MPLCONFIGDIR
+mkdir -p "${MPLCONFIGDIR}"
+
+python - <<'PY'
+import brahe
+import numpy
+import yaml
+
+print("greedy_lns setup ok")
+PY

--- a/solvers/aeossp_standard/greedy_lns/solve.sh
+++ b/solvers/aeossp_standard/greedy_lns/solve.sh
@@ -10,7 +10,9 @@ SOLUTION_DIR="${3:-solution}"
 export MPLCONFIGDIR
 mkdir -p "${MPLCONFIGDIR}"
 
-PYTHONPATH="${SCRIPT_DIR}/src${PYTHONPATH:+:${PYTHONPATH}}" python "${SCRIPT_DIR}/src/solve.py" \
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}" python -m solvers.aeossp_standard.greedy_lns.src.solve \
   --case-dir "${CASE_DIR}" \
   --config-dir "${CONFIG_DIR}" \
   --solution-dir "${SOLUTION_DIR}"

--- a/solvers/aeossp_standard/greedy_lns/solve.sh
+++ b/solvers/aeossp_standard/greedy_lns/solve.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CASE_DIR="${1:?usage: ./solve.sh <case_dir> [config_dir] [solution_dir]}"
+CONFIG_DIR="${2:-}"
+SOLUTION_DIR="${3:-solution}"
+
+: "${MPLCONFIGDIR:=/tmp/astroreason-matplotlib}"
+export MPLCONFIGDIR
+mkdir -p "${MPLCONFIGDIR}"
+
+PYTHONPATH="${SCRIPT_DIR}/src${PYTHONPATH:+:${PYTHONPATH}}" python "${SCRIPT_DIR}/src/solve.py" \
+  --case-dir "${CASE_DIR}" \
+  --config-dir "${CONFIG_DIR}" \
+  --solution-dir "${SOLUTION_DIR}"

--- a/solvers/aeossp_standard/greedy_lns/src/candidates.py
+++ b/solvers/aeossp_standard/greedy_lns/src/candidates.py
@@ -6,8 +6,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Any
 
-from case_io import AeosspCase, Satellite, Task, iso_z
-from geometry import PropagationContext, initial_slew_feasible, observation_geometry_valid
+from .case_io import AeosspCase, Satellite, Task, iso_z
+from .geometry import PropagationContext, initial_slew_feasible, observation_geometry_valid
 
 
 @dataclass(frozen=True, slots=True)

--- a/solvers/aeossp_standard/greedy_lns/src/candidates.py
+++ b/solvers/aeossp_standard/greedy_lns/src/candidates.py
@@ -1,0 +1,221 @@
+"""Candidate observation generation for the standalone greedy-LNS solver."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import timedelta
+from typing import Any
+
+from case_io import AeosspCase, Satellite, Task, iso_z
+from geometry import PropagationContext, initial_slew_feasible, observation_geometry_valid
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateConfig:
+    candidate_stride_multiplier: int = 1
+    max_candidates: int | None = None
+    max_candidates_per_task: int | None = None
+    debug: bool = False
+
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "CandidateConfig":
+        payload = payload or {}
+        return cls(
+            candidate_stride_multiplier=max(1, int(payload.get("candidate_stride_multiplier", 1))),
+            max_candidates=_optional_positive_int(payload.get("max_candidates")),
+            max_candidates_per_task=_optional_positive_int(
+                payload.get("max_candidates_per_task")
+            ),
+            debug=bool(payload.get("debug", False)),
+        )
+
+    def as_status_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class Candidate:
+    candidate_id: str
+    satellite_id: str
+    task_id: str
+    start_offset_s: int
+    end_offset_s: int
+    start_time: str
+    end_time: str
+    task_weight: float
+    duration_s: int
+    utility: float
+    utility_tie_break: tuple[float, int, float, str]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class CandidateSummary:
+    candidate_count: int = 0
+    per_satellite_candidate_counts: dict[str, int] = field(default_factory=dict)
+    per_task_candidate_counts: dict[str, int] = field(default_factory=dict)
+    skipped_sensor_mismatch: int = 0
+    skipped_geometry: int = 0
+    skipped_initial_slew: int = 0
+    skipped_cap: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_count": self.candidate_count,
+            "per_satellite_candidate_counts": dict(sorted(self.per_satellite_candidate_counts.items())),
+            "per_task_candidate_counts": dict(sorted(self.per_task_candidate_counts.items())),
+            "skipped_sensor_mismatch": self.skipped_sensor_mismatch,
+            "skipped_geometry": self.skipped_geometry,
+            "skipped_initial_slew": self.skipped_initial_slew,
+            "skipped_cap": self.skipped_cap,
+        }
+
+    def as_debug_dict(self, case: AeosspCase) -> dict[str, Any]:
+        zero_candidate_task_ids = sorted(
+            task.task_id
+            for task in case.tasks.values()
+            if self.per_task_candidate_counts.get(task.task_id, 0) == 0
+        )
+        zero_candidate_task_counts_by_sensor: dict[str, int] = {}
+        for task_id in zero_candidate_task_ids:
+            sensor_type = case.tasks[task_id].required_sensor_type
+            zero_candidate_task_counts_by_sensor[sensor_type] = (
+                zero_candidate_task_counts_by_sensor.get(sensor_type, 0) + 1
+            )
+        return {
+            **self.as_dict(),
+            "task_count": len(case.tasks),
+            "satellite_count": len(case.satellites),
+            "zero_candidate_task_count": len(zero_candidate_task_ids),
+            "zero_candidate_task_counts_by_sensor": dict(
+                sorted(zero_candidate_task_counts_by_sensor.items())
+            ),
+            "zero_candidate_task_ids": zero_candidate_task_ids,
+        }
+
+
+def _optional_positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError("candidate cap values must be positive integers")
+    return parsed
+
+
+def start_offsets_for_task(
+    case: AeosspCase,
+    task: Task,
+    *,
+    stride_multiplier: int = 1,
+) -> list[int]:
+    step_s = case.mission.action_time_step_s * max(1, stride_multiplier)
+    first_offset = int(round((task.release_time - case.mission.horizon_start).total_seconds()))
+    last_offset = int(
+        round((task.due_time - case.mission.horizon_start).total_seconds())
+    ) - task.required_duration_s
+    if last_offset < first_offset:
+        return []
+    return list(range(first_offset, last_offset + 1, step_s))
+
+
+def _sensor_matches(satellite: Satellite, task: Task) -> bool:
+    return satellite.sensor_type == task.required_sensor_type
+
+
+def _compute_utility(task: Task) -> float:
+    if task.required_duration_s > 0:
+        return task.weight / task.required_duration_s
+    return float("inf")
+
+
+def generate_candidates(
+    case: AeosspCase,
+    config: CandidateConfig | None = None,
+) -> tuple[list[Candidate], CandidateSummary]:
+    config = config or CandidateConfig()
+    summary = CandidateSummary()
+    candidates: list[Candidate] = []
+    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+    propagation = PropagationContext(case.satellites, step_s=step_s)
+
+    for satellite in sorted(case.satellites.values(), key=lambda item: item.satellite_id):
+        summary.per_satellite_candidate_counts.setdefault(satellite.satellite_id, 0)
+        for task in sorted(case.tasks.values(), key=lambda item: item.task_id):
+            summary.per_task_candidate_counts.setdefault(task.task_id, 0)
+            if not _sensor_matches(satellite, task):
+                summary.skipped_sensor_mismatch += len(
+                    start_offsets_for_task(
+                        case,
+                        task,
+                        stride_multiplier=config.candidate_stride_multiplier,
+                    )
+                )
+                continue
+            for start_offset_s in start_offsets_for_task(
+                case,
+                task,
+                stride_multiplier=config.candidate_stride_multiplier,
+            ):
+                if (
+                    config.max_candidates is not None
+                    and len(candidates) >= config.max_candidates
+                ):
+                    summary.skipped_cap += 1
+                    continue
+                if (
+                    config.max_candidates_per_task is not None
+                    and summary.per_task_candidate_counts[task.task_id]
+                    >= config.max_candidates_per_task
+                ):
+                    summary.skipped_cap += 1
+                    continue
+                start_time = case.mission.horizon_start + timedelta(seconds=start_offset_s)
+                end_offset_s = start_offset_s + task.required_duration_s
+                end_time = case.mission.horizon_start + timedelta(seconds=end_offset_s)
+                if not observation_geometry_valid(
+                    mission=case.mission,
+                    satellite=satellite,
+                    task=task,
+                    propagation=propagation,
+                    start_time=start_time,
+                    end_time=end_time,
+                ):
+                    summary.skipped_geometry += 1
+                    continue
+                if not initial_slew_feasible(
+                    mission=case.mission,
+                    satellite=satellite,
+                    task=task,
+                    propagation=propagation,
+                    start_time=start_time,
+                ):
+                    summary.skipped_initial_slew += 1
+                    continue
+                utility = _compute_utility(task)
+                candidate_id = f"{satellite.satellite_id}|{task.task_id}|{start_offset_s}"
+                candidate = Candidate(
+                    candidate_id=candidate_id,
+                    satellite_id=satellite.satellite_id,
+                    task_id=task.task_id,
+                    start_offset_s=start_offset_s,
+                    end_offset_s=end_offset_s,
+                    start_time=iso_z(start_time),
+                    end_time=iso_z(end_time),
+                    task_weight=task.weight,
+                    duration_s=task.required_duration_s,
+                    utility=utility,
+                    utility_tie_break=(
+                        -task.weight,
+                        int(round((task.due_time - case.mission.horizon_start).total_seconds())),
+                        0.0,
+                        candidate_id,
+                    ),
+                )
+                candidates.append(candidate)
+                summary.candidate_count += 1
+                summary.per_satellite_candidate_counts[satellite.satellite_id] += 1
+                summary.per_task_candidate_counts[task.task_id] += 1
+    return candidates, summary

--- a/solvers/aeossp_standard/greedy_lns/src/candidates.py
+++ b/solvers/aeossp_standard/greedy_lns/src/candidates.py
@@ -134,12 +134,15 @@ def _compute_utility(task: Task) -> float:
 def generate_candidates(
     case: AeosspCase,
     config: CandidateConfig | None = None,
+    *,
+    propagation: PropagationContext | None = None,
 ) -> tuple[list[Candidate], CandidateSummary]:
     config = config or CandidateConfig()
     summary = CandidateSummary()
     candidates: list[Candidate] = []
-    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
-    propagation = PropagationContext(case.satellites, step_s=step_s)
+    if propagation is None:
+        step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+        propagation = PropagationContext(case.satellites, step_s=step_s)
 
     for satellite in sorted(case.satellites.values(), key=lambda item: item.satellite_id):
         summary.per_satellite_candidate_counts.setdefault(satellite.satellite_id, 0)

--- a/solvers/aeossp_standard/greedy_lns/src/case_io.py
+++ b/solvers/aeossp_standard/greedy_lns/src/case_io.py
@@ -1,0 +1,380 @@
+"""Public case-file loading for the standalone AEOSSP greedy-LNS solver."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+import json
+
+import brahe
+import yaml
+
+
+NUMERICAL_EPS = 1.0e-9
+
+
+@dataclass(frozen=True, slots=True)
+class Mission:
+    case_id: str
+    horizon_start: datetime
+    horizon_end: datetime
+    action_time_step_s: int
+    geometry_sample_step_s: int
+    resource_sample_step_s: int
+
+    @property
+    def horizon_seconds(self) -> int:
+        seconds = (self.horizon_end - self.horizon_start).total_seconds()
+        if abs(seconds - round(seconds)) > NUMERICAL_EPS:
+            raise ValueError("mission horizon must be an integer number of seconds")
+        return int(round(seconds))
+
+
+@dataclass(frozen=True, slots=True)
+class AttitudeModel:
+    max_slew_velocity_deg_per_s: float
+    max_slew_acceleration_deg_per_s2: float
+    settling_time_s: float
+    max_off_nadir_deg: float
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceModel:
+    battery_capacity_wh: float
+    initial_battery_wh: float
+    idle_power_w: float
+    imaging_power_w: float
+    slew_power_w: float
+    sunlit_charge_power_w: float
+
+
+@dataclass(frozen=True, slots=True)
+class Satellite:
+    satellite_id: str
+    norad_catalog_id: int
+    tle_line1: str
+    tle_line2: str
+    sensor_type: str
+    attitude_model: AttitudeModel
+    resource_model: ResourceModel
+
+
+@dataclass(frozen=True, slots=True)
+class Task:
+    task_id: str
+    name: str
+    latitude_deg: float
+    longitude_deg: float
+    altitude_m: float
+    release_time: datetime
+    due_time: datetime
+    required_duration_s: int
+    required_sensor_type: str
+    weight: float
+    target_ecef_m: tuple[float, float, float]
+
+
+@dataclass(frozen=True, slots=True)
+class AeosspCase:
+    case_dir: Path
+    mission: Mission
+    satellites: dict[str, Satellite]
+    tasks: dict[str, Task]
+
+
+def parse_iso_z(value: str, *, field_name: str = "timestamp") -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be an ISO 8601 timestamp string")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include timezone information")
+    return parsed.astimezone(UTC)
+
+
+def iso_z(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _load_yaml(path: Path) -> Any:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _require_mapping(payload: Any, context: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{context} must be a mapping/object")
+    return payload
+
+
+def _require_list(payload: Any, context: str) -> list[Any]:
+    if not isinstance(payload, list):
+        raise ValueError(f"{context} must be a list/array")
+    return payload
+
+
+def _require_str(mapping: dict[str, Any], key: str, context: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{context}.{key} must be a non-empty string")
+    return value
+
+
+def _require_int(mapping: dict[str, Any], key: str, context: str) -> int:
+    value = mapping.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"{context}.{key} must be an integer")
+    return value
+
+
+def _require_float(mapping: dict[str, Any], key: str, context: str) -> float:
+    value = mapping.get(key)
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{context}.{key} must be numeric")
+    return float(value)
+
+
+def _is_aligned(seconds: float, step_s: int) -> bool:
+    return abs((seconds / step_s) - round(seconds / step_s)) <= NUMERICAL_EPS
+
+
+def _validate_positive(value: float, *, field_name: str) -> None:
+    if value <= 0.0:
+        raise ValueError(f"{field_name} must be > 0")
+
+
+def _validate_non_negative(value: float, *, field_name: str) -> None:
+    if value < -NUMERICAL_EPS:
+        raise ValueError(f"{field_name} must be >= 0")
+
+
+def _target_ecef_m(task_raw: dict[str, Any], context: str) -> tuple[float, float, float]:
+    value = brahe.position_geodetic_to_ecef(
+        [
+            _require_float(task_raw, "longitude_deg", context),
+            _require_float(task_raw, "latitude_deg", context),
+            _require_float(task_raw, "altitude_m", context),
+        ],
+        brahe.AngleFormat.DEGREES,
+    )
+    return tuple(float(item) for item in value)
+
+
+def load_case(case_dir: str | Path) -> AeosspCase:
+    case_path = Path(case_dir).resolve()
+    mission_doc = _require_mapping(_load_yaml(case_path / "mission.yaml"), "mission.yaml")
+    satellites_doc = _require_mapping(
+        _load_yaml(case_path / "satellites.yaml"), "satellites.yaml"
+    )
+    tasks_doc = _require_mapping(_load_yaml(case_path / "tasks.yaml"), "tasks.yaml")
+
+    mission_raw = _require_mapping(mission_doc.get("mission"), "mission.yaml.mission")
+    mission = Mission(
+        case_id=_require_str(mission_raw, "case_id", "mission.yaml.mission"),
+        horizon_start=parse_iso_z(
+            _require_str(mission_raw, "horizon_start", "mission.yaml.mission"),
+            field_name="mission.horizon_start",
+        ),
+        horizon_end=parse_iso_z(
+            _require_str(mission_raw, "horizon_end", "mission.yaml.mission"),
+            field_name="mission.horizon_end",
+        ),
+        action_time_step_s=_require_int(
+            mission_raw, "action_time_step_s", "mission.yaml.mission"
+        ),
+        geometry_sample_step_s=_require_int(
+            mission_raw, "geometry_sample_step_s", "mission.yaml.mission"
+        ),
+        resource_sample_step_s=_require_int(
+            mission_raw, "resource_sample_step_s", "mission.yaml.mission"
+        ),
+    )
+    if mission.horizon_end <= mission.horizon_start:
+        raise ValueError("mission.horizon_end must be after mission.horizon_start")
+    for field_name, step_s in (
+        ("action_time_step_s", mission.action_time_step_s),
+        ("geometry_sample_step_s", mission.geometry_sample_step_s),
+        ("resource_sample_step_s", mission.resource_sample_step_s),
+    ):
+        _validate_positive(float(step_s), field_name=f"mission.{field_name}")
+        if not _is_aligned(float(mission.horizon_seconds), step_s):
+            raise ValueError(f"mission horizon must be divisible by {field_name}")
+
+    satellites: dict[str, Satellite] = {}
+    for index, payload in enumerate(
+        _require_list(satellites_doc.get("satellites"), "satellites.yaml.satellites")
+    ):
+        context = f"satellites.yaml.satellites[{index}]"
+        sat_raw = _require_mapping(payload, context)
+        sat_id = _require_str(sat_raw, "satellite_id", context)
+        if sat_id in satellites:
+            raise ValueError(f"Duplicate satellite_id: {sat_id}")
+        tle_line1 = _require_str(sat_raw, "tle_line1", context)
+        tle_line2 = _require_str(sat_raw, "tle_line2", context)
+        if not brahe.validate_tle_lines(tle_line1, tle_line2):
+            raise ValueError(f"{context} contains an invalid TLE pair")
+        sensor_raw = _require_mapping(sat_raw.get("sensor"), f"{context}.sensor")
+        attitude_raw = _require_mapping(sat_raw.get("attitude_model"), f"{context}.attitude_model")
+        resource_raw = _require_mapping(sat_raw.get("resource_model"), f"{context}.resource_model")
+        sensor_type = _require_str(sensor_raw, "sensor_type", f"{context}.sensor")
+        if sensor_type not in {"visible", "infrared"}:
+            raise ValueError(f"{context}.sensor.sensor_type must be 'visible' or 'infrared'")
+        attitude = AttitudeModel(
+            max_slew_velocity_deg_per_s=_require_float(
+                attitude_raw, "max_slew_velocity_deg_per_s", f"{context}.attitude_model"
+            ),
+            max_slew_acceleration_deg_per_s2=_require_float(
+                attitude_raw,
+                "max_slew_acceleration_deg_per_s2",
+                f"{context}.attitude_model",
+            ),
+            settling_time_s=_require_float(
+                attitude_raw, "settling_time_s", f"{context}.attitude_model"
+            ),
+            max_off_nadir_deg=_require_float(
+                attitude_raw, "max_off_nadir_deg", f"{context}.attitude_model"
+            ),
+        )
+        resource = ResourceModel(
+            battery_capacity_wh=_require_float(
+                resource_raw, "battery_capacity_wh", f"{context}.resource_model"
+            ),
+            initial_battery_wh=_require_float(
+                resource_raw, "initial_battery_wh", f"{context}.resource_model"
+            ),
+            idle_power_w=_require_float(resource_raw, "idle_power_w", f"{context}.resource_model"),
+            imaging_power_w=_require_float(
+                resource_raw, "imaging_power_w", f"{context}.resource_model"
+            ),
+            slew_power_w=_require_float(resource_raw, "slew_power_w", f"{context}.resource_model"),
+            sunlit_charge_power_w=_require_float(
+                resource_raw, "sunlit_charge_power_w", f"{context}.resource_model"
+            ),
+        )
+        for field_name, value in (
+            ("max_slew_velocity_deg_per_s", attitude.max_slew_velocity_deg_per_s),
+            ("max_slew_acceleration_deg_per_s2", attitude.max_slew_acceleration_deg_per_s2),
+            ("settling_time_s", attitude.settling_time_s),
+            ("max_off_nadir_deg", attitude.max_off_nadir_deg),
+            ("battery_capacity_wh", resource.battery_capacity_wh),
+            ("initial_battery_wh", resource.initial_battery_wh),
+            ("idle_power_w", resource.idle_power_w),
+            ("imaging_power_w", resource.imaging_power_w),
+            ("slew_power_w", resource.slew_power_w),
+            ("sunlit_charge_power_w", resource.sunlit_charge_power_w),
+        ):
+            _validate_non_negative(value, field_name=f"{context}.{field_name}")
+        _validate_positive(
+            resource.battery_capacity_wh,
+            field_name=f"{context}.resource_model.battery_capacity_wh",
+        )
+        if resource.initial_battery_wh > resource.battery_capacity_wh + NUMERICAL_EPS:
+            raise ValueError(
+                f"{context}.resource_model.initial_battery_wh must be <= "
+                "resource_model.battery_capacity_wh"
+            )
+        satellites[sat_id] = Satellite(
+            satellite_id=sat_id,
+            norad_catalog_id=_require_int(sat_raw, "norad_catalog_id", context),
+            tle_line1=tle_line1,
+            tle_line2=tle_line2,
+            sensor_type=sensor_type,
+            attitude_model=attitude,
+            resource_model=resource,
+        )
+
+    tasks: dict[str, Task] = {}
+    for index, payload in enumerate(
+        _require_list(tasks_doc.get("tasks"), "tasks.yaml.tasks")
+    ):
+        context = f"tasks.yaml.tasks[{index}]"
+        task_raw = _require_mapping(payload, context)
+        task_id = _require_str(task_raw, "task_id", context)
+        if task_id in tasks:
+            raise ValueError(f"Duplicate task_id: {task_id}")
+        release_time = parse_iso_z(
+            _require_str(task_raw, "release_time", context),
+            field_name=f"{context}.release_time",
+        )
+        due_time = parse_iso_z(
+            _require_str(task_raw, "due_time", context),
+            field_name=f"{context}.due_time",
+        )
+        duration_s = _require_int(task_raw, "required_duration_s", context)
+        if release_time < mission.horizon_start or due_time > mission.horizon_end:
+            raise ValueError(f"{context} window must lie inside mission horizon")
+        if due_time <= release_time:
+            raise ValueError(f"{context}.due_time must be after release_time")
+        if duration_s <= 0:
+            raise ValueError(f"{context}.required_duration_s must be > 0")
+        for field_name, seconds in (
+            ("release_time", (release_time - mission.horizon_start).total_seconds()),
+            ("due_time", (due_time - mission.horizon_start).total_seconds()),
+            ("required_duration_s", float(duration_s)),
+        ):
+            if not _is_aligned(seconds, mission.action_time_step_s):
+                raise ValueError(
+                    f"{context}.{field_name} must align to the action grid"
+                )
+        if duration_s > int((due_time - release_time).total_seconds()):
+            raise ValueError(f"{context}.required_duration_s exceeds the task window")
+        sensor_type = _require_str(task_raw, "required_sensor_type", context)
+        if sensor_type not in {"visible", "infrared"}:
+            raise ValueError(
+                f"{context}.required_sensor_type must be 'visible' or 'infrared'"
+            )
+        weight = float(task_raw.get("weight", 1.0))
+        _validate_positive(weight, field_name=f"{context}.weight")
+        tasks[task_id] = Task(
+            task_id=task_id,
+            name=_require_str(task_raw, "name", context),
+            latitude_deg=_require_float(task_raw, "latitude_deg", context),
+            longitude_deg=_require_float(task_raw, "longitude_deg", context),
+            altitude_m=_require_float(task_raw, "altitude_m", context),
+            release_time=release_time,
+            due_time=due_time,
+            required_duration_s=duration_s,
+            required_sensor_type=sensor_type,
+            weight=weight,
+            target_ecef_m=_target_ecef_m(task_raw, context),
+        )
+
+    return AeosspCase(
+        case_dir=case_path,
+        mission=mission,
+        satellites=satellites,
+        tasks=tasks,
+    )
+
+
+def load_solver_config(config_dir: str | Path | None) -> dict[str, Any]:
+    if not config_dir:
+        return {}
+    path = Path(config_dir)
+    if not path.exists():
+        raise FileNotFoundError(f"config path does not exist: {path}")
+    if path.is_file():
+        candidates = [path]
+    else:
+        candidates = [
+            path / "config.yaml",
+            path / "config.yml",
+            path / "config.json",
+            path / "greedy_lns.yaml",
+            path / "greedy_lns.yml",
+            path / "greedy_lns.json",
+        ]
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        if candidate.suffix == ".json":
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        else:
+            payload = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+        if payload is None:
+            raise ValueError(f"{candidate} is empty")
+        if not isinstance(payload, dict):
+            raise ValueError(f"{candidate} must contain a mapping/object")
+        return payload
+    attempted = ", ".join(str(candidate) for candidate in candidates)
+    raise FileNotFoundError(f"no supported config file found under {path}; tried: {attempted}")

--- a/solvers/aeossp_standard/greedy_lns/src/components.py
+++ b/solvers/aeossp_standard/greedy_lns/src/components.py
@@ -6,10 +6,10 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
-from candidates import Candidate
-from case_io import AeosspCase
-from geometry import PropagationContext
-from transition import TransitionVectorCache, max_transition_gap_s, transition_gap_conflict
+from .candidates import Candidate
+from .case_io import AeosspCase
+from .geometry import PropagationContext
+from .transition import TransitionVectorCache, max_transition_gap_s, transition_gap_conflict
 
 
 @dataclass(frozen=True, slots=True)

--- a/solvers/aeossp_standard/greedy_lns/src/components.py
+++ b/solvers/aeossp_standard/greedy_lns/src/components.py
@@ -1,0 +1,201 @@
+"""Per-satellite dependence graphs and connected-component extraction."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from candidates import Candidate
+from case_io import AeosspCase
+from geometry import PropagationContext
+from transition import TransitionVectorCache, max_transition_gap_s, transition_gap_conflict
+
+
+@dataclass(frozen=True, slots=True)
+class Component:
+    satellite_id: str
+    component_id: str
+    candidates: tuple[Candidate, ...]
+
+    @property
+    def size(self) -> int:
+        return len(self.candidates)
+
+    @property
+    def candidate_ids(self) -> tuple[str, ...]:
+        return tuple(c.candidate_id for c in self.candidates)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "satellite_id": self.satellite_id,
+            "component_id": self.component_id,
+            "size": self.size,
+            "candidate_ids": list(self.candidate_ids),
+        }
+
+
+@dataclass(slots=True)
+class ComponentStats:
+    satellite_count: int = 0
+    component_count: int = 0
+    largest_component_size: int = 0
+    singleton_count: int = 0
+    component_size_histogram: dict[str, int] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ComponentIndex:
+    components: list[Component]
+    candidate_id_to_component: dict[str, Component]
+    per_satellite: dict[str, list[Component]]
+    stats: ComponentStats
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "stats": self.stats.as_dict(),
+            "components": [c.as_dict() for c in self.components],
+        }
+
+
+def _build_satellite_dependence_edges(
+    case: AeosspCase,
+    satellite_id: str,
+    candidates: list[Candidate],
+) -> dict[str, set[str]]:
+    """Build a dependence adjacency map for one satellite.
+
+    An edge exists between two candidates when their time windows overlap
+    after transition padding, i.e. they cannot both appear in the same
+    schedule regardless of ordering.
+    """
+    satellite = case.satellites[satellite_id]
+    safe_gap_s = max_transition_gap_s(satellite)
+
+    adjacency: dict[str, set[str]] = {
+        candidate.candidate_id: set() for candidate in candidates
+    }
+
+    ordered = sorted(
+        candidates,
+        key=lambda item: (item.start_offset_s, item.end_offset_s, item.candidate_id),
+    )
+
+    # We need a vector cache for transition_gap_conflict, but creating one
+    # per satellite is fine.  We only use it when gap <= safe_gap_s.
+    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+    propagation = PropagationContext(case.satellites, step_s=step_s)
+    vector_cache = TransitionVectorCache(case, propagation)
+
+    for left_index, candidate_a in enumerate(ordered):
+        for candidate_b in ordered[left_index + 1 :]:
+            if candidate_b.start_offset_s < candidate_a.end_offset_s:
+                # overlap
+                adjacency[candidate_a.candidate_id].add(candidate_b.candidate_id)
+                adjacency[candidate_b.candidate_id].add(candidate_a.candidate_id)
+                continue
+            gap_s = candidate_b.start_offset_s - candidate_a.end_offset_s
+            if gap_s > safe_gap_s:
+                break
+            if transition_gap_conflict(
+                candidate_a,
+                candidate_b,
+                case=case,
+                vector_cache=vector_cache,
+            ):
+                adjacency[candidate_a.candidate_id].add(candidate_b.candidate_id)
+                adjacency[candidate_b.candidate_id].add(candidate_a.candidate_id)
+
+    return adjacency
+
+
+def _extract_components(
+    satellite_id: str,
+    adjacency: dict[str, set[str]],
+    candidate_by_id: dict[str, Candidate],
+) -> list[Component]:
+    """Extract connected components from a satellite's dependence graph.
+
+    Deterministic ordering: roots chosen lexicographically, neighbors
+    visited in sorted order.
+    """
+    remaining = set(adjacency)
+    components: list[Component] = []
+
+    while remaining:
+        root_id = min(remaining)
+        stack = [root_id]
+        remaining.remove(root_id)
+        member_ids: list[str] = []
+
+        while stack:
+            current_id = stack.pop()
+            member_ids.append(current_id)
+            for neighbor_id in sorted(adjacency[current_id]):
+                if neighbor_id in remaining:
+                    remaining.remove(neighbor_id)
+                    stack.append(neighbor_id)
+
+        member_ids.sort()
+        component_id = f"{satellite_id}::{root_id}"
+        components.append(
+            Component(
+                satellite_id=satellite_id,
+                component_id=component_id,
+                candidates=tuple(candidate_by_id[mid] for mid in member_ids),
+            )
+        )
+
+    return sorted(components, key=lambda c: (c.satellite_id, c.component_id))
+
+
+def build_component_index(
+    case: AeosspCase,
+    candidates: list[Candidate],
+) -> ComponentIndex:
+    """Build per-satellite dependence graphs and extract connected components."""
+    by_satellite: dict[str, list[Candidate]] = defaultdict(list)
+    for candidate in candidates:
+        by_satellite[candidate.satellite_id].append(candidate)
+
+    all_components: list[Component] = []
+    candidate_id_to_component: dict[str, Component] = {}
+    per_satellite: dict[str, list[Component]] = {}
+
+    for satellite_id in sorted(by_satellite):
+        satellite_candidates = by_satellite[satellite_id]
+        candidate_by_id = {c.candidate_id: c for c in satellite_candidates}
+        adjacency = _build_satellite_dependence_edges(
+            case, satellite_id, satellite_candidates
+        )
+        satellite_components = _extract_components(
+            satellite_id, adjacency, candidate_by_id
+        )
+        per_satellite[satellite_id] = satellite_components
+        all_components.extend(satellite_components)
+        for component in satellite_components:
+            for candidate in component.candidates:
+                candidate_id_to_component[candidate.candidate_id] = component
+
+    histogram: dict[str, int] = {}
+    for component in all_components:
+        key = str(component.size)
+        histogram[key] = histogram.get(key, 0) + 1
+
+    stats = ComponentStats(
+        satellite_count=len(per_satellite),
+        component_count=len(all_components),
+        largest_component_size=max((c.size for c in all_components), default=0),
+        singleton_count=histogram.get("1", 0),
+        component_size_histogram=dict(sorted(histogram.items(), key=lambda item: int(item[0]))),
+    )
+
+    return ComponentIndex(
+        components=sorted(all_components, key=lambda c: (c.satellite_id, c.component_id)),
+        candidate_id_to_component=candidate_id_to_component,
+        per_satellite=per_satellite,
+        stats=stats,
+    )

--- a/solvers/aeossp_standard/greedy_lns/src/components.py
+++ b/solvers/aeossp_standard/greedy_lns/src/components.py
@@ -65,6 +65,9 @@ def _build_satellite_dependence_edges(
     case: AeosspCase,
     satellite_id: str,
     candidates: list[Candidate],
+    *,
+    propagation: PropagationContext,
+    vector_cache: TransitionVectorCache,
 ) -> dict[str, set[str]]:
     """Build a dependence adjacency map for one satellite.
 
@@ -83,12 +86,6 @@ def _build_satellite_dependence_edges(
         candidates,
         key=lambda item: (item.start_offset_s, item.end_offset_s, item.candidate_id),
     )
-
-    # We need a vector cache for transition_gap_conflict, but creating one
-    # per satellite is fine.  We only use it when gap <= safe_gap_s.
-    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
-    propagation = PropagationContext(case.satellites, step_s=step_s)
-    vector_cache = TransitionVectorCache(case, propagation)
 
     for left_index, candidate_a in enumerate(ordered):
         for candidate_b in ordered[left_index + 1 :]:
@@ -155,8 +152,17 @@ def _extract_components(
 def build_component_index(
     case: AeosspCase,
     candidates: list[Candidate],
+    *,
+    propagation: PropagationContext | None = None,
+    vector_cache: TransitionVectorCache | None = None,
 ) -> ComponentIndex:
     """Build per-satellite dependence graphs and extract connected components."""
+    if propagation is None:
+        step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+        propagation = PropagationContext(case.satellites, step_s=step_s)
+    if vector_cache is None:
+        vector_cache = TransitionVectorCache(case, propagation)
+
     by_satellite: dict[str, list[Candidate]] = defaultdict(list)
     for candidate in candidates:
         by_satellite[candidate.satellite_id].append(candidate)
@@ -169,7 +175,11 @@ def build_component_index(
         satellite_candidates = by_satellite[satellite_id]
         candidate_by_id = {c.candidate_id: c for c in satellite_candidates}
         adjacency = _build_satellite_dependence_edges(
-            case, satellite_id, satellite_candidates
+            case,
+            satellite_id,
+            satellite_candidates,
+            propagation=propagation,
+            vector_cache=vector_cache,
         )
         satellite_components = _extract_components(
             satellite_id, adjacency, candidate_by_id

--- a/solvers/aeossp_standard/greedy_lns/src/geometry.py
+++ b/solvers/aeossp_standard/greedy_lns/src/geometry.py
@@ -8,7 +8,7 @@ import math
 import brahe
 import numpy as np
 
-from case_io import Mission, NUMERICAL_EPS, Satellite, Task
+from .case_io import Mission, NUMERICAL_EPS, Satellite, Task
 
 
 _BRAHE_READY = False

--- a/solvers/aeossp_standard/greedy_lns/src/geometry.py
+++ b/solvers/aeossp_standard/greedy_lns/src/geometry.py
@@ -1,0 +1,231 @@
+"""Solver-local AEOSSP geometry and first-action slew helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import math
+
+import brahe
+import numpy as np
+
+from case_io import Mission, NUMERICAL_EPS, Satellite, Task
+
+
+_BRAHE_READY = False
+
+
+class PropagationContext:
+    def __init__(self, satellites: dict[str, Satellite], step_s: float):
+        ensure_brahe_ready()
+        self.propagators = {
+            satellite_id: brahe.SGPPropagator.from_tle(
+                satellite.tle_line1,
+                satellite.tle_line2,
+                step_s,
+            )
+            for satellite_id, satellite in satellites.items()
+        }
+        self._eci_cache: dict[tuple[str, datetime], np.ndarray] = {}
+        self._ecef_cache: dict[tuple[str, datetime], np.ndarray] = {}
+
+    def state_eci(self, satellite_id: str, instant: datetime) -> np.ndarray:
+        key = (satellite_id, instant.astimezone(UTC))
+        state = self._eci_cache.get(key)
+        if state is None:
+            state = np.asarray(
+                self.propagators[satellite_id].state_eci(datetime_to_epoch(key[1])),
+                dtype=float,
+            ).reshape(6)
+            self._eci_cache[key] = state
+        return state
+
+    def state_ecef(self, satellite_id: str, instant: datetime) -> np.ndarray:
+        key = (satellite_id, instant.astimezone(UTC))
+        state = self._ecef_cache.get(key)
+        if state is None:
+            state = np.asarray(
+                self.propagators[satellite_id].state_ecef(datetime_to_epoch(key[1])),
+                dtype=float,
+            ).reshape(6)
+            self._ecef_cache[key] = state
+        return state
+
+
+def ensure_brahe_ready() -> None:
+    global _BRAHE_READY
+    if _BRAHE_READY:
+        return
+    brahe.set_global_eop_provider_from_static_provider(
+        brahe.StaticEOPProvider.from_zero()
+    )
+    _BRAHE_READY = True
+
+
+def datetime_to_epoch(value: datetime) -> brahe.Epoch:
+    value = value.astimezone(UTC)
+    second = float(value.second) + (value.microsecond / 1_000_000.0)
+    return brahe.Epoch.from_datetime(
+        value.year,
+        value.month,
+        value.day,
+        value.hour,
+        value.minute,
+        second,
+        0.0,
+        brahe.TimeSystem.UTC,
+    )
+
+
+def action_sample_times(
+    mission: Mission,
+    start_time: datetime,
+    end_time: datetime,
+) -> list[datetime]:
+    if end_time <= start_time:
+        return [start_time]
+    points = [start_time]
+    step_s = mission.geometry_sample_step_s
+    start_offset_s = int(round((start_time - mission.horizon_start).total_seconds()))
+    end_offset_s = int(round((end_time - mission.horizon_start).total_seconds()))
+    next_grid_offset_s = ((start_offset_s // step_s) + 1) * step_s
+    while next_grid_offset_s < end_offset_s:
+        points.append(mission.horizon_start + timedelta(seconds=next_grid_offset_s))
+        next_grid_offset_s += step_s
+    if points[-1] != end_time:
+        points.append(end_time)
+    return points
+
+
+def angle_between_deg(vector_a: np.ndarray, vector_b: np.ndarray) -> float:
+    norm_a = float(np.linalg.norm(vector_a))
+    norm_b = float(np.linalg.norm(vector_b))
+    if norm_a <= NUMERICAL_EPS or norm_b <= NUMERICAL_EPS:
+        return 0.0
+    cosine = float(np.dot(vector_a, vector_b) / (norm_a * norm_b))
+    cosine = max(-1.0, min(1.0, cosine))
+    return math.degrees(math.acos(cosine))
+
+
+def slew_time_s(
+    delta_angle_deg: float,
+    max_velocity_deg_per_s: float,
+    max_acceleration_deg_per_s2: float,
+) -> float:
+    delta_angle_deg = max(0.0, delta_angle_deg)
+    if delta_angle_deg <= NUMERICAL_EPS:
+        return 0.0
+    if max_velocity_deg_per_s <= 0.0 or max_acceleration_deg_per_s2 <= 0.0:
+        return math.inf
+    ramp_time = max_velocity_deg_per_s / max_acceleration_deg_per_s2
+    triangular_threshold = (
+        max_velocity_deg_per_s * max_velocity_deg_per_s / max_acceleration_deg_per_s2
+    )
+    if delta_angle_deg <= triangular_threshold:
+        return 2.0 * math.sqrt(delta_angle_deg / max_acceleration_deg_per_s2)
+    cruise_angle = delta_angle_deg - triangular_threshold
+    return (2.0 * ramp_time) + (cruise_angle / max_velocity_deg_per_s)
+
+
+def required_slew_settle_s(
+    delta_angle_deg: float,
+    satellite: Satellite,
+) -> float:
+    return slew_time_s(
+        delta_angle_deg,
+        satellite.attitude_model.max_slew_velocity_deg_per_s,
+        satellite.attitude_model.max_slew_acceleration_deg_per_s2,
+    ) + satellite.attitude_model.settling_time_s
+
+
+def initial_slew_feasible_from_vectors(
+    *,
+    nadir_vector_eci: np.ndarray,
+    target_vector_eci: np.ndarray,
+    available_gap_s: float,
+    satellite: Satellite,
+) -> bool:
+    slew_angle_deg = angle_between_deg(nadir_vector_eci, target_vector_eci)
+    return available_gap_s + NUMERICAL_EPS >= required_slew_settle_s(
+        slew_angle_deg,
+        satellite,
+    )
+
+
+def target_vector_eci(
+    task: Task,
+    propagation: PropagationContext,
+    satellite_id: str,
+    instant: datetime,
+) -> np.ndarray:
+    epoch = datetime_to_epoch(instant)
+    target_eci = np.asarray(
+        brahe.position_ecef_to_eci(epoch, np.asarray(task.target_ecef_m, dtype=float)),
+        dtype=float,
+    ).reshape(3)
+    sat_state_eci = propagation.state_eci(satellite_id, instant)
+    return target_eci - sat_state_eci[:3]
+
+
+def off_nadir_deg(
+    satellite_position_ecef_m: np.ndarray,
+    target_ecef_m: np.ndarray,
+) -> float:
+    return angle_between_deg(
+        -satellite_position_ecef_m,
+        target_ecef_m - satellite_position_ecef_m,
+    )
+
+
+def target_visible(
+    satellite_position_ecef_m: np.ndarray,
+    target_ecef_m: np.ndarray,
+) -> bool:
+    target_norm = float(np.linalg.norm(target_ecef_m))
+    if target_norm <= NUMERICAL_EPS:
+        return False
+    target_normal = target_ecef_m / target_norm
+    return float(np.dot(satellite_position_ecef_m - target_ecef_m, target_normal)) > 0.0
+
+
+def observation_geometry_valid(
+    *,
+    mission: Mission,
+    satellite: Satellite,
+    task: Task,
+    propagation: PropagationContext,
+    start_time: datetime,
+    end_time: datetime,
+) -> bool:
+    target_ecef_m = np.asarray(task.target_ecef_m, dtype=float)
+    for sample_time in action_sample_times(mission, start_time, end_time):
+        sat_pos_ecef = propagation.state_ecef(satellite.satellite_id, sample_time)[:3]
+        if not target_visible(sat_pos_ecef, target_ecef_m):
+            return False
+        if (
+            off_nadir_deg(sat_pos_ecef, target_ecef_m)
+            > satellite.attitude_model.max_off_nadir_deg + 1.0e-6
+        ):
+            return False
+    return True
+
+
+def initial_slew_feasible(
+    *,
+    mission: Mission,
+    satellite: Satellite,
+    task: Task,
+    propagation: PropagationContext,
+    start_time: datetime,
+) -> bool:
+    sat_state_eci = propagation.state_eci(satellite.satellite_id, start_time)
+    return initial_slew_feasible_from_vectors(
+        nadir_vector_eci=-sat_state_eci[:3],
+        target_vector_eci=target_vector_eci(
+            task,
+            propagation,
+            satellite.satellite_id,
+            start_time,
+        ),
+        available_gap_s=(start_time - mission.horizon_start).total_seconds(),
+        satellite=satellite,
+    )

--- a/solvers/aeossp_standard/greedy_lns/src/insertion.py
+++ b/solvers/aeossp_standard/greedy_lns/src/insertion.py
@@ -1,0 +1,164 @@
+"""Deterministic greedy insertion scheduler for AEOSSP candidates."""
+
+from __future__ import annotations
+
+from bisect import bisect_left
+from dataclasses import asdict, dataclass, field
+from datetime import timedelta
+from typing import Any
+
+from candidates import Candidate
+from case_io import AeosspCase
+from geometry import PropagationContext, initial_slew_feasible
+from transition import TransitionVectorCache, transition_result
+
+
+@dataclass(frozen=True, slots=True)
+class InsertionConfig:
+    max_repair_iterations: int = 200
+
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "InsertionConfig":
+        payload = payload or {}
+        return cls(max_repair_iterations=max(0, int(payload.get("max_repair_iterations", 200))))
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class InsertionStats:
+    candidates_considered: int = 0
+    candidates_inserted: int = 0
+    candidates_skipped_duplicate_task: int = 0
+    candidates_rejected_overlap: int = 0
+    candidates_rejected_transition: int = 0
+    candidates_rejected_initial_slew: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class InsertionResult:
+    selected: list[Candidate]
+    stats: InsertionStats
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "selected_count": len(self.selected),
+            "stats": self.stats.as_dict(),
+        }
+
+
+def _candidate_sort_key(candidate: Candidate) -> tuple[float, ...]:
+    """Sort key: higher utility first, then tie-break tuple."""
+    return (-candidate.utility, candidate.utility_tie_break)
+
+
+def _insertion_position(
+    satellite_schedule: list[Candidate],
+    candidate: Candidate,
+) -> int:
+    """Return the index at which *candidate* should be inserted to keep the
+    schedule ordered by ``(start_offset_s, end_offset_s, candidate_id)``.
+    """
+    return bisect_left(
+        satellite_schedule,
+        (candidate.start_offset_s, candidate.end_offset_s, candidate.candidate_id),
+        key=lambda item: (item.start_offset_s, item.end_offset_s, item.candidate_id),
+    )
+
+
+def greedy_insertion(
+    case: AeosspCase,
+    candidates: list[Candidate],
+    config: InsertionConfig | None = None,
+) -> InsertionResult:
+    """Build a schedule by greedily inserting candidates in utility order.
+
+    Conflicts handled:
+    - duplicate task (a task may be scheduled at most once)
+    - same-satellite overlap
+    - same-satellite insufficient transition gap
+    - first-action initial slew from nadir
+
+    Battery feasibility is *not* checked during insertion; run solver-local
+    validation/repair afterwards if needed.
+    """
+    config = config or InsertionConfig()
+    stats = InsertionStats()
+
+    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+    propagation = PropagationContext(case.satellites, step_s=step_s)
+    vector_cache = TransitionVectorCache(case, propagation)
+
+    sorted_candidates = sorted(candidates, key=_candidate_sort_key)
+
+    # satellite_id -> ordered list of selected candidates
+    satellite_schedules: dict[str, list[Candidate]] = {
+        satellite_id: [] for satellite_id in sorted(case.satellites)
+    }
+    scheduled_tasks: set[str] = set()
+
+    for candidate in sorted_candidates:
+        stats.candidates_considered += 1
+
+        if candidate.task_id in scheduled_tasks:
+            stats.candidates_skipped_duplicate_task += 1
+            continue
+
+        schedule = satellite_schedules[candidate.satellite_id]
+        pos = _insertion_position(schedule, candidate)
+
+        # --- overlap checks ---
+        left = schedule[pos - 1] if pos > 0 else None
+        right = schedule[pos] if pos < len(schedule) else None
+
+        if left is not None and left.end_offset_s > candidate.start_offset_s:
+            stats.candidates_rejected_overlap += 1
+            continue
+        if right is not None and candidate.end_offset_s > right.start_offset_s:
+            stats.candidates_rejected_overlap += 1
+            continue
+
+        # --- transition checks ---
+        transition_ok = True
+        if left is not None:
+            result = transition_result(left, candidate, case=case, vector_cache=vector_cache)
+            if not result.feasible:
+                stats.candidates_rejected_transition += 1
+                transition_ok = False
+        if transition_ok and right is not None:
+            result = transition_result(candidate, right, case=case, vector_cache=vector_cache)
+            if not result.feasible:
+                stats.candidates_rejected_transition += 1
+                transition_ok = False
+        if not transition_ok:
+            continue
+
+        # --- initial slew check (only if first on this satellite) ---
+        if left is None:
+            start_time = case.mission.horizon_start + timedelta(seconds=candidate.start_offset_s)
+            if not initial_slew_feasible(
+                mission=case.mission,
+                satellite=case.satellites[candidate.satellite_id],
+                task=case.tasks[candidate.task_id],
+                propagation=propagation,
+                start_time=start_time,
+            ):
+                stats.candidates_rejected_initial_slew += 1
+                continue
+
+        schedule.insert(pos, candidate)
+        scheduled_tasks.add(candidate.task_id)
+        stats.candidates_inserted += 1
+
+    # Flatten schedules into a single sorted list
+    selected = [
+        candidate
+        for satellite_id in sorted(satellite_schedules)
+        for candidate in satellite_schedules[satellite_id]
+    ]
+
+    return InsertionResult(selected=selected, stats=stats)

--- a/solvers/aeossp_standard/greedy_lns/src/insertion.py
+++ b/solvers/aeossp_standard/greedy_lns/src/insertion.py
@@ -154,6 +154,9 @@ def greedy_insertion(
     case: AeosspCase,
     candidates: list[Candidate],
     config: InsertionConfig | None = None,
+    *,
+    propagation: PropagationContext | None = None,
+    vector_cache: TransitionVectorCache | None = None,
 ) -> InsertionResult:
     """Build a schedule by greedily inserting candidates in utility order.
 
@@ -176,9 +179,11 @@ def greedy_insertion(
     config = config or InsertionConfig()
     stats = InsertionStats()
 
-    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
-    propagation = PropagationContext(case.satellites, step_s=step_s)
-    vector_cache = TransitionVectorCache(case, propagation)
+    if propagation is None:
+        step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+        propagation = PropagationContext(case.satellites, step_s=step_s)
+    if vector_cache is None:
+        vector_cache = TransitionVectorCache(case, propagation)
 
     sorted_candidates = sorted(candidates, key=_candidate_sort_key)
 

--- a/solvers/aeossp_standard/greedy_lns/src/insertion.py
+++ b/solvers/aeossp_standard/greedy_lns/src/insertion.py
@@ -16,11 +16,15 @@ from transition import TransitionVectorCache, transition_result
 @dataclass(frozen=True, slots=True)
 class InsertionConfig:
     max_repair_iterations: int = 200
+    minimize_transition_increment: bool = False
 
     @classmethod
     def from_mapping(cls, payload: dict[str, Any] | None) -> "InsertionConfig":
         payload = payload or {}
-        return cls(max_repair_iterations=max(0, int(payload.get("max_repair_iterations", 200))))
+        return cls(
+            max_repair_iterations=max(0, int(payload.get("max_repair_iterations", 200))),
+            minimize_transition_increment=bool(payload.get("minimize_transition_increment", False)),
+        )
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -70,6 +74,82 @@ def _insertion_position(
     )
 
 
+def _check_position_feasible(
+    case: AeosspCase,
+    satellite_id: str,
+    schedule: list[Candidate],
+    pos: int,
+    candidate: Candidate,
+    propagation: PropagationContext,
+    vector_cache: TransitionVectorCache,
+) -> bool:
+    """Check whether *candidate* can be inserted at *pos* without overlap,
+    transition, or initial-slew violations."""
+    left = schedule[pos - 1] if pos > 0 else None
+    right = schedule[pos] if pos < len(schedule) else None
+
+    if left is not None and left.end_offset_s > candidate.start_offset_s:
+        return False
+    if right is not None and candidate.end_offset_s > right.start_offset_s:
+        return False
+
+    if left is not None:
+        result = transition_result(left, candidate, case=case, vector_cache=vector_cache)
+        if not result.feasible:
+            return False
+    if right is not None:
+        result = transition_result(candidate, right, case=case, vector_cache=vector_cache)
+        if not result.feasible:
+            return False
+
+    if left is None:
+        start_time = case.mission.horizon_start + timedelta(seconds=candidate.start_offset_s)
+        if not initial_slew_feasible(
+            mission=case.mission,
+            satellite=case.satellites[satellite_id],
+            task=case.tasks[candidate.task_id],
+            propagation=propagation,
+            start_time=start_time,
+        ):
+            return False
+
+    return True
+
+
+def _transition_increment_at_position(
+    case: AeosspCase,
+    satellite_id: str,
+    schedule: list[Candidate],
+    pos: int,
+    candidate: Candidate,
+    vector_cache: TransitionVectorCache,
+) -> float:
+    """Compute the transition-time increment if *candidate* is inserted at *pos*.
+
+    increment = T(left, candidate) + T(candidate, right)
+    (boundary terms are 0 when left/right is None).
+    """
+    left = schedule[pos - 1] if pos > 0 else None
+    right = schedule[pos] if pos < len(schedule) else None
+
+    increment = 0.0
+    if left is not None:
+        result = transition_result(left, candidate, case=case, vector_cache=vector_cache)
+        increment += result.required_gap_s
+    if right is not None:
+        result = transition_result(candidate, right, case=case, vector_cache=vector_cache)
+        increment += result.required_gap_s
+    return increment
+
+
+def _insert_at_position(
+    schedule: list[Candidate],
+    pos: int,
+    candidate: Candidate,
+) -> None:
+    schedule.insert(pos, candidate)
+
+
 def greedy_insertion(
     case: AeosspCase,
     candidates: list[Candidate],
@@ -82,6 +162,13 @@ def greedy_insertion(
     - same-satellite overlap
     - same-satellite insufficient transition gap
     - first-action initial slew from nadir
+
+    When *minimize_transition_increment* is True, the algorithm evaluates all
+    feasible insertion positions and chooses the one with the smallest
+    transition-time increment, matching Antuori et al. Section 4.1.1.
+    Because this benchmark uses fixed grid-aligned times, there is typically
+    only one feasible position (the time-ordered position), so the effect is
+    usually minimal; the code structure is preserved for fidelity to the paper.
 
     Battery feasibility is *not* checked during insertion; run solver-local
     validation/repair afterwards if needed.
@@ -109,50 +196,108 @@ def greedy_insertion(
             continue
 
         schedule = satellite_schedules[candidate.satellite_id]
-        pos = _insertion_position(schedule, candidate)
 
-        # --- overlap checks ---
-        left = schedule[pos - 1] if pos > 0 else None
-        right = schedule[pos] if pos < len(schedule) else None
+        if config.minimize_transition_increment:
+            # Evaluate all positions and pick the feasible one with minimum
+            # transition increment.  Tie-break by earlier position.
+            best_pos: int | None = None
+            best_increment: float = float("inf")
 
-        if left is not None and left.end_offset_s > candidate.start_offset_s:
-            stats.candidates_rejected_overlap += 1
-            continue
-        if right is not None and candidate.end_offset_s > right.start_offset_s:
-            stats.candidates_rejected_overlap += 1
-            continue
+            for pos in range(len(schedule) + 1):
+                feasible = _check_position_feasible(
+                    case,
+                    candidate.satellite_id,
+                    schedule,
+                    pos,
+                    candidate,
+                    propagation,
+                    vector_cache,
+                )
+                if not feasible:
+                    continue
+                increment = _transition_increment_at_position(
+                    case,
+                    candidate.satellite_id,
+                    schedule,
+                    pos,
+                    candidate,
+                    vector_cache,
+                )
+                if increment < best_increment - 1.0e-9:
+                    best_increment = increment
+                    best_pos = pos
 
-        # --- transition checks ---
-        transition_ok = True
-        if left is not None:
-            result = transition_result(left, candidate, case=case, vector_cache=vector_cache)
-            if not result.feasible:
-                stats.candidates_rejected_transition += 1
-                transition_ok = False
-        if transition_ok and right is not None:
-            result = transition_result(candidate, right, case=case, vector_cache=vector_cache)
-            if not result.feasible:
-                stats.candidates_rejected_transition += 1
-                transition_ok = False
-        if not transition_ok:
-            continue
-
-        # --- initial slew check (only if first on this satellite) ---
-        if left is None:
-            start_time = case.mission.horizon_start + timedelta(seconds=candidate.start_offset_s)
-            if not initial_slew_feasible(
-                mission=case.mission,
-                satellite=case.satellites[candidate.satellite_id],
-                task=case.tasks[candidate.task_id],
-                propagation=propagation,
-                start_time=start_time,
-            ):
-                stats.candidates_rejected_initial_slew += 1
+            if best_pos is None:
+                # No feasible position found.  Categorize the rejection by
+                # checking the time-ordered position for diagnostics.
+                pos = _insertion_position(schedule, candidate)
+                left = schedule[pos - 1] if pos > 0 else None
+                right = schedule[pos] if pos < len(schedule) else None
+                if left is not None and left.end_offset_s > candidate.start_offset_s:
+                    stats.candidates_rejected_overlap += 1
+                elif right is not None and candidate.end_offset_s > right.start_offset_s:
+                    stats.candidates_rejected_overlap += 1
+                elif left is None and not initial_slew_feasible(
+                    mission=case.mission,
+                    satellite=case.satellites[candidate.satellite_id],
+                    task=case.tasks[candidate.task_id],
+                    propagation=propagation,
+                    start_time=case.mission.horizon_start + timedelta(seconds=candidate.start_offset_s),
+                ):
+                    stats.candidates_rejected_initial_slew += 1
+                else:
+                    stats.candidates_rejected_transition += 1
                 continue
 
-        schedule.insert(pos, candidate)
-        scheduled_tasks.add(candidate.task_id)
-        stats.candidates_inserted += 1
+            _insert_at_position(schedule, best_pos, candidate)
+            scheduled_tasks.add(candidate.task_id)
+            stats.candidates_inserted += 1
+        else:
+            # Fast path: time-ordered position only.
+            pos = _insertion_position(schedule, candidate)
+
+            # --- overlap checks ---
+            left = schedule[pos - 1] if pos > 0 else None
+            right = schedule[pos] if pos < len(schedule) else None
+
+            if left is not None and left.end_offset_s > candidate.start_offset_s:
+                stats.candidates_rejected_overlap += 1
+                continue
+            if right is not None and candidate.end_offset_s > right.start_offset_s:
+                stats.candidates_rejected_overlap += 1
+                continue
+
+            # --- transition checks ---
+            transition_ok = True
+            if left is not None:
+                result = transition_result(left, candidate, case=case, vector_cache=vector_cache)
+                if not result.feasible:
+                    stats.candidates_rejected_transition += 1
+                    transition_ok = False
+            if transition_ok and right is not None:
+                result = transition_result(candidate, right, case=case, vector_cache=vector_cache)
+                if not result.feasible:
+                    stats.candidates_rejected_transition += 1
+                    transition_ok = False
+            if not transition_ok:
+                continue
+
+            # --- initial slew check (only if first on this satellite) ---
+            if left is None:
+                start_time = case.mission.horizon_start + timedelta(seconds=candidate.start_offset_s)
+                if not initial_slew_feasible(
+                    mission=case.mission,
+                    satellite=case.satellites[candidate.satellite_id],
+                    task=case.tasks[candidate.task_id],
+                    propagation=propagation,
+                    start_time=start_time,
+                ):
+                    stats.candidates_rejected_initial_slew += 1
+                    continue
+
+            schedule.insert(pos, candidate)
+            scheduled_tasks.add(candidate.task_id)
+            stats.candidates_inserted += 1
 
     # Flatten schedules into a single sorted list
     selected = [

--- a/solvers/aeossp_standard/greedy_lns/src/insertion.py
+++ b/solvers/aeossp_standard/greedy_lns/src/insertion.py
@@ -7,10 +7,10 @@ from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Any
 
-from candidates import Candidate
-from case_io import AeosspCase
-from geometry import PropagationContext, initial_slew_feasible
-from transition import TransitionVectorCache, transition_result
+from .candidates import Candidate
+from .case_io import AeosspCase
+from .geometry import PropagationContext, initial_slew_feasible
+from .transition import TransitionVectorCache, transition_result
 
 
 @dataclass(frozen=True, slots=True)

--- a/solvers/aeossp_standard/greedy_lns/src/local_search.py
+++ b/solvers/aeossp_standard/greedy_lns/src/local_search.py
@@ -10,12 +10,12 @@ from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Any
 
-from candidates import Candidate
-from case_io import AeosspCase
-from components import Component, ComponentIndex, build_component_index
-from geometry import PropagationContext, initial_slew_feasible
-from insertion import _insertion_position
-from transition import TransitionVectorCache, transition_result
+from .candidates import Candidate
+from .case_io import AeosspCase
+from .components import Component, ComponentIndex, build_component_index
+from .geometry import PropagationContext, initial_slew_feasible
+from .insertion import _insertion_position
+from .transition import TransitionVectorCache, transition_result
 
 
 @dataclass(frozen=True, slots=True)

--- a/solvers/aeossp_standard/greedy_lns/src/local_search.py
+++ b/solvers/aeossp_standard/greedy_lns/src/local_search.py
@@ -177,6 +177,7 @@ def _recompute_component(
     (new_component_weight, insertion_failures).
     """
     satellite_id = component.satellite_id
+    satellite_schedule = by_satellite.setdefault(satellite_id, [])
 
     # 1. Remove currently selected candidates in this component
     selected_in_component = [
@@ -187,7 +188,7 @@ def _recompute_component(
     ]
 
     for c in selected_in_component:
-        by_satellite[satellite_id].remove(c)
+        satellite_schedule.remove(c)
         del scheduled_tasks[c.task_id]
 
     # 2. Compute marginal profit for every candidate in the component
@@ -212,7 +213,7 @@ def _recompute_component(
         inserted = _try_insert_into_satellite(
             case,
             satellite_id,
-            by_satellite[satellite_id],
+            satellite_schedule,
             candidate,
             propagation,
             vector_cache,
@@ -275,6 +276,8 @@ def _perturb(
     scheduled_tasks = dict(scheduled_tasks)
 
     all_selected = list(scheduled_tasks.values())
+    if not all_selected:
+        return by_satellite, scheduled_tasks
     to_remove = rng.sample(all_selected, max(1, int(len(all_selected) * fraction)))
 
     for candidate in to_remove:
@@ -289,6 +292,9 @@ def local_search(
     all_candidates: list[Candidate],
     greedy_solution: list[Candidate],
     config: LocalSearchConfig | None = None,
+    *,
+    propagation: PropagationContext | None = None,
+    vector_cache: TransitionVectorCache | None = None,
 ) -> LocalSearchResult:
     """Improve a greedy solution via connected-component local search.
 
@@ -300,12 +306,19 @@ def local_search(
     stats = LocalSearchStats()
     stats.exact_subproblem_solver = "none"
 
-    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
-    propagation = PropagationContext(case.satellites, step_s=step_s)
-    vector_cache = TransitionVectorCache(case, propagation)
+    if propagation is None:
+        step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+        propagation = PropagationContext(case.satellites, step_s=step_s)
+    if vector_cache is None:
+        vector_cache = TransitionVectorCache(case, propagation)
 
     # Build component index over all candidates
-    component_index = build_component_index(case, all_candidates)
+    component_index = build_component_index(
+        case,
+        all_candidates,
+        propagation=propagation,
+        vector_cache=vector_cache,
+    )
     stats.component_count = component_index.stats.component_count
     stats.largest_component_size = component_index.stats.largest_component_size
 

--- a/solvers/aeossp_standard/greedy_lns/src/local_search.py
+++ b/solvers/aeossp_standard/greedy_lns/src/local_search.py
@@ -1,0 +1,404 @@
+"""Connected-component local search for AEOSSP greedy-LNS solver."""
+
+from __future__ import annotations
+
+import random
+import time
+from bisect import bisect_left
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field
+from datetime import timedelta
+from typing import Any
+
+from candidates import Candidate
+from case_io import AeosspCase
+from components import Component, ComponentIndex, build_component_index
+from geometry import PropagationContext, initial_slew_feasible
+from insertion import _insertion_position
+from transition import TransitionVectorCache, transition_result
+
+
+@dataclass(frozen=True, slots=True)
+class LocalSearchConfig:
+    max_local_search_iterations: int = 1000
+    max_local_search_time_s: float | None = None
+    restart_count: int = 0
+    random_seed: int | None = None
+    stochastic_ordering: bool = False
+
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "LocalSearchConfig":
+        payload = payload or {}
+        return cls(
+            max_local_search_iterations=max(0, int(payload.get("max_local_search_iterations", 1000))),
+            max_local_search_time_s=_optional_positive_float(payload.get("max_local_search_time_s")),
+            restart_count=max(0, int(payload.get("restart_count", 0))),
+            random_seed=_optional_int(payload.get("random_seed")),
+            stochastic_ordering=bool(payload.get("stochastic_ordering", False)),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class LocalSearchStats:
+    greedy_objective: float = 0.0
+    best_objective: float = 0.0
+    final_objective: float = 0.0
+    iterations: int = 0
+    moves_attempted: int = 0
+    moves_accepted: int = 0
+    restarts_executed: int = 0
+    stop_reason: str = ""
+    component_count: int = 0
+    largest_component_size: int = 0
+    exact_subproblem_solver: str = "none"
+    insertion_failures_during_local_search: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class LocalSearchResult:
+    candidates: list[Candidate]
+    stats: LocalSearchStats
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidates_count": len(self.candidates),
+            "stats": self.stats.as_dict(),
+        }
+
+
+def _optional_positive_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    f = float(value)
+    if f <= 0:
+        return None
+    return f
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def _total_weight(candidates: list[Candidate]) -> float:
+    return sum(c.task_weight for c in candidates)
+
+
+def _by_satellite(candidates: list[Candidate]) -> dict[str, list[Candidate]]:
+    result: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        result.setdefault(candidate.satellite_id, []).append(candidate)
+    for satellite_id in result:
+        result[satellite_id].sort(
+            key=lambda item: (item.start_offset_s, item.end_offset_s, item.candidate_id)
+        )
+    return result
+
+
+def _try_insert_into_satellite(
+    case: AeosspCase,
+    satellite_id: str,
+    satellite_schedule: list[Candidate],
+    candidate: Candidate,
+    propagation: PropagationContext,
+    vector_cache: TransitionVectorCache,
+) -> bool:
+    """Try to insert *candidate* into *satellite_schedule* while preserving
+    ordering and feasibility.  Return True if inserted.
+    """
+    pos = _insertion_position(satellite_schedule, candidate)
+
+    # overlap checks
+    left = satellite_schedule[pos - 1] if pos > 0 else None
+    right = satellite_schedule[pos] if pos < len(satellite_schedule) else None
+
+    if left is not None and left.end_offset_s > candidate.start_offset_s:
+        return False
+    if right is not None and candidate.end_offset_s > right.start_offset_s:
+        return False
+
+    # transition checks
+    if left is not None:
+        result = transition_result(left, candidate, case=case, vector_cache=vector_cache)
+        if not result.feasible:
+            return False
+    if right is not None:
+        result = transition_result(candidate, right, case=case, vector_cache=vector_cache)
+        if not result.feasible:
+            return False
+
+    # initial slew check (only if first on this satellite)
+    if left is None:
+        start_time = case.mission.horizon_start + timedelta(seconds=candidate.start_offset_s)
+        if not initial_slew_feasible(
+            mission=case.mission,
+            satellite=case.satellites[satellite_id],
+            task=case.tasks[candidate.task_id],
+            propagation=propagation,
+            start_time=start_time,
+        ):
+            return False
+
+    satellite_schedule.insert(pos, candidate)
+    return True
+
+
+def _marginal_profit(
+    candidate: Candidate,
+    scheduled_tasks: dict[str, Candidate],
+) -> float:
+    """Marginal profit of selecting *candidate* given current schedule."""
+    existing = scheduled_tasks.get(candidate.task_id)
+    if existing is None:
+        return candidate.task_weight
+    if existing.candidate_id == candidate.candidate_id:
+        return candidate.task_weight
+    return candidate.task_weight - existing.task_weight
+
+
+def _recompute_component(
+    case: AeosspCase,
+    component: Component,
+    by_satellite: dict[str, list[Candidate]],
+    scheduled_tasks: dict[str, Candidate],
+    propagation: PropagationContext,
+    vector_cache: TransitionVectorCache,
+) -> tuple[float, int]:
+    """Recompute one connected component in-place.
+
+    Mutates *by_satellite* and *scheduled_tasks*.  Returns
+    (new_component_weight, insertion_failures).
+    """
+    satellite_id = component.satellite_id
+
+    # 1. Remove currently selected candidates in this component
+    selected_in_component = [
+        scheduled_tasks[c.task_id]
+        for c in component.candidates
+        if c.task_id in scheduled_tasks
+        and scheduled_tasks[c.task_id].candidate_id == c.candidate_id
+    ]
+
+    for c in selected_in_component:
+        by_satellite[satellite_id].remove(c)
+        del scheduled_tasks[c.task_id]
+
+    # 2. Compute marginal profit for every candidate in the component
+    component_candidates = list(component.candidates)
+    component_candidates.sort(
+        key=lambda c: (
+            -_marginal_profit(c, scheduled_tasks),
+            -c.task_weight,
+            c.start_offset_s,
+            c.candidate_id,
+        )
+    )
+
+    # 3. Greedy insert in marginal-profit order, stopping at first non-positive
+    new_component_weight = 0.0
+    insertion_failures = 0
+
+    for candidate in component_candidates:
+        mp = _marginal_profit(candidate, scheduled_tasks)
+        if mp <= 0:
+            break
+        inserted = _try_insert_into_satellite(
+            case,
+            satellite_id,
+            by_satellite[satellite_id],
+            candidate,
+            propagation,
+            vector_cache,
+        )
+        if inserted:
+            # If this task was selected by an alternative outside the component,
+            # remove that alternative now.
+            existing = scheduled_tasks.get(candidate.task_id)
+            if existing is not None and existing.candidate_id != candidate.candidate_id:
+                by_satellite[existing.satellite_id].remove(existing)
+            scheduled_tasks[candidate.task_id] = candidate
+            new_component_weight += candidate.task_weight
+        else:
+            insertion_failures += 1
+
+    return new_component_weight, insertion_failures
+
+
+def _flatten_schedule(by_satellite: dict[str, list[Candidate]]) -> list[Candidate]:
+    return [
+        candidate
+        for satellite_id in sorted(by_satellite)
+        for candidate in by_satellite[satellite_id]
+    ]
+
+
+def _copy_state(
+    by_satellite: dict[str, list[Candidate]],
+    scheduled_tasks: dict[str, Candidate],
+) -> tuple[dict[str, list[Candidate]], dict[str, Candidate]]:
+    return (
+        {sid: list(schedule) for sid, schedule in by_satellite.items()},
+        dict(scheduled_tasks),
+    )
+
+
+def _objective(scheduled_tasks: dict[str, Candidate]) -> float:
+    return sum(c.task_weight for c in scheduled_tasks.values())
+
+
+def _ordered_components(
+    component_index: ComponentIndex,
+    stochastic: bool,
+    rng: random.Random,
+) -> list[Component]:
+    components = list(component_index.components)
+    if stochastic:
+        rng.shuffle(components)
+    return components
+
+
+def _perturb(
+    by_satellite: dict[str, list[Candidate]],
+    scheduled_tasks: dict[str, Candidate],
+    rng: random.Random,
+    fraction: float = 0.05,
+) -> tuple[dict[str, list[Candidate]], dict[str, Candidate]]:
+    """Randomly deselect a fraction of candidates and return new state."""
+    by_satellite = {sid: list(schedule) for sid, schedule in by_satellite.items()}
+    scheduled_tasks = dict(scheduled_tasks)
+
+    all_selected = list(scheduled_tasks.values())
+    to_remove = rng.sample(all_selected, max(1, int(len(all_selected) * fraction)))
+
+    for candidate in to_remove:
+        by_satellite[candidate.satellite_id].remove(candidate)
+        del scheduled_tasks[candidate.task_id]
+
+    return by_satellite, scheduled_tasks
+
+
+def local_search(
+    case: AeosspCase,
+    all_candidates: list[Candidate],
+    greedy_solution: list[Candidate],
+    config: LocalSearchConfig | None = None,
+) -> LocalSearchResult:
+    """Improve a greedy solution via connected-component local search.
+
+    Implements first-improving descent over per-satellite connected components
+    with optional bounded restarts.  The paper's CP-SAT TSPTW fallback is
+    omitted; greedy insertion is used exclusively within component moves.
+    """
+    config = config or LocalSearchConfig()
+    stats = LocalSearchStats()
+    stats.exact_subproblem_solver = "none"
+
+    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+    propagation = PropagationContext(case.satellites, step_s=step_s)
+    vector_cache = TransitionVectorCache(case, propagation)
+
+    # Build component index over all candidates
+    component_index = build_component_index(case, all_candidates)
+    stats.component_count = component_index.stats.component_count
+    stats.largest_component_size = component_index.stats.largest_component_size
+
+    # Initialize state from greedy solution
+    by_satellite = _by_satellite(greedy_solution)
+    scheduled_tasks: dict[str, Candidate] = {c.task_id: c for c in greedy_solution}
+
+    greedy_objective = _objective(scheduled_tasks)
+    stats.greedy_objective = greedy_objective
+    stats.best_objective = greedy_objective
+    stats.final_objective = greedy_objective
+
+    best_by_satellite = _copy_state(by_satellite, scheduled_tasks)
+    rng = random.Random(config.random_seed)
+
+    time_limit = config.max_local_search_time_s
+    start_time = time.perf_counter()
+
+    for restart in range(config.restart_count + 1):
+        if restart > 0:
+            by_satellite, scheduled_tasks = _perturb(
+                best_by_satellite[0], best_by_satellite[1], rng
+            )
+            stats.restarts_executed += 1
+
+        for iteration in range(config.max_local_search_iterations):
+            stats.iterations += 1
+
+            if time_limit is not None:
+                if time.perf_counter() - start_time > time_limit:
+                    stats.stop_reason = "time_limit"
+                    break
+
+            improved = False
+            components = _ordered_components(
+                component_index, config.stochastic_ordering, rng
+            )
+
+            for component in components:
+                stats.moves_attempted += 1
+
+                # Snapshot state before the move
+                old_by_satellite, old_scheduled_tasks = _copy_state(
+                    by_satellite, scheduled_tasks
+                )
+
+                new_weight, failures = _recompute_component(
+                    case,
+                    component,
+                    by_satellite,
+                    scheduled_tasks,
+                    propagation,
+                    vector_cache,
+                )
+                stats.insertion_failures_during_local_search += failures
+
+                old_weight = sum(
+                    old_scheduled_tasks[c.task_id].task_weight
+                    for c in component.candidates
+                    if c.task_id in old_scheduled_tasks
+                    and old_scheduled_tasks[c.task_id].candidate_id == c.candidate_id
+                )
+
+                new_objective = _objective(scheduled_tasks)
+                old_objective = _objective(old_scheduled_tasks)
+
+                if new_objective > old_objective:
+                    stats.moves_accepted += 1
+                    improved = True
+                    if new_objective > stats.best_objective:
+                        stats.best_objective = new_objective
+                        best_by_satellite = _copy_state(by_satellite, scheduled_tasks)
+                    break  # first-improving
+                else:
+                    # Rollback
+                    by_satellite, scheduled_tasks = old_by_satellite, old_scheduled_tasks
+
+            if not improved:
+                stats.stop_reason = "local_minimum"
+                break
+
+            if stats.stop_reason:
+                break
+
+        if stats.stop_reason == "time_limit":
+            break
+
+    if not stats.stop_reason:
+        stats.stop_reason = "max_iterations"
+
+    # Restore best incumbent
+    by_satellite, scheduled_tasks = best_by_satellite
+    stats.final_objective = _objective(scheduled_tasks)
+
+    final_candidates = _flatten_schedule(by_satellite)
+    return LocalSearchResult(candidates=final_candidates, stats=stats)

--- a/solvers/aeossp_standard/greedy_lns/src/solution_io.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solution_io.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 import json
 
-from candidates import Candidate
+from .candidates import Candidate
 
 
 def write_json(path: Path, payload: Any) -> None:

--- a/solvers/aeossp_standard/greedy_lns/src/solution_io.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solution_io.py
@@ -1,0 +1,45 @@
+"""Solution and status writers for the greedy-LNS scaffold."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import json
+
+from candidates import Candidate
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_empty_solution(solution_dir: Path) -> Path:
+    path = solution_dir / "solution.json"
+    write_json(path, {"actions": []})
+    return path
+
+
+def candidates_to_actions(candidates: list[Candidate]) -> list[dict[str, str]]:
+    return [
+        {
+            "type": "observation",
+            "satellite_id": candidate.satellite_id,
+            "task_id": candidate.task_id,
+            "start_time": candidate.start_time,
+            "end_time": candidate.end_time,
+        }
+        for candidate in sorted(
+            candidates,
+            key=lambda item: (item.start_offset_s, item.satellite_id, item.task_id),
+        )
+    ]
+
+
+def write_solution(solution_dir: Path, candidates: list[Candidate]) -> Path:
+    path = solution_dir / "solution.json"
+    write_json(path, {"actions": candidates_to_actions(candidates)})
+    return path

--- a/solvers/aeossp_standard/greedy_lns/src/solve.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solve.py
@@ -1,0 +1,139 @@
+"""Solver entrypoint: generate candidates and emit actions for Phase 1."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from candidates import CandidateConfig, generate_candidates
+from case_io import load_case, load_solver_config
+from solution_io import write_json, write_empty_solution
+
+
+def _build_status(
+    *,
+    case_dir: Path,
+    config_dir: Path | None,
+    solution_path: Path,
+    case,
+    candidate_config: CandidateConfig,
+    candidate_summary,
+    timing_seconds: dict[str, float],
+) -> dict:
+    return {
+        "status": "phase_1_candidates_generated",
+        "phase": 1,
+        "case_dir": str(case_dir),
+        "config_dir": str(config_dir) if config_dir is not None else None,
+        "solution": str(solution_path),
+        "case_id": case.mission.case_id,
+        "satellite_count": len(case.satellites),
+        "task_count": len(case.tasks),
+        "candidate_config": candidate_config.as_status_dict(),
+        "utility_policy": "weight_over_duration",
+        **candidate_summary.as_debug_dict(case),
+        "timing_seconds": timing_seconds,
+    }
+
+
+def _write_debug_artifacts(
+    *,
+    solution_dir: Path,
+    case,
+    candidate_config: CandidateConfig,
+    candidate_summary,
+    candidates,
+    timing_seconds: dict[str, float],
+) -> None:
+    write_json(
+        solution_dir / "debug" / "candidate_summary.json",
+        {
+            "case_id": case.mission.case_id,
+            "candidate_config": candidate_config.as_status_dict(),
+            "summary": candidate_summary.as_debug_dict(case),
+        },
+    )
+    write_json(
+        solution_dir / "debug" / "candidates.json",
+        [candidate.as_dict() for candidate in candidates],
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate AEOSSP greedy-LNS candidates and write a Phase-1 scaffold solution."
+    )
+    parser.add_argument("--case-dir", required=True)
+    parser.add_argument("--config-dir", default="")
+    parser.add_argument("--solution-dir", required=True)
+    args = parser.parse_args(argv)
+
+    case_dir = Path(args.case_dir).resolve()
+    config_dir = Path(args.config_dir).resolve() if args.config_dir else None
+    solution_dir = Path(args.solution_dir).resolve()
+
+    try:
+        total_start = time.perf_counter()
+        config_payload = load_solver_config(config_dir)
+        candidate_config = CandidateConfig.from_mapping(config_payload)
+        case = load_case(case_dir)
+        candidate_start = time.perf_counter()
+        candidates, candidate_summary = generate_candidates(case, candidate_config)
+        candidate_end = time.perf_counter()
+        # Phase 1 writes an empty solution; schedule construction comes in Phase 2.
+        solution_path = write_empty_solution(solution_dir)
+        total_end = time.perf_counter()
+        timing_seconds = {
+            "candidate_generation": candidate_end - candidate_start,
+            "total": total_end - total_start,
+        }
+        status = _build_status(
+            case_dir=case_dir,
+            config_dir=config_dir,
+            solution_path=solution_path,
+            case=case,
+            candidate_config=candidate_config,
+            candidate_summary=candidate_summary,
+            timing_seconds=timing_seconds,
+        )
+        write_json(solution_dir / "status.json", status)
+        if candidate_config.debug:
+            _write_debug_artifacts(
+                solution_dir=solution_dir,
+                case=case,
+                candidate_config=candidate_config,
+                candidate_summary=candidate_summary,
+                candidates=candidates,
+                timing_seconds=timing_seconds,
+            )
+    except Exception as exc:
+        traceback_text = traceback.format_exc()
+        solution_dir.mkdir(parents=True, exist_ok=True)
+        write_json(
+            solution_dir / "status.json",
+            {
+                "status": "error",
+                "phase": 1,
+                "case_dir": str(case_dir),
+                "config_dir": str(config_dir) if config_dir is not None else None,
+                "error": str(exc),
+                "traceback": traceback_text,
+            },
+        )
+        print(traceback_text, file=sys.stderr, end="")
+        return 2
+
+    print(
+        f"phase_1_candidates_generated: {case.mission.case_id} "
+        f"candidates={candidate_summary.candidate_count} "
+        f"satellites={len(case.satellites)} "
+        f"tasks={len(case.tasks)} -> {solution_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/solvers/aeossp_standard/greedy_lns/src/solve.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solve.py
@@ -1,4 +1,5 @@
-"""Solver entrypoint: generate candidates and emit actions for Phase 1."""
+"""Solver entrypoint: generate candidates, build schedule via greedy insertion,
+run solver-local repair, and emit a benchmark-compatible solution."""
 
 from __future__ import annotations
 
@@ -10,7 +11,9 @@ from pathlib import Path
 
 from candidates import CandidateConfig, generate_candidates
 from case_io import load_case, load_solver_config
-from solution_io import write_json, write_empty_solution
+from insertion import InsertionConfig, greedy_insertion
+from solution_io import write_json, write_solution
+from validation import RepairConfig, repair_schedule
 
 
 def _build_status(
@@ -21,11 +24,13 @@ def _build_status(
     case,
     candidate_config: CandidateConfig,
     candidate_summary,
+    insertion_result,
+    repair_result,
     timing_seconds: dict[str, float],
 ) -> dict:
     return {
-        "status": "phase_1_candidates_generated",
-        "phase": 1,
+        "status": "phase_2_greedy_insertion_solution_generated",
+        "phase": 2,
         "case_dir": str(case_dir),
         "config_dir": str(config_dir) if config_dir is not None else None,
         "solution": str(solution_path),
@@ -35,6 +40,8 @@ def _build_status(
         "candidate_config": candidate_config.as_status_dict(),
         "utility_policy": "weight_over_duration",
         **candidate_summary.as_debug_dict(case),
+        "insertion": insertion_result.as_dict(),
+        "repair": repair_result.as_status_dict(),
         "timing_seconds": timing_seconds,
     }
 
@@ -46,6 +53,8 @@ def _write_debug_artifacts(
     candidate_config: CandidateConfig,
     candidate_summary,
     candidates,
+    insertion_result,
+    repair_result,
     timing_seconds: dict[str, float],
 ) -> None:
     write_json(
@@ -60,11 +69,28 @@ def _write_debug_artifacts(
         solution_dir / "debug" / "candidates.json",
         [candidate.as_dict() for candidate in candidates],
     )
+    write_json(
+        solution_dir / "debug" / "insertion_stats.json",
+        {
+            "case_id": case.mission.case_id,
+            "insertion": insertion_result.as_dict(),
+            "selected_candidates": [candidate.as_dict() for candidate in insertion_result.selected],
+        },
+    )
+    write_json(
+        solution_dir / "debug" / "repair_log.json",
+        repair_result.as_debug_dict(),
+    )
+    write_json(
+        solution_dir / "debug" / "repaired_candidates.json",
+        [candidate.as_dict() for candidate in repair_result.candidates],
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Generate AEOSSP greedy-LNS candidates and write a Phase-1 scaffold solution."
+        description="Generate AEOSSP greedy-LNS candidates, build a schedule via greedy insertion, "
+        "run solver-local repair, and write a benchmark-compatible solution."
     )
     parser.add_argument("--case-dir", required=True)
     parser.add_argument("--config-dir", default="")
@@ -79,15 +105,24 @@ def main(argv: list[str] | None = None) -> int:
         total_start = time.perf_counter()
         config_payload = load_solver_config(config_dir)
         candidate_config = CandidateConfig.from_mapping(config_payload)
+        insertion_config = InsertionConfig.from_mapping(config_payload)
+        repair_config = RepairConfig.from_mapping(config_payload)
         case = load_case(case_dir)
         candidate_start = time.perf_counter()
         candidates, candidate_summary = generate_candidates(case, candidate_config)
         candidate_end = time.perf_counter()
-        # Phase 1 writes an empty solution; schedule construction comes in Phase 2.
-        solution_path = write_empty_solution(solution_dir)
+        insertion_start = time.perf_counter()
+        insertion_result = greedy_insertion(case, candidates, insertion_config)
+        insertion_end = time.perf_counter()
+        repair_start = time.perf_counter()
+        repair_result = repair_schedule(case, insertion_result.selected, config=repair_config)
+        repair_end = time.perf_counter()
+        solution_path = write_solution(solution_dir, repair_result.candidates)
         total_end = time.perf_counter()
         timing_seconds = {
             "candidate_generation": candidate_end - candidate_start,
+            "insertion": insertion_end - insertion_start,
+            "repair": repair_end - repair_start,
             "total": total_end - total_start,
         }
         status = _build_status(
@@ -97,6 +132,8 @@ def main(argv: list[str] | None = None) -> int:
             case=case,
             candidate_config=candidate_config,
             candidate_summary=candidate_summary,
+            insertion_result=insertion_result,
+            repair_result=repair_result,
             timing_seconds=timing_seconds,
         )
         write_json(solution_dir / "status.json", status)
@@ -107,6 +144,8 @@ def main(argv: list[str] | None = None) -> int:
                 candidate_config=candidate_config,
                 candidate_summary=candidate_summary,
                 candidates=candidates,
+                insertion_result=insertion_result,
+                repair_result=repair_result,
                 timing_seconds=timing_seconds,
             )
     except Exception as exc:
@@ -116,7 +155,7 @@ def main(argv: list[str] | None = None) -> int:
             solution_dir / "status.json",
             {
                 "status": "error",
-                "phase": 1,
+                "phase": 2,
                 "case_dir": str(case_dir),
                 "config_dir": str(config_dir) if config_dir is not None else None,
                 "error": str(exc),
@@ -127,10 +166,12 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     print(
-        f"phase_1_candidates_generated: {case.mission.case_id} "
+        f"phase_2_greedy_insertion_solution_generated: {case.mission.case_id} "
         f"candidates={candidate_summary.candidate_count} "
-        f"satellites={len(case.satellites)} "
-        f"tasks={len(case.tasks)} -> {solution_path}"
+        f"inserted={insertion_result.stats.candidates_inserted} "
+        f"after_repair={len(repair_result.candidates)} "
+        f"local_valid={repair_result.final_report.valid} "
+        f"repair_removals={len(repair_result.removals)} -> {solution_path}"
     )
     return 0
 

--- a/solvers/aeossp_standard/greedy_lns/src/solve.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solve.py
@@ -11,10 +11,11 @@ from pathlib import Path
 
 from candidates import CandidateConfig, generate_candidates
 from case_io import load_case, load_solver_config
+from components import build_component_index
 from insertion import InsertionConfig, greedy_insertion
 from local_search import LocalSearchConfig, local_search
 from solution_io import write_json, write_solution
-from validation import RepairConfig, repair_schedule
+from validation import RepairConfig, repair_schedule, validate_schedule
 
 
 def _build_status(
@@ -31,8 +32,8 @@ def _build_status(
     timing_seconds: dict[str, float],
 ) -> dict:
     return {
-        "status": "phase_3_local_search_solution_generated",
-        "phase": 3,
+        "status": "phase_5_tuned_solution_generated",
+        "phase": 5,
         "case_dir": str(case_dir),
         "config_dir": str(config_dir) if config_dir is not None else None,
         "solution": str(solution_path),
@@ -46,6 +47,29 @@ def _build_status(
         "local_search": local_search_result.as_dict(),
         "repair": repair_result.as_status_dict(),
         "timing_seconds": timing_seconds,
+        "reproduction_notes": {
+            "method_reference": "Antuori, Wojtowicz, and Hebrard, CP 2025",
+            "components_reproduced": {
+                "greedy_initial_construction": True,
+                "connected_component_local_search": True,
+                "marginal_profit_recomputation": True,
+            },
+            "components_omitted": {
+                "tempo_cp_sat_tsptw_fallback": "omitted — proprietary dependency",
+                "download_memory_planning": "omitted — benchmark is observation-only",
+            },
+            "adaptations": {
+                "battery_handling": "solver-local simulation + bounded repair",
+                "action_grid_alignment": "benchmark-mandated fixed times",
+                "weighted_objective": "maximize task weight (proxy for WCR)",
+            },
+            "known_limitations": [
+                "No CP-SAT exact subproblem fallback (Tempo omitted)",
+                "Candidates use fixed grid-aligned times; no continuous sliding within windows",
+                "Battery model is solver-local approximation, not benchmark verifier",
+                "No download or memory scheduling (benchmark is observation-only)",
+            ],
+        },
     }
 
 
@@ -89,6 +113,29 @@ def _write_debug_artifacts(
             "post_local_search_candidates": [candidate.as_dict() for candidate in local_search_result.candidates],
         },
     )
+
+    # Build component summary from all candidates
+    component_index = build_component_index(case, candidates)
+    write_json(
+        solution_dir / "debug" / "component_summary.json",
+        {
+            "case_id": case.mission.case_id,
+            "component_index": component_index.as_dict(),
+        },
+    )
+
+    # Validation summary: pre-repair and post-repair
+    pre_repair_validation = validate_schedule(case, local_search_result.candidates)
+    post_repair_validation = repair_result.final_report
+    write_json(
+        solution_dir / "debug" / "validation_summary.json",
+        {
+            "case_id": case.mission.case_id,
+            "pre_repair": pre_repair_validation.as_dict(),
+            "post_repair": post_repair_validation.as_dict(),
+        },
+    )
+
     write_json(
         solution_dir / "debug" / "repair_log.json",
         repair_result.as_debug_dict(),
@@ -176,7 +223,7 @@ def main(argv: list[str] | None = None) -> int:
             solution_dir / "status.json",
             {
                 "status": "error",
-                "phase": 3,
+                "phase": 5,
                 "case_dir": str(case_dir),
                 "config_dir": str(config_dir) if config_dir is not None else None,
                 "error": str(exc),
@@ -187,7 +234,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     print(
-        f"phase_3_local_search_solution_generated: {case.mission.case_id} "
+        f"phase_5_tuned_solution_generated: {case.mission.case_id} "
         f"candidates={candidate_summary.candidate_count} "
         f"inserted={insertion_result.stats.candidates_inserted} "
         f"ls_accepted={local_search_result.stats.moves_accepted} "

--- a/solvers/aeossp_standard/greedy_lns/src/solve.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solve.py
@@ -9,13 +9,13 @@ import time
 import traceback
 from pathlib import Path
 
-from candidates import CandidateConfig, generate_candidates
-from case_io import load_case, load_solver_config
-from components import build_component_index
-from insertion import InsertionConfig, greedy_insertion
-from local_search import LocalSearchConfig, local_search
-from solution_io import write_json, write_solution
-from validation import RepairConfig, repair_schedule, validate_schedule
+from .candidates import CandidateConfig, generate_candidates
+from .case_io import load_case, load_solver_config
+from .components import build_component_index
+from .insertion import InsertionConfig, greedy_insertion
+from .local_search import LocalSearchConfig, local_search
+from .solution_io import write_json, write_solution
+from .validation import RepairConfig, repair_schedule, validate_schedule
 
 
 def _build_status(

--- a/solvers/aeossp_standard/greedy_lns/src/solve.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solve.py
@@ -12,9 +12,11 @@ from pathlib import Path
 from .candidates import CandidateConfig, generate_candidates
 from .case_io import load_case, load_solver_config
 from .components import build_component_index
+from .geometry import PropagationContext
 from .insertion import InsertionConfig, greedy_insertion
 from .local_search import LocalSearchConfig, local_search
 from .solution_io import write_json, write_solution
+from .transition import TransitionVectorCache
 from .validation import RepairConfig, repair_schedule, validate_schedule
 
 
@@ -83,6 +85,8 @@ def _write_debug_artifacts(
     local_search_result,
     repair_result,
     timing_seconds: dict[str, float],
+    propagation: PropagationContext,
+    vector_cache: TransitionVectorCache,
 ) -> None:
     write_json(
         solution_dir / "debug" / "candidate_summary.json",
@@ -114,7 +118,12 @@ def _write_debug_artifacts(
     )
 
     # Build component summary from all candidates
-    component_index = build_component_index(case, candidates)
+    component_index = build_component_index(
+        case,
+        candidates,
+        propagation=propagation,
+        vector_cache=vector_cache,
+    )
     write_json(
         solution_dir / "debug" / "component_summary.json",
         {
@@ -124,7 +133,12 @@ def _write_debug_artifacts(
     )
 
     # Validation summary: pre-repair and post-repair
-    pre_repair_validation = validate_schedule(case, local_search_result.candidates)
+    pre_repair_validation = validate_schedule(
+        case,
+        local_search_result.candidates,
+        propagation=propagation,
+        vector_cache=vector_cache,
+    )
     post_repair_validation = repair_result.final_report
     write_json(
         solution_dir / "debug" / "validation_summary.json",
@@ -167,19 +181,43 @@ def main(argv: list[str] | None = None) -> int:
         local_search_config = LocalSearchConfig.from_mapping(config_payload)
         repair_config = RepairConfig.from_mapping(config_payload)
         case = load_case(case_dir)
+        step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+        propagation = PropagationContext(case.satellites, step_s=step_s)
+        vector_cache = TransitionVectorCache(case, propagation)
         candidate_start = time.perf_counter()
-        candidates, candidate_summary = generate_candidates(case, candidate_config)
+        candidates, candidate_summary = generate_candidates(
+            case,
+            candidate_config,
+            propagation=propagation,
+        )
         candidate_end = time.perf_counter()
         insertion_start = time.perf_counter()
-        insertion_result = greedy_insertion(case, candidates, insertion_config)
+        insertion_result = greedy_insertion(
+            case,
+            candidates,
+            insertion_config,
+            propagation=propagation,
+            vector_cache=vector_cache,
+        )
         insertion_end = time.perf_counter()
         local_search_start = time.perf_counter()
         local_search_result = local_search(
-            case, candidates, insertion_result.selected, config=local_search_config
+            case,
+            candidates,
+            insertion_result.selected,
+            config=local_search_config,
+            propagation=propagation,
+            vector_cache=vector_cache,
         )
         local_search_end = time.perf_counter()
         repair_start = time.perf_counter()
-        repair_result = repair_schedule(case, local_search_result.candidates, config=repair_config)
+        repair_result = repair_schedule(
+            case,
+            local_search_result.candidates,
+            config=repair_config,
+            propagation=propagation,
+            vector_cache=vector_cache,
+        )
         repair_end = time.perf_counter()
         solution_path = write_solution(solution_dir, repair_result.candidates)
         total_end = time.perf_counter()
@@ -214,6 +252,8 @@ def main(argv: list[str] | None = None) -> int:
                 local_search_result=local_search_result,
                 repair_result=repair_result,
                 timing_seconds=timing_seconds,
+                propagation=propagation,
+                vector_cache=vector_cache,
             )
     except Exception as exc:
         traceback_text = traceback.format_exc()

--- a/solvers/aeossp_standard/greedy_lns/src/solve.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solve.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from candidates import CandidateConfig, generate_candidates
 from case_io import load_case, load_solver_config
 from insertion import InsertionConfig, greedy_insertion
+from local_search import LocalSearchConfig, local_search
 from solution_io import write_json, write_solution
 from validation import RepairConfig, repair_schedule
 
@@ -25,12 +26,13 @@ def _build_status(
     candidate_config: CandidateConfig,
     candidate_summary,
     insertion_result,
+    local_search_result,
     repair_result,
     timing_seconds: dict[str, float],
 ) -> dict:
     return {
-        "status": "phase_2_greedy_insertion_solution_generated",
-        "phase": 2,
+        "status": "phase_3_local_search_solution_generated",
+        "phase": 3,
         "case_dir": str(case_dir),
         "config_dir": str(config_dir) if config_dir is not None else None,
         "solution": str(solution_path),
@@ -41,6 +43,7 @@ def _build_status(
         "utility_policy": "weight_over_duration",
         **candidate_summary.as_debug_dict(case),
         "insertion": insertion_result.as_dict(),
+        "local_search": local_search_result.as_dict(),
         "repair": repair_result.as_status_dict(),
         "timing_seconds": timing_seconds,
     }
@@ -54,6 +57,7 @@ def _write_debug_artifacts(
     candidate_summary,
     candidates,
     insertion_result,
+    local_search_result,
     repair_result,
     timing_seconds: dict[str, float],
 ) -> None:
@@ -75,6 +79,14 @@ def _write_debug_artifacts(
             "case_id": case.mission.case_id,
             "insertion": insertion_result.as_dict(),
             "selected_candidates": [candidate.as_dict() for candidate in insertion_result.selected],
+        },
+    )
+    write_json(
+        solution_dir / "debug" / "local_search_stats.json",
+        {
+            "case_id": case.mission.case_id,
+            "local_search": local_search_result.as_dict(),
+            "post_local_search_candidates": [candidate.as_dict() for candidate in local_search_result.candidates],
         },
     )
     write_json(
@@ -106,6 +118,7 @@ def main(argv: list[str] | None = None) -> int:
         config_payload = load_solver_config(config_dir)
         candidate_config = CandidateConfig.from_mapping(config_payload)
         insertion_config = InsertionConfig.from_mapping(config_payload)
+        local_search_config = LocalSearchConfig.from_mapping(config_payload)
         repair_config = RepairConfig.from_mapping(config_payload)
         case = load_case(case_dir)
         candidate_start = time.perf_counter()
@@ -114,14 +127,20 @@ def main(argv: list[str] | None = None) -> int:
         insertion_start = time.perf_counter()
         insertion_result = greedy_insertion(case, candidates, insertion_config)
         insertion_end = time.perf_counter()
+        local_search_start = time.perf_counter()
+        local_search_result = local_search(
+            case, candidates, insertion_result.selected, config=local_search_config
+        )
+        local_search_end = time.perf_counter()
         repair_start = time.perf_counter()
-        repair_result = repair_schedule(case, insertion_result.selected, config=repair_config)
+        repair_result = repair_schedule(case, local_search_result.candidates, config=repair_config)
         repair_end = time.perf_counter()
         solution_path = write_solution(solution_dir, repair_result.candidates)
         total_end = time.perf_counter()
         timing_seconds = {
             "candidate_generation": candidate_end - candidate_start,
             "insertion": insertion_end - insertion_start,
+            "local_search": local_search_end - local_search_start,
             "repair": repair_end - repair_start,
             "total": total_end - total_start,
         }
@@ -133,6 +152,7 @@ def main(argv: list[str] | None = None) -> int:
             candidate_config=candidate_config,
             candidate_summary=candidate_summary,
             insertion_result=insertion_result,
+            local_search_result=local_search_result,
             repair_result=repair_result,
             timing_seconds=timing_seconds,
         )
@@ -145,6 +165,7 @@ def main(argv: list[str] | None = None) -> int:
                 candidate_summary=candidate_summary,
                 candidates=candidates,
                 insertion_result=insertion_result,
+                local_search_result=local_search_result,
                 repair_result=repair_result,
                 timing_seconds=timing_seconds,
             )
@@ -155,7 +176,7 @@ def main(argv: list[str] | None = None) -> int:
             solution_dir / "status.json",
             {
                 "status": "error",
-                "phase": 2,
+                "phase": 3,
                 "case_dir": str(case_dir),
                 "config_dir": str(config_dir) if config_dir is not None else None,
                 "error": str(exc),
@@ -166,9 +187,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     print(
-        f"phase_2_greedy_insertion_solution_generated: {case.mission.case_id} "
+        f"phase_3_local_search_solution_generated: {case.mission.case_id} "
         f"candidates={candidate_summary.candidate_count} "
         f"inserted={insertion_result.stats.candidates_inserted} "
+        f"ls_accepted={local_search_result.stats.moves_accepted} "
+        f"ls_stop={local_search_result.stats.stop_reason} "
         f"after_repair={len(repair_result.candidates)} "
         f"local_valid={repair_result.final_report.valid} "
         f"repair_removals={len(repair_result.removals)} -> {solution_path}"

--- a/solvers/aeossp_standard/greedy_lns/src/solve.py
+++ b/solvers/aeossp_standard/greedy_lns/src/solve.py
@@ -32,8 +32,7 @@ def _build_status(
     timing_seconds: dict[str, float],
 ) -> dict:
     return {
-        "status": "phase_5_tuned_solution_generated",
-        "phase": 5,
+        "status": "solution_generated",
         "case_dir": str(case_dir),
         "config_dir": str(config_dir) if config_dir is not None else None,
         "solution": str(solution_path),
@@ -223,7 +222,6 @@ def main(argv: list[str] | None = None) -> int:
             solution_dir / "status.json",
             {
                 "status": "error",
-                "phase": 5,
                 "case_dir": str(case_dir),
                 "config_dir": str(config_dir) if config_dir is not None else None,
                 "error": str(exc),
@@ -234,7 +232,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     print(
-        f"phase_5_tuned_solution_generated: {case.mission.case_id} "
+        f"solution_generated: {case.mission.case_id} "
         f"candidates={candidate_summary.candidate_count} "
         f"inserted={insertion_result.stats.candidates_inserted} "
         f"ls_accepted={local_search_result.stats.moves_accepted} "

--- a/solvers/aeossp_standard/greedy_lns/src/transition.py
+++ b/solvers/aeossp_standard/greedy_lns/src/transition.py
@@ -1,0 +1,115 @@
+"""Transition feasibility helpers for AEOSSP candidate pairs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+import numpy as np
+
+from candidates import Candidate
+from case_io import AeosspCase, NUMERICAL_EPS, Satellite
+from geometry import (
+    PropagationContext,
+    angle_between_deg,
+    required_slew_settle_s,
+    target_vector_eci,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionResult:
+    feasible: bool
+    required_gap_s: float
+    available_gap_s: float
+    slew_angle_deg: float
+
+
+class TransitionVectorCache:
+    def __init__(self, case: AeosspCase, propagation: PropagationContext):
+        self.case = case
+        self.propagation = propagation
+        self._vectors: dict[tuple[str, str], np.ndarray] = {}
+
+    def vector(self, candidate: Candidate, endpoint: str) -> np.ndarray:
+        key = (candidate.candidate_id, endpoint)
+        cached = self._vectors.get(key)
+        if cached is not None:
+            return cached
+        if endpoint == "start":
+            offset_s = candidate.start_offset_s
+        elif endpoint == "end":
+            offset_s = candidate.end_offset_s
+        else:
+            raise ValueError(f"Unsupported endpoint: {endpoint}")
+        instant = self.case.mission.horizon_start + timedelta(seconds=offset_s)
+        vector = target_vector_eci(
+            self.case.tasks[candidate.task_id],
+            self.propagation,
+            candidate.satellite_id,
+            instant,
+        )
+        self._vectors[key] = vector
+        return vector
+
+
+def max_transition_gap_s(satellite: Satellite) -> float:
+    return required_slew_settle_s(180.0, satellite)
+
+
+def order_for_transition(
+    candidate_a: Candidate,
+    candidate_b: Candidate,
+) -> tuple[Candidate, Candidate]:
+    return tuple(
+        sorted(
+            (candidate_a, candidate_b),
+            key=lambda item: (item.start_offset_s, item.end_offset_s, item.candidate_id),
+        )
+    )
+
+
+def transition_result(
+    previous: Candidate,
+    current: Candidate,
+    *,
+    case: AeosspCase,
+    vector_cache: TransitionVectorCache,
+) -> TransitionResult:
+    if previous.satellite_id != current.satellite_id:
+        return TransitionResult(
+            feasible=True,
+            required_gap_s=0.0,
+            available_gap_s=float("inf"),
+            slew_angle_deg=0.0,
+        )
+    satellite = case.satellites[previous.satellite_id]
+    available_gap_s = float(current.start_offset_s - previous.end_offset_s)
+    from_vector = vector_cache.vector(previous, "end")
+    to_vector = vector_cache.vector(current, "start")
+    slew_angle_deg = angle_between_deg(from_vector, to_vector)
+    required_gap_s = required_slew_settle_s(slew_angle_deg, satellite)
+    return TransitionResult(
+        feasible=available_gap_s + NUMERICAL_EPS >= required_gap_s,
+        required_gap_s=required_gap_s,
+        available_gap_s=available_gap_s,
+        slew_angle_deg=slew_angle_deg,
+    )
+
+
+def transition_gap_conflict(
+    candidate_a: Candidate,
+    candidate_b: Candidate,
+    *,
+    case: AeosspCase,
+    vector_cache: TransitionVectorCache,
+) -> bool:
+    previous, current = order_for_transition(candidate_a, candidate_b)
+    if previous.end_offset_s > current.start_offset_s:
+        return True
+    return not transition_result(
+        previous,
+        current,
+        case=case,
+        vector_cache=vector_cache,
+    ).feasible

--- a/solvers/aeossp_standard/greedy_lns/src/transition.py
+++ b/solvers/aeossp_standard/greedy_lns/src/transition.py
@@ -7,9 +7,9 @@ from datetime import timedelta
 
 import numpy as np
 
-from candidates import Candidate
-from case_io import AeosspCase, NUMERICAL_EPS, Satellite
-from geometry import (
+from .candidates import Candidate
+from .case_io import AeosspCase, NUMERICAL_EPS, Satellite
+from .geometry import (
     PropagationContext,
     angle_between_deg,
     required_slew_settle_s,

--- a/solvers/aeossp_standard/greedy_lns/src/validation.py
+++ b/solvers/aeossp_standard/greedy_lns/src/validation.py
@@ -8,16 +8,16 @@ from typing import Any
 
 import brahe
 
-from candidates import Candidate
-from case_io import AeosspCase, NUMERICAL_EPS, Satellite, _is_aligned, iso_z
-from geometry import (
+from .candidates import Candidate
+from .case_io import AeosspCase, NUMERICAL_EPS, Satellite, _is_aligned, iso_z
+from .geometry import (
     PropagationContext,
     angle_between_deg,
     datetime_to_epoch,
     required_slew_settle_s,
     target_vector_eci,
 )
-from transition import TransitionVectorCache, transition_result
+from .transition import TransitionVectorCache, transition_result
 
 
 @dataclass(frozen=True, slots=True)

--- a/solvers/aeossp_standard/greedy_lns/src/validation.py
+++ b/solvers/aeossp_standard/greedy_lns/src/validation.py
@@ -1,0 +1,533 @@
+"""Solver-local schedule validation and bounded repair for greedy-LNS."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import timedelta
+from typing import Any
+
+import brahe
+
+from candidates import Candidate
+from case_io import AeosspCase, NUMERICAL_EPS, Satellite, iso_z
+from geometry import (
+    PropagationContext,
+    angle_between_deg,
+    datetime_to_epoch,
+    required_slew_settle_s,
+    target_vector_eci,
+)
+from transition import TransitionVectorCache, transition_result
+
+
+@dataclass(frozen=True, slots=True)
+class RepairConfig:
+    max_repair_iterations: int = 200
+
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "RepairConfig":
+        payload = payload or {}
+        return cls(max_repair_iterations=max(0, int(payload.get("max_repair_iterations", 200))))
+
+    def as_status_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationIssue:
+    reason: str
+    message: str
+    candidate_ids: tuple[str, ...] = ()
+    satellite_id: str | None = None
+    task_id: str | None = None
+    offset_s: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "reason": self.reason,
+            "message": self.message,
+            "candidate_ids": list(self.candidate_ids),
+        }
+        if self.satellite_id is not None:
+            payload["satellite_id"] = self.satellite_id
+        if self.task_id is not None:
+            payload["task_id"] = self.task_id
+        if self.offset_s is not None:
+            payload["offset_s"] = self.offset_s
+        return payload
+
+
+@dataclass(slots=True)
+class BatteryTrace:
+    satellite_id: str
+    min_battery_wh: float
+    min_offset_s: float
+    final_battery_wh: float
+    gross_consumption_wh: float
+    total_charge_wh: float
+    total_imaging_time_s: float
+    total_slew_time_s: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ValidationReport:
+    valid: bool
+    issue_count: int
+    issues: list[ValidationIssue] = field(default_factory=list)
+    battery: dict[str, BatteryTrace] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "valid": self.valid,
+            "issue_count": self.issue_count,
+            "issues": [issue.as_dict() for issue in self.issues],
+            "battery": {
+                satellite_id: trace.as_dict()
+                for satellite_id, trace in sorted(self.battery.items())
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RepairRemoval:
+    iteration: int
+    candidate_id: str
+    reason: str
+    task_weight: float
+    satellite_id: str
+    task_id: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RepairResult:
+    candidates: list[Candidate]
+    reports: list[ValidationReport]
+    removals: list[RepairRemoval]
+    terminated_reason: str
+
+    @property
+    def final_report(self) -> ValidationReport:
+        return self.reports[-1]
+
+    def as_status_dict(self) -> dict[str, Any]:
+        return {
+            "attempts": len(self.reports),
+            "actions_before_repair": (
+                len(self.candidates) + len(self.removals) if self.reports else len(self.candidates)
+            ),
+            "actions_after_repair": len(self.candidates),
+            "removed_actions": [removal.as_dict() for removal in self.removals],
+            "terminated_reason": self.terminated_reason,
+            "initial_local_valid": self.reports[0].valid if self.reports else True,
+            "initial_issue_count": self.reports[0].issue_count if self.reports else 0,
+            "final_local_valid": self.final_report.valid,
+            "final_issue_count": self.final_report.issue_count,
+            "initial_report": self.reports[0].as_dict() if self.reports else None,
+            "final_report": self.final_report.as_dict(),
+        }
+
+    def as_debug_dict(self) -> dict[str, Any]:
+        return {
+            "attempts": len(self.reports),
+            "terminated_reason": self.terminated_reason,
+            "removed_actions": [removal.as_dict() for removal in self.removals],
+            "reports": [report.as_dict() for report in self.reports],
+        }
+
+
+def duplicate_task_issues(candidates: list[Candidate]) -> list[ValidationIssue]:
+    by_task: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        by_task.setdefault(candidate.task_id, []).append(candidate)
+    issues: list[ValidationIssue] = []
+    for task_id, task_candidates in sorted(by_task.items()):
+        if len(task_candidates) <= 1:
+            continue
+        ordered = sorted(
+            task_candidates,
+            key=lambda item: (item.task_weight, -item.end_offset_s, item.candidate_id),
+        )
+        issues.append(
+            ValidationIssue(
+                reason="duplicate_task",
+                message=f"task {task_id} is selected more than once",
+                candidate_ids=tuple(candidate.candidate_id for candidate in ordered),
+                task_id=task_id,
+            )
+        )
+    return issues
+
+
+def _initial_slew_required_s(
+    case: AeosspCase,
+    candidate: Candidate,
+    *,
+    propagation: PropagationContext,
+) -> float:
+    satellite = case.satellites[candidate.satellite_id]
+    instant = case.mission.horizon_start + timedelta(seconds=candidate.start_offset_s)
+    sat_state_eci = propagation.state_eci(candidate.satellite_id, instant)
+    slew_angle_deg = angle_between_deg(
+        -sat_state_eci[:3],
+        target_vector_eci(
+            case.tasks[candidate.task_id],
+            propagation,
+            candidate.satellite_id,
+            instant,
+        ),
+    )
+    return required_slew_settle_s(slew_angle_deg, satellite)
+
+
+def schedule_issues(
+    case: AeosspCase,
+    candidates: list[Candidate],
+    *,
+    propagation: PropagationContext,
+) -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    vector_cache = TransitionVectorCache(case, propagation)
+    by_satellite: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        if candidate.satellite_id in case.satellites and candidate.task_id in case.tasks:
+            by_satellite.setdefault(candidate.satellite_id, []).append(candidate)
+
+    for satellite_id, satellite_candidates in sorted(by_satellite.items()):
+        ordered = sorted(
+            satellite_candidates,
+            key=lambda item: (item.start_offset_s, item.end_offset_s, item.candidate_id),
+        )
+        if ordered:
+            initial_required = _initial_slew_required_s(
+                case,
+                ordered[0],
+                propagation=propagation,
+            )
+            if ordered[0].start_offset_s + NUMERICAL_EPS < initial_required:
+                issues.append(
+                    ValidationIssue(
+                        reason="initial_slew_gap",
+                        message="first action does not leave enough time to slew from nadir",
+                        candidate_ids=(ordered[0].candidate_id,),
+                        satellite_id=satellite_id,
+                        task_id=ordered[0].task_id,
+                        offset_s=ordered[0].start_offset_s,
+                    )
+                )
+        for previous, current in zip(ordered, ordered[1:]):
+            if previous.end_offset_s > current.start_offset_s:
+                issues.append(
+                    ValidationIssue(
+                        reason="overlap",
+                        message="same-satellite actions overlap",
+                        candidate_ids=(previous.candidate_id, current.candidate_id),
+                        satellite_id=satellite_id,
+                        offset_s=current.start_offset_s,
+                    )
+                )
+                continue
+            result = transition_result(
+                previous,
+                current,
+                case=case,
+                vector_cache=vector_cache,
+            )
+            if not result.feasible:
+                issues.append(
+                    ValidationIssue(
+                        reason="transition_gap",
+                        message=(
+                            "same-satellite actions have insufficient transition gap "
+                            f"available={result.available_gap_s:.3f}s "
+                            f"required={result.required_gap_s:.3f}s"
+                        ),
+                        candidate_ids=(previous.candidate_id, current.candidate_id),
+                        satellite_id=satellite_id,
+                        offset_s=current.start_offset_s,
+                    )
+                )
+    return issues
+
+
+def is_sunlit(
+    propagation: PropagationContext,
+    satellite_id: str,
+    instant_offset_s: float,
+    case: AeosspCase,
+) -> bool:
+    instant = case.mission.horizon_start + timedelta(seconds=instant_offset_s)
+    epoch = datetime_to_epoch(instant)
+    sat_state_eci = propagation.state_eci(satellite_id, instant)
+    illumination = float(brahe.eclipse_cylindrical(sat_state_eci[:3], brahe.sun_position(epoch)))
+    return illumination > 0.5
+
+
+def _contains_offset(intervals: list[tuple[float, float, str]], offset_s: float) -> bool:
+    return any(start_s <= offset_s < end_s for start_s, end_s, _ in intervals)
+
+
+def _resource_time_points(
+    case: AeosspCase,
+    imaging_intervals: list[tuple[float, float, str]],
+    slew_intervals: list[tuple[float, float, str]],
+) -> list[float]:
+    points: set[float] = {0.0, float(case.mission.horizon_seconds)}
+    step_s = case.mission.resource_sample_step_s
+    for offset_s in range(0, case.mission.horizon_seconds, step_s):
+        points.add(float(offset_s))
+        points.add(float(min(offset_s + step_s, case.mission.horizon_seconds)))
+    for start_s, end_s, _ in imaging_intervals:
+        points.add(start_s)
+        points.add(end_s)
+    for start_s, end_s, _ in slew_intervals:
+        points.add(start_s)
+        points.add(end_s)
+    return sorted(points)
+
+
+def _slew_intervals(
+    case: AeosspCase,
+    satellite_candidates: list[Candidate],
+    *,
+    propagation: PropagationContext,
+) -> tuple[list[tuple[float, float, str]], list[ValidationIssue]]:
+    intervals: list[tuple[float, float, str]] = []
+    issues: list[ValidationIssue] = []
+    ordered = sorted(
+        satellite_candidates,
+        key=lambda item: (item.start_offset_s, item.end_offset_s, item.candidate_id),
+    )
+    if not ordered:
+        return intervals, issues
+    first = ordered[0]
+    initial_required = _initial_slew_required_s(case, first, propagation=propagation)
+    initial_start = first.start_offset_s - initial_required
+    if initial_start < -NUMERICAL_EPS:
+        issues.append(
+            ValidationIssue(
+                reason="initial_slew_gap",
+                message="first action requires a pre-horizon slew interval",
+                candidate_ids=(first.candidate_id,),
+                satellite_id=first.satellite_id,
+                task_id=first.task_id,
+                offset_s=first.start_offset_s,
+            )
+        )
+    else:
+        intervals.append((max(0.0, initial_start), float(first.start_offset_s), first.candidate_id))
+
+    vector_cache = TransitionVectorCache(case, propagation)
+    for previous, current in zip(ordered, ordered[1:]):
+        result = transition_result(previous, current, case=case, vector_cache=vector_cache)
+        intervals.append(
+            (
+                max(float(previous.end_offset_s), float(current.start_offset_s) - result.required_gap_s),
+                float(current.start_offset_s),
+                current.candidate_id,
+            )
+        )
+    return intervals, issues
+
+
+def battery_issues(
+    case: AeosspCase,
+    candidates: list[Candidate],
+    *,
+    propagation: PropagationContext,
+) -> tuple[list[ValidationIssue], dict[str, BatteryTrace]]:
+    issues: list[ValidationIssue] = []
+    traces: dict[str, BatteryTrace] = {}
+    by_satellite: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        if candidate.satellite_id in case.satellites:
+            by_satellite.setdefault(candidate.satellite_id, []).append(candidate)
+
+    for satellite_id, satellite in sorted(case.satellites.items()):
+        resource = satellite.resource_model
+        energy_wh = resource.initial_battery_wh
+        min_energy_wh = energy_wh
+        min_offset_s = 0.0
+        gross_consumption_wh = 0.0
+        total_charge_wh = 0.0
+        total_imaging_time_s = 0.0
+        total_slew_time_s = 0.0
+        satellite_candidates = by_satellite.get(satellite_id, [])
+        imaging_intervals = [
+            (float(candidate.start_offset_s), float(candidate.end_offset_s), candidate.candidate_id)
+            for candidate in satellite_candidates
+        ]
+        slew_intervals, slew_issues = _slew_intervals(
+            case,
+            satellite_candidates,
+            propagation=propagation,
+        )
+        issues.extend(slew_issues)
+        time_points = _resource_time_points(case, imaging_intervals, slew_intervals)
+        for start_s, end_s in zip(time_points, time_points[1:]):
+            delta_s = end_s - start_s
+            if delta_s <= 0.0:
+                continue
+            midpoint_s = start_s + (0.5 * delta_s)
+            load_w = resource.idle_power_w
+            if _contains_offset(imaging_intervals, midpoint_s):
+                load_w += resource.imaging_power_w
+                total_imaging_time_s += delta_s
+            if _contains_offset(slew_intervals, midpoint_s):
+                load_w += resource.slew_power_w
+                total_slew_time_s += delta_s
+            charge_w = (
+                resource.sunlit_charge_power_w
+                if is_sunlit(propagation, satellite_id, midpoint_s, case)
+                else 0.0
+            )
+            gross_consumption_wh += load_w * (delta_s / 3600.0)
+            total_charge_wh += charge_w * (delta_s / 3600.0)
+            energy_wh += (charge_w - load_w) * (delta_s / 3600.0)
+            if energy_wh < -NUMERICAL_EPS:
+                min_energy_wh = energy_wh
+                min_offset_s = end_s
+                break
+            energy_wh = min(resource.battery_capacity_wh, energy_wh)
+            if energy_wh < min_energy_wh:
+                min_energy_wh = energy_wh
+                min_offset_s = end_s
+        traces[satellite_id] = BatteryTrace(
+            satellite_id=satellite_id,
+            min_battery_wh=min_energy_wh,
+            min_offset_s=min_offset_s,
+            final_battery_wh=energy_wh,
+            gross_consumption_wh=gross_consumption_wh,
+            total_charge_wh=total_charge_wh,
+            total_imaging_time_s=total_imaging_time_s,
+            total_slew_time_s=total_slew_time_s,
+        )
+        if min_energy_wh < -NUMERICAL_EPS:
+            issues.append(
+                ValidationIssue(
+                    reason="battery_depletion",
+                    message=f"local battery estimate falls below zero: {min_energy_wh:.6f} Wh",
+                    satellite_id=satellite_id,
+                    offset_s=min_offset_s,
+                )
+            )
+    return issues, traces
+
+
+def validate_schedule(case: AeosspCase, candidates: list[Candidate]) -> ValidationReport:
+    stable_candidates = sorted(
+        candidates,
+        key=lambda item: (item.start_offset_s, item.satellite_id, item.task_id, item.candidate_id),
+    )
+    issues: list[ValidationIssue] = []
+    issues.extend(duplicate_task_issues(stable_candidates))
+
+    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+    propagation = PropagationContext(case.satellites, step_s=step_s)
+    issues.extend(schedule_issues(case, stable_candidates, propagation=propagation))
+    battery_failure_issues, battery = battery_issues(
+        case,
+        stable_candidates,
+        propagation=propagation,
+    )
+    issues.extend(battery_failure_issues)
+    return ValidationReport(valid=not issues, issue_count=len(issues), issues=issues, battery=battery)
+
+
+def _candidate_priority(candidate: Candidate) -> tuple[Any, ...]:
+    """Lower priority = more likely to be removed."""
+    return (candidate.utility, candidate.utility_tie_break)
+
+
+def _choose_removal(
+    issue: ValidationIssue,
+    candidates: list[Candidate],
+) -> Candidate | None:
+    if issue.reason == "battery_depletion":
+        if issue.satellite_id is None:
+            return None
+        # Remove lowest-utility candidate on the failing satellite that starts
+        # at or before the depletion point.
+        cutoff_s = issue.offset_s if issue.offset_s is not None else float("inf")
+        same_satellite = [
+            candidate
+            for candidate in candidates
+            if candidate.satellite_id == issue.satellite_id
+            and candidate.start_offset_s <= cutoff_s + NUMERICAL_EPS
+        ]
+        if not same_satellite:
+            same_satellite = [
+                candidate for candidate in candidates if candidate.satellite_id == issue.satellite_id
+            ]
+        if not same_satellite:
+            return None
+        return min(same_satellite, key=_candidate_priority)
+
+    # For non-battery issues, remove the lowest-utility implicated candidate.
+    candidate_by_id = {candidate.candidate_id: candidate for candidate in candidates}
+    implicated = [
+        candidate_by_id[candidate_id]
+        for candidate_id in issue.candidate_ids
+        if candidate_id in candidate_by_id
+    ]
+    if not implicated:
+        return None
+    return min(implicated, key=_candidate_priority)
+
+
+def repair_schedule(
+    case: AeosspCase,
+    candidates: list[Candidate],
+    *,
+    config: RepairConfig | None = None,
+) -> RepairResult:
+    config = config or RepairConfig()
+    current = sorted(
+        candidates,
+        key=lambda item: (item.start_offset_s, item.satellite_id, item.task_id, item.candidate_id),
+    )
+    reports: list[ValidationReport] = []
+    removals: list[RepairRemoval] = []
+    terminated_reason = "max_iterations"
+
+    for iteration in range(config.max_repair_iterations + 1):
+        report = validate_schedule(case, current)
+        reports.append(report)
+        if report.valid:
+            terminated_reason = "valid"
+            break
+        if iteration >= config.max_repair_iterations:
+            break
+        removal = None
+        for issue in report.issues:
+            removal = _choose_removal(issue, current)
+            if removal is not None:
+                break
+        if removal is None:
+            terminated_reason = "no_removal_candidate"
+            break
+        current = [
+            candidate for candidate in current if candidate.candidate_id != removal.candidate_id
+        ]
+        removals.append(
+            RepairRemoval(
+                iteration=iteration,
+                candidate_id=removal.candidate_id,
+                reason=issue.reason,
+                task_weight=removal.task_weight,
+                satellite_id=removal.satellite_id,
+                task_id=removal.task_id,
+            )
+        )
+
+    return RepairResult(
+        candidates=current,
+        reports=reports,
+        removals=removals,
+        terminated_reason=terminated_reason,
+    )

--- a/solvers/aeossp_standard/greedy_lns/src/validation.py
+++ b/solvers/aeossp_standard/greedy_lns/src/validation.py
@@ -9,7 +9,7 @@ from typing import Any
 import brahe
 
 from candidates import Candidate
-from case_io import AeosspCase, NUMERICAL_EPS, Satellite, iso_z
+from case_io import AeosspCase, NUMERICAL_EPS, Satellite, _is_aligned, iso_z
 from geometry import (
     PropagationContext,
     angle_between_deg,
@@ -419,12 +419,120 @@ def battery_issues(
     return issues, traces
 
 
+def candidate_shape_issues(case: AeosspCase, candidates: list[Candidate]) -> list[ValidationIssue]:
+    """Check that each selected candidate conforms to case-level constraints."""
+    issues: list[ValidationIssue] = []
+    for candidate in candidates:
+        if candidate.satellite_id not in case.satellites:
+            issues.append(
+                ValidationIssue(
+                    reason="unknown_satellite",
+                    message=f"satellite_id {candidate.satellite_id!r} not in case",
+                    candidate_ids=(candidate.candidate_id,),
+                    satellite_id=candidate.satellite_id,
+                    task_id=candidate.task_id,
+                )
+            )
+            continue
+        if candidate.task_id not in case.tasks:
+            issues.append(
+                ValidationIssue(
+                    reason="unknown_task",
+                    message=f"task_id {candidate.task_id!r} not in case",
+                    candidate_ids=(candidate.candidate_id,),
+                    satellite_id=candidate.satellite_id,
+                    task_id=candidate.task_id,
+                )
+            )
+            continue
+
+        satellite = case.satellites[candidate.satellite_id]
+        task = case.tasks[candidate.task_id]
+
+        if candidate.duration_s != task.required_duration_s:
+            issues.append(
+                ValidationIssue(
+                    reason="duration_mismatch",
+                    message=(
+                        f"duration {candidate.duration_s}s != required {task.required_duration_s}s"
+                    ),
+                    candidate_ids=(candidate.candidate_id,),
+                    satellite_id=candidate.satellite_id,
+                    task_id=candidate.task_id,
+                    offset_s=candidate.start_offset_s,
+                )
+            )
+
+        if not _is_aligned(candidate.start_offset_s, case.mission.action_time_step_s):
+            issues.append(
+                ValidationIssue(
+                    reason="grid_misalignment",
+                    message=(
+                        f"start_offset_s={candidate.start_offset_s} is not aligned to "
+                        f"action_time_step_s={case.mission.action_time_step_s}"
+                    ),
+                    candidate_ids=(candidate.candidate_id,),
+                    satellite_id=candidate.satellite_id,
+                    task_id=candidate.task_id,
+                    offset_s=candidate.start_offset_s,
+                )
+            )
+
+        release_offset_s = (task.release_time - case.mission.horizon_start).total_seconds()
+        due_offset_s = (task.due_time - case.mission.horizon_start).total_seconds()
+        if candidate.start_offset_s + NUMERICAL_EPS < release_offset_s:
+            issues.append(
+                ValidationIssue(
+                    reason="window_violation",
+                    message=(
+                        f"start {candidate.start_offset_s}s is before task release "
+                        f"{release_offset_s}s"
+                    ),
+                    candidate_ids=(candidate.candidate_id,),
+                    satellite_id=candidate.satellite_id,
+                    task_id=candidate.task_id,
+                    offset_s=candidate.start_offset_s,
+                )
+            )
+        if candidate.end_offset_s > due_offset_s + NUMERICAL_EPS:
+            issues.append(
+                ValidationIssue(
+                    reason="window_violation",
+                    message=(
+                        f"end {candidate.end_offset_s}s is after task due "
+                        f"{due_offset_s}s"
+                    ),
+                    candidate_ids=(candidate.candidate_id,),
+                    satellite_id=candidate.satellite_id,
+                    task_id=candidate.task_id,
+                    offset_s=candidate.end_offset_s,
+                )
+            )
+
+        if task.required_sensor_type != satellite.sensor_type:
+            issues.append(
+                ValidationIssue(
+                    reason="sensor_mismatch",
+                    message=(
+                        f"task sensor {task.required_sensor_type!r} != "
+                        f"satellite sensor {satellite.sensor_type!r}"
+                    ),
+                    candidate_ids=(candidate.candidate_id,),
+                    satellite_id=candidate.satellite_id,
+                    task_id=candidate.task_id,
+                )
+            )
+
+    return issues
+
+
 def validate_schedule(case: AeosspCase, candidates: list[Candidate]) -> ValidationReport:
     stable_candidates = sorted(
         candidates,
         key=lambda item: (item.start_offset_s, item.satellite_id, item.task_id, item.candidate_id),
     )
     issues: list[ValidationIssue] = []
+    issues.extend(candidate_shape_issues(case, stable_candidates))
     issues.extend(duplicate_task_issues(stable_candidates))
 
     step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))

--- a/solvers/aeossp_standard/greedy_lns/src/validation.py
+++ b/solvers/aeossp_standard/greedy_lns/src/validation.py
@@ -190,9 +190,11 @@ def schedule_issues(
     candidates: list[Candidate],
     *,
     propagation: PropagationContext,
+    vector_cache: TransitionVectorCache | None = None,
 ) -> list[ValidationIssue]:
     issues: list[ValidationIssue] = []
-    vector_cache = TransitionVectorCache(case, propagation)
+    if vector_cache is None:
+        vector_cache = TransitionVectorCache(case, propagation)
     by_satellite: dict[str, list[Candidate]] = {}
     for candidate in candidates:
         if candidate.satellite_id in case.satellites and candidate.task_id in case.tasks:
@@ -296,6 +298,7 @@ def _slew_intervals(
     satellite_candidates: list[Candidate],
     *,
     propagation: PropagationContext,
+    vector_cache: TransitionVectorCache,
 ) -> tuple[list[tuple[float, float, str]], list[ValidationIssue]]:
     intervals: list[tuple[float, float, str]] = []
     issues: list[ValidationIssue] = []
@@ -322,7 +325,6 @@ def _slew_intervals(
     else:
         intervals.append((max(0.0, initial_start), float(first.start_offset_s), first.candidate_id))
 
-    vector_cache = TransitionVectorCache(case, propagation)
     for previous, current in zip(ordered, ordered[1:]):
         result = transition_result(previous, current, case=case, vector_cache=vector_cache)
         intervals.append(
@@ -340,9 +342,12 @@ def battery_issues(
     candidates: list[Candidate],
     *,
     propagation: PropagationContext,
+    vector_cache: TransitionVectorCache | None = None,
 ) -> tuple[list[ValidationIssue], dict[str, BatteryTrace]]:
     issues: list[ValidationIssue] = []
     traces: dict[str, BatteryTrace] = {}
+    if vector_cache is None:
+        vector_cache = TransitionVectorCache(case, propagation)
     by_satellite: dict[str, list[Candidate]] = {}
     for candidate in candidates:
         if candidate.satellite_id in case.satellites:
@@ -366,6 +371,7 @@ def battery_issues(
             case,
             satellite_candidates,
             propagation=propagation,
+            vector_cache=vector_cache,
         )
         issues.extend(slew_issues)
         time_points = _resource_time_points(case, imaging_intervals, slew_intervals)
@@ -526,7 +532,13 @@ def candidate_shape_issues(case: AeosspCase, candidates: list[Candidate]) -> lis
     return issues
 
 
-def validate_schedule(case: AeosspCase, candidates: list[Candidate]) -> ValidationReport:
+def validate_schedule(
+    case: AeosspCase,
+    candidates: list[Candidate],
+    *,
+    propagation: PropagationContext | None = None,
+    vector_cache: TransitionVectorCache | None = None,
+) -> ValidationReport:
     stable_candidates = sorted(
         candidates,
         key=lambda item: (item.start_offset_s, item.satellite_id, item.task_id, item.candidate_id),
@@ -535,13 +547,24 @@ def validate_schedule(case: AeosspCase, candidates: list[Candidate]) -> Validati
     issues.extend(candidate_shape_issues(case, stable_candidates))
     issues.extend(duplicate_task_issues(stable_candidates))
 
-    step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
-    propagation = PropagationContext(case.satellites, step_s=step_s)
-    issues.extend(schedule_issues(case, stable_candidates, propagation=propagation))
+    if propagation is None:
+        step_s = float(min(case.mission.action_time_step_s, case.mission.geometry_sample_step_s))
+        propagation = PropagationContext(case.satellites, step_s=step_s)
+    if vector_cache is None:
+        vector_cache = TransitionVectorCache(case, propagation)
+    issues.extend(
+        schedule_issues(
+            case,
+            stable_candidates,
+            propagation=propagation,
+            vector_cache=vector_cache,
+        )
+    )
     battery_failure_issues, battery = battery_issues(
         case,
         stable_candidates,
         propagation=propagation,
+        vector_cache=vector_cache,
     )
     issues.extend(battery_failure_issues)
     return ValidationReport(valid=not issues, issue_count=len(issues), issues=issues, battery=battery)
@@ -593,6 +616,8 @@ def repair_schedule(
     candidates: list[Candidate],
     *,
     config: RepairConfig | None = None,
+    propagation: PropagationContext | None = None,
+    vector_cache: TransitionVectorCache | None = None,
 ) -> RepairResult:
     config = config or RepairConfig()
     current = sorted(
@@ -604,7 +629,12 @@ def repair_schedule(
     terminated_reason = "max_iterations"
 
     for iteration in range(config.max_repair_iterations + 1):
-        report = validate_schedule(case, current)
+        report = validate_schedule(
+            case,
+            current,
+            propagation=propagation,
+            vector_cache=vector_cache,
+        )
         reports.append(report)
         if report.valid:
             terminated_reason = "valid"

--- a/solvers/aeossp_standard/mwis_conflict_graph/solve.sh
+++ b/solvers/aeossp_standard/mwis_conflict_graph/solve.sh
@@ -10,7 +10,9 @@ SOLUTION_DIR="${3:-solution}"
 export MPLCONFIGDIR
 mkdir -p "${MPLCONFIGDIR}"
 
-PYTHONPATH="${SCRIPT_DIR}/src${PYTHONPATH:+:${PYTHONPATH}}" python "${SCRIPT_DIR}/src/solve.py" \
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}" python -m solvers.aeossp_standard.mwis_conflict_graph.src.solve \
   --case-dir "${CASE_DIR}" \
   --config-dir "${CONFIG_DIR}" \
   --solution-dir "${SOLUTION_DIR}"

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/__init__.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/__init__.py
@@ -1,10 +1,10 @@
 """Standalone source package for the AEOSSP MWIS conflict-graph solver."""
 
-from candidates import Candidate, CandidateConfig, CandidateSummary, generate_candidates
-from case_io import AeosspCase, Mission, Satellite, Task, load_case
-from graph import ConflictGraph, GraphStats, build_conflict_graph
-from mwis import MwisConfig, MwisStats, select_weighted_independent_set
-from validation import RepairConfig, RepairResult, ValidationReport, repair_candidates, validate_candidates
+from .candidates import Candidate, CandidateConfig, CandidateSummary, generate_candidates
+from .case_io import AeosspCase, Mission, Satellite, Task, load_case
+from .graph import ConflictGraph, GraphStats, build_conflict_graph
+from .mwis import MwisConfig, MwisStats, select_weighted_independent_set
+from .validation import RepairConfig, RepairResult, ValidationReport, repair_candidates, validate_candidates
 
 __all__ = [
     "AeosspCase",

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/candidates.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/candidates.py
@@ -6,8 +6,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Any
 
-from case_io import AeosspCase, Satellite, Task, iso_z
-from geometry import PropagationContext, initial_slew_feasible, observation_geometry_valid
+from .case_io import AeosspCase, Satellite, Task, iso_z
+from .geometry import PropagationContext, initial_slew_feasible, observation_geometry_valid
 
 
 @dataclass(frozen=True, slots=True)

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/geometry.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/geometry.py
@@ -8,7 +8,7 @@ import math
 import brahe
 import numpy as np
 
-from case_io import Mission, NUMERICAL_EPS, Satellite, Task
+from .case_io import Mission, NUMERICAL_EPS, Satellite, Task
 
 
 _BRAHE_READY = False

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/graph.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/graph.py
@@ -6,10 +6,10 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from itertools import combinations
 
-from candidates import Candidate
-from case_io import AeosspCase
-from geometry import PropagationContext
-from transition import (
+from .candidates import Candidate
+from .case_io import AeosspCase
+from .geometry import PropagationContext
+from .transition import (
     TransitionVectorCache,
     max_transition_gap_s,
     transition_gap_conflict,

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/mwis.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/mwis.py
@@ -8,8 +8,8 @@ from itertools import combinations
 import time
 from typing import Any
 
-from candidates import Candidate
-from graph import ConflictGraph, connected_components
+from .candidates import Candidate
+from .graph import ConflictGraph, connected_components
 
 
 SELECTION_POLICIES = ("weight_end_degree", "weight_degree_end")

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/solution_io.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/solution_io.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 import json
 
-from candidates import Candidate
+from .candidates import Candidate
 
 
 def write_json(path: Path, payload: Any) -> None:

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/solve.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/solve.py
@@ -8,12 +8,12 @@ import time
 import traceback
 from pathlib import Path
 
-from candidates import CandidateConfig, generate_candidates
-from case_io import load_case, load_solver_config
-from graph import build_conflict_graph, connected_components
-from mwis import MwisConfig, select_weighted_independent_set
-from solution_io import write_json, write_solution
-from validation import RepairConfig, repair_candidates
+from .candidates import CandidateConfig, generate_candidates
+from .case_io import load_case, load_solver_config
+from .graph import build_conflict_graph, connected_components
+from .mwis import MwisConfig, select_weighted_independent_set
+from .solution_io import write_json, write_solution
+from .validation import RepairConfig, repair_candidates
 
 
 def _build_status(

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/transition.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/transition.py
@@ -7,9 +7,9 @@ from datetime import timedelta
 
 import numpy as np
 
-from candidates import Candidate
-from case_io import AeosspCase, NUMERICAL_EPS, Satellite
-from geometry import (
+from .candidates import Candidate
+from .case_io import AeosspCase, NUMERICAL_EPS, Satellite
+from .geometry import (
     PropagationContext,
     angle_between_deg,
     required_slew_settle_s,

--- a/solvers/aeossp_standard/mwis_conflict_graph/src/validation.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/src/validation.py
@@ -8,16 +8,16 @@ from typing import Any
 
 import brahe
 
-from candidates import Candidate
-from case_io import AeosspCase, NUMERICAL_EPS, Satellite, iso_z
-from geometry import (
+from .candidates import Candidate
+from .case_io import AeosspCase, NUMERICAL_EPS, Satellite, iso_z
+from .geometry import (
     PropagationContext,
     angle_between_deg,
     datetime_to_epoch,
     required_slew_settle_s,
     target_vector_eci,
 )
-from transition import TransitionVectorCache, transition_result
+from .transition import TransitionVectorCache, transition_result
 
 
 @dataclass(frozen=True, slots=True)

--- a/solvers/finished_solvers.json
+++ b/solvers/finished_solvers.json
@@ -32,6 +32,14 @@
       "evidence_type": "reproduced_solver",
       "runnable": true,
       "ci_smoke": true
+    },
+    {
+      "benchmark": "aeossp_standard",
+      "solver": "greedy_lns",
+      "path": "solvers/aeossp_standard/greedy_lns",
+      "evidence_type": "reproduced_solver",
+      "runnable": true,
+      "ci_smoke": true
     }
   ]
 }

--- a/tests/solvers/test_aeossp_standard_greedy_lns.py
+++ b/tests/solvers/test_aeossp_standard_greedy_lns.py
@@ -36,6 +36,8 @@ from solution_io import candidates_to_actions, write_empty_solution  # noqa: E40
 from transition import TransitionVectorCache, transition_gap_conflict, transition_result  # noqa: E402
 
 from candidates import Candidate  # noqa: E402
+from insertion import greedy_insertion, InsertionConfig, InsertionResult  # noqa: E402
+from validation import RepairConfig, ValidationIssue, repair_schedule  # noqa: E402
 
 
 def _mission() -> Mission:
@@ -378,3 +380,140 @@ def test_candidate_summary_zero_task_tracking() -> None:
     assert debug["zero_candidate_task_count"] == 1
     assert debug["zero_candidate_task_ids"] == ["task_b"]
     assert debug["zero_candidate_task_counts_by_sensor"] == {"infrared": 1}
+
+
+
+def test_greedy_insertion_selects_higher_utility_first(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_a", start_offset_s=30, end_offset_s=40, weight=1.0)
+    case = _case_for_candidates([a, b])
+
+    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+
+    result = greedy_insertion(case, [a, b])
+    assert len(result.selected) == 1
+    assert result.selected[0].candidate_id == "a"
+    assert result.stats.candidates_skipped_duplicate_task == 1
+
+
+def test_greedy_insertion_rejects_overlap(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=25, weight=5.0)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=20, end_offset_s=30, weight=1.0)
+    case = _case_for_candidates([a, b])
+
+    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+
+    result = greedy_insertion(case, [a, b])
+    assert len(result.selected) == 1
+    assert result.selected[0].candidate_id == "a"
+    assert result.stats.candidates_rejected_overlap == 1
+
+
+def test_greedy_insertion_rejects_insufficient_transition(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=22, end_offset_s=32, weight=1.0)
+    case = _case_for_candidates([a, b])
+
+    class FakeResult:
+        feasible = False
+
+    def fake_transition(previous, current, **kwargs):
+        if previous.candidate_id == "a" and current.candidate_id == "b":
+            return FakeResult()
+        return type("R", (), {"feasible": True})()
+
+    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("insertion.transition_result", fake_transition)
+
+    result = greedy_insertion(case, [a, b])
+    assert len(result.selected) == 1
+    assert result.selected[0].candidate_id == "a"
+    assert result.stats.candidates_rejected_transition == 1
+
+
+def test_greedy_insertion_respects_initial_slew(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    case = _case_for_candidates([a])
+
+    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: False)
+
+    result = greedy_insertion(case, [a])
+    assert len(result.selected) == 0
+    assert result.stats.candidates_rejected_initial_slew == 1
+
+
+def test_greedy_insertion_insert_between_feasible(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=1.0)
+    c = _candidate("c", satellite_id="sat_a", task_id="task_c", start_offset_s=30, end_offset_s=40, weight=1.0)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=22, end_offset_s=28, weight=1.0)
+    case = _case_for_candidates([a, b, c])
+
+    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+
+    result = greedy_insertion(case, [a, b, c])
+    ids = [item.candidate_id for item in result.selected]
+    assert ids == ["a", "b", "c"]
+    assert result.stats.candidates_inserted == 3
+
+
+def test_greedy_insertion_cross_satellite_same_task_rejected(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_x", start_offset_s=10, end_offset_s=20, weight=5.0)
+    b = _candidate("b", satellite_id="sat_b", task_id="task_x", start_offset_s=30, end_offset_s=40, weight=1.0)
+    case = _case_for_candidates([a, b])
+
+    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+
+    result = greedy_insertion(case, [a, b])
+    assert len(result.selected) == 1
+    assert result.selected[0].candidate_id == "a"
+    assert result.stats.candidates_skipped_duplicate_task == 1
+
+
+def test_repair_removes_battery_violation(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=30, end_offset_s=40, weight=1.0)
+    case = _case_for_candidates([a, b])
+
+    monkeypatch.setattr("validation.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("validation.schedule_issues", lambda case, candidates, **kwargs: [])
+
+    def fake_battery_issues(case, candidates, **kwargs):
+        if any(c.candidate_id == "b" for c in candidates):
+            return (
+                [ValidationIssue(reason="battery_depletion", message="battery depleted", satellite_id="sat_a", offset_s=35.0)],
+                {},
+            )
+        return ([], {})
+
+    monkeypatch.setattr("validation.battery_issues", fake_battery_issues)
+
+    result = repair_schedule(case, [a, b], config=RepairConfig(max_repair_iterations=10))
+    assert len(result.candidates) == 1
+    assert result.candidates[0].candidate_id == "a"
+    assert result.terminated_reason == "valid"
+    assert len(result.removals) == 1
+    assert result.removals[0].candidate_id == "b"
+
+
+def test_repair_passes_when_valid(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    case = _case_for_candidates([a])
+
+    monkeypatch.setattr("validation.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("validation.schedule_issues", lambda case, candidates, **kwargs: [])
+    monkeypatch.setattr("validation.battery_issues", lambda case, candidates, **kwargs: ([], {}))
+
+    result = repair_schedule(case, [a], config=RepairConfig(max_repair_iterations=10))
+    assert len(result.candidates) == 1
+    assert result.terminated_reason == "valid"
+    assert len(result.removals) == 0

--- a/tests/solvers/test_aeossp_standard_greedy_lns.py
+++ b/tests/solvers/test_aeossp_standard_greedy_lns.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOLVER_DIR = REPO_ROOT / "solvers" / "aeossp_standard" / "greedy_lns" / "src"
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(SOLVER_DIR))
+
+from candidates import CandidateConfig, CandidateSummary, generate_candidates, start_offsets_for_task  # noqa: E402
+from case_io import (  # noqa: E402
+    AeosspCase,
+    AttitudeModel,
+    Mission,
+    ResourceModel,
+    Satellite,
+    Task,
+    iso_z,
+    load_case,
+    load_solver_config,
+    parse_iso_z,
+)
+from geometry import (  # noqa: E402
+    action_sample_times,
+    angle_between_deg,
+    initial_slew_feasible_from_vectors,
+    slew_time_s,
+)
+from solution_io import candidates_to_actions, write_empty_solution  # noqa: E402
+from transition import TransitionVectorCache, transition_gap_conflict, transition_result  # noqa: E402
+
+from candidates import Candidate  # noqa: E402
+
+
+def _mission() -> Mission:
+    return Mission(
+        case_id="unit_case",
+        horizon_start=datetime(2026, 4, 14, 4, 0, tzinfo=UTC),
+        horizon_end=datetime(2026, 4, 14, 5, 0, tzinfo=UTC),
+        action_time_step_s=5,
+        geometry_sample_step_s=5,
+        resource_sample_step_s=10,
+    )
+
+
+def _satellite(satellite_id: str = "sat_a", sensor_type: str = "visible") -> Satellite:
+    return Satellite(
+        satellite_id=satellite_id,
+        norad_catalog_id=1,
+        tle_line1="tle1",
+        tle_line2="tle2",
+        sensor_type=sensor_type,
+        attitude_model=AttitudeModel(
+            max_slew_velocity_deg_per_s=1.0,
+            max_slew_acceleration_deg_per_s2=1.0,
+            settling_time_s=2.0,
+            max_off_nadir_deg=30.0,
+        ),
+        resource_model=ResourceModel(
+            battery_capacity_wh=1.0,
+            initial_battery_wh=1.0,
+            idle_power_w=1.0,
+            imaging_power_w=1.0,
+            slew_power_w=1.0,
+            sunlit_charge_power_w=0.0,
+        ),
+    )
+
+
+def _task(task_id: str = "task_a", sensor_type: str = "visible") -> Task:
+    mission = _mission()
+    return Task(
+        task_id=task_id,
+        name="task",
+        latitude_deg=0.0,
+        longitude_deg=0.0,
+        altitude_m=0.0,
+        release_time=mission.horizon_start + timedelta(seconds=10),
+        due_time=mission.horizon_start + timedelta(seconds=30),
+        required_duration_s=10,
+        required_sensor_type=sensor_type,
+        weight=3.0,
+        target_ecef_m=(1.0, 0.0, 0.0),
+    )
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    satellite_id: str = "sat_a",
+    task_id: str = "task_a",
+    start_offset_s: int = 10,
+    end_offset_s: int = 20,
+    weight: float = 1.0,
+) -> Candidate:
+    mission = _mission()
+    return Candidate(
+        candidate_id=candidate_id,
+        satellite_id=satellite_id,
+        task_id=task_id,
+        start_offset_s=start_offset_s,
+        end_offset_s=end_offset_s,
+        start_time=iso_z(mission.horizon_start + timedelta(seconds=start_offset_s)),
+        end_time=iso_z(mission.horizon_start + timedelta(seconds=end_offset_s)),
+        task_weight=weight,
+        duration_s=end_offset_s - start_offset_s,
+        utility=weight / max(1, end_offset_s - start_offset_s),
+        utility_tie_break=(-weight, 30, 0.0, candidate_id),
+    )
+
+
+def _case_for_candidates(candidates: list[Candidate]) -> AeosspCase:
+    satellites = {
+        candidate.satellite_id: _satellite(candidate.satellite_id, "visible")
+        for candidate in candidates
+    }
+    tasks = {
+        candidate.task_id: _task(candidate.task_id, "visible")
+        for candidate in candidates
+    }
+    return AeosspCase(
+        case_dir=Path("."),
+        mission=_mission(),
+        satellites=satellites,
+        tasks=tasks,
+    )
+
+
+def test_iso_z_timestamp_round_trip() -> None:
+    parsed = parse_iso_z("2026-04-14T04:00:05Z")
+    assert parsed.tzinfo is UTC
+    assert iso_z(parsed) == "2026-04-14T04:00:05Z"
+
+
+def test_load_case_rejects_initial_battery_above_capacity(tmp_path: Path) -> None:
+    (tmp_path / "mission.yaml").write_text(
+        """mission:
+  case_id: overfull_battery
+  horizon_start: "2026-04-14T04:00:00Z"
+  horizon_end: "2026-04-14T05:00:00Z"
+  action_time_step_s: 5
+  geometry_sample_step_s: 5
+  resource_sample_step_s: 10
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "satellites.yaml").write_text(
+        """satellites:
+- satellite_id: sat_001
+  norad_catalog_id: 28051
+  tle_line1: 1 28051U 03046A   26103.92936350  .00000126  00000+0  55914-4 0  9994
+  tle_line2: 2 28051  98.1985 143.5711 0064246 173.9227 286.4737 14.36137850171300
+  sensor:
+    sensor_type: visible
+  attitude_model:
+    max_slew_velocity_deg_per_s: 1.8
+    max_slew_acceleration_deg_per_s2: 0.4
+    settling_time_s: 2.0
+    max_off_nadir_deg: 30.0
+  resource_model:
+    battery_capacity_wh: 1300.0
+    initial_battery_wh: 1300.1
+    idle_power_w: 20.0
+    imaging_power_w: 420.0
+    slew_power_w: 360.0
+    sunlit_charge_power_w: 85.0
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "tasks.yaml").write_text(
+        """tasks:
+- task_id: task_0001
+  name: task
+  latitude_deg: 0.0
+  longitude_deg: 0.0
+  altitude_m: 0.0
+  release_time: "2026-04-14T04:10:00Z"
+  due_time: "2026-04-14T04:20:00Z"
+  required_duration_s: 10
+  required_sensor_type: visible
+  weight: 1.0
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="initial_battery_wh"):
+        load_case(tmp_path)
+
+
+def test_load_solver_config_rejects_explicit_missing_path(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="config path does not exist"):
+        load_solver_config(tmp_path / "missing")
+
+
+def test_load_solver_config_rejects_empty_explicit_directory(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="no supported config file found"):
+        load_solver_config(tmp_path)
+
+
+def test_action_grid_iteration_respects_window_and_duration() -> None:
+    case = AeosspCase(
+        case_dir=Path("."),
+        mission=_mission(),
+        satellites={},
+        tasks={"task_a": _task()},
+    )
+    assert start_offsets_for_task(case, _task()) == [10, 15, 20]
+    assert start_offsets_for_task(case, _task(), stride_multiplier=2) == [10, 20]
+
+
+def test_geometry_sample_times_include_boundaries_and_interior_grid() -> None:
+    mission = _mission()
+    start = mission.horizon_start + timedelta(seconds=7)
+    end = mission.horizon_start + timedelta(seconds=22)
+    offsets = [
+        int((item - mission.horizon_start).total_seconds())
+        for item in action_sample_times(mission, start, end)
+    ]
+    assert offsets == [7, 10, 15, 20, 22]
+
+
+def test_initial_slew_feasibility_from_nadir_vectors() -> None:
+    satellite = _satellite()
+    assert initial_slew_feasible_from_vectors(
+        nadir_vector_eci=np.array([1.0, 0.0, 0.0]),
+        target_vector_eci=np.array([1.0, 0.0, 0.0]),
+        available_gap_s=2.0,
+        satellite=satellite,
+    )
+    assert not initial_slew_feasible_from_vectors(
+        nadir_vector_eci=np.array([1.0, 0.0, 0.0]),
+        target_vector_eci=np.array([0.0, 1.0, 0.0]),
+        available_gap_s=2.0,
+        satellite=satellite,
+    )
+
+
+def test_generate_candidates_filters_sensor_and_keeps_stable_ids(monkeypatch) -> None:
+    mission = _mission()
+    case = AeosspCase(
+        case_dir=Path("."),
+        mission=mission,
+        satellites={
+            "sat_a": _satellite("sat_a", "visible"),
+            "sat_b": _satellite("sat_b", "infrared"),
+        },
+        tasks={
+            "task_a": _task("task_a", "visible"),
+            "task_b": _task("task_b", "infrared"),
+        },
+    )
+
+    class DummyPropagation:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("candidates.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("candidates.observation_geometry_valid", lambda **kwargs: True)
+    monkeypatch.setattr("candidates.initial_slew_feasible", lambda **kwargs: True)
+
+    candidates, summary = generate_candidates(case, CandidateConfig())
+    candidate_ids = [item.candidate_id for item in candidates]
+
+    assert candidate_ids == [
+        "sat_a|task_a|10",
+        "sat_a|task_a|15",
+        "sat_a|task_a|20",
+        "sat_b|task_b|10",
+        "sat_b|task_b|15",
+        "sat_b|task_b|20",
+    ]
+    assert len(candidate_ids) == len(set(candidate_ids))
+    assert summary.per_satellite_candidate_counts["sat_a"] == 3
+    assert summary.per_satellite_candidate_counts["sat_b"] == 3
+    assert summary.per_task_candidate_counts["task_a"] == 3
+    assert summary.per_task_candidate_counts["task_b"] == 3
+
+
+def test_angle_between_deg_edge_cases() -> None:
+    assert angle_between_deg(np.array([1.0, 0.0, 0.0]), np.array([1.0, 0.0, 0.0])) == pytest.approx(0.0)
+    assert angle_between_deg(np.array([1.0, 0.0, 0.0]), np.array([-1.0, 0.0, 0.0])) == pytest.approx(180.0)
+    assert angle_between_deg(np.array([0.0, 0.0, 0.0]), np.array([1.0, 0.0, 0.0])) == pytest.approx(0.0)
+
+
+def test_slew_time_triangular_vs_trapezoidal() -> None:
+    # Triangular profile: small angle
+    t_tri = slew_time_s(1.0, 2.0, 2.0)
+    assert t_tri == pytest.approx(2.0 * (1.0 / 2.0) ** 0.5)
+    # Trapezoidal profile: large angle
+    t_trap = slew_time_s(10.0, 2.0, 2.0)
+    ramp_time = 2.0 / 2.0
+    threshold = 2.0 * 2.0 / 2.0
+    cruise = 10.0 - threshold
+    expected = (2.0 * ramp_time) + (cruise / 2.0)
+    assert t_trap == pytest.approx(expected)
+    # Zero angle
+    assert slew_time_s(0.0, 2.0, 2.0) == pytest.approx(0.0)
+
+
+def test_transition_result_cross_satellite_is_always_feasible() -> None:
+    case = _case_for_candidates([])
+    a = _candidate("a", satellite_id="sat_a", start_offset_s=10, end_offset_s=20)
+    b = _candidate("b", satellite_id="sat_b", start_offset_s=30, end_offset_s=40)
+
+    class DummyCache:
+        pass
+
+    result = transition_result(a, b, case=case, vector_cache=DummyCache())  # type: ignore[arg-type]
+    assert result.feasible
+    assert result.required_gap_s == 0.0
+    assert result.available_gap_s == float("inf")
+
+
+def test_transition_gap_conflict_same_satellite_overlap() -> None:
+    case = _case_for_candidates([])
+    a = _candidate("a", satellite_id="sat_a", start_offset_s=10, end_offset_s=25)
+    b = _candidate("b", satellite_id="sat_a", start_offset_s=20, end_offset_s=30)
+
+    class DummyCache:
+        pass
+
+    assert transition_gap_conflict(a, b, case=case, vector_cache=DummyCache())  # type: ignore[arg-type]
+
+
+def test_candidates_to_actions_sorts_and_formats() -> None:
+    c1 = _candidate("c1", satellite_id="sat_a", task_id="task_a", start_offset_s=20, end_offset_s=30)
+    c2 = _candidate("c2", satellite_id="sat_a", task_id="task_b", start_offset_s=10, end_offset_s=20)
+    actions = candidates_to_actions([c1, c2])
+    assert actions[0]["task_id"] == "task_b"
+    assert actions[1]["task_id"] == "task_a"
+    for action in actions:
+        assert action["type"] == "observation"
+        assert "satellite_id" in action
+        assert "start_time" in action
+        assert "end_time" in action
+
+
+def test_write_empty_solution_creates_valid_json(tmp_path: Path) -> None:
+    path = write_empty_solution(tmp_path)
+    assert path.exists()
+    import json
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == {"actions": []}
+
+
+def test_candidate_config_from_mapping_defaults() -> None:
+    cfg = CandidateConfig.from_mapping(None)
+    assert cfg.candidate_stride_multiplier == 1
+    assert cfg.max_candidates is None
+    assert cfg.max_candidates_per_task is None
+    assert not cfg.debug
+
+
+def test_candidate_config_caps_reject_non_positive() -> None:
+    with pytest.raises(ValueError, match="positive integers"):
+        CandidateConfig.from_mapping({"max_candidates": 0})
+
+
+def test_candidate_summary_zero_task_tracking() -> None:
+    mission = _mission()
+    case = AeosspCase(
+        case_dir=Path("."),
+        mission=mission,
+        satellites={"sat_a": _satellite("sat_a", "visible")},
+        tasks={
+            "task_a": _task("task_a", "visible"),
+            "task_b": _task("task_b", "infrared"),
+        },
+    )
+    summary = CandidateSummary()
+    summary.per_task_candidate_counts["task_a"] = 2
+    debug = summary.as_debug_dict(case)
+    assert debug["zero_candidate_task_count"] == 1
+    assert debug["zero_candidate_task_ids"] == ["task_b"]
+    assert debug["zero_candidate_task_counts_by_sensor"] == {"infrared": 1}

--- a/tests/solvers/test_aeossp_standard_greedy_lns.py
+++ b/tests/solvers/test_aeossp_standard_greedy_lns.py
@@ -670,3 +670,56 @@ def test_local_search_restart_determinism(monkeypatch) -> None:
     result2 = local_search(case, [a], greedy_solution, config=LocalSearchConfig(restart_count=2, random_seed=42))
     assert result1.stats.stop_reason == result2.stats.stop_reason
     assert result1.stats.final_objective == result2.stats.final_objective
+
+
+def test_candidate_shape_issues_catch_duration_mismatch(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    case = _case_for_candidates([a])
+    # Create a new task with a different required_duration_s
+    task = case.tasks["task_a"]
+    new_task = task.__class__(
+        task_id=task.task_id,
+        name=task.name,
+        latitude_deg=task.latitude_deg,
+        longitude_deg=task.longitude_deg,
+        altitude_m=task.altitude_m,
+        release_time=task.release_time,
+        due_time=task.due_time,
+        required_duration_s=15,
+        required_sensor_type=task.required_sensor_type,
+        weight=task.weight,
+        target_ecef_m=task.target_ecef_m,
+    )
+    new_case = AeosspCase(
+        case_dir=case.case_dir,
+        mission=case.mission,
+        satellites=case.satellites,
+        tasks={**case.tasks, "task_a": new_task},
+    )
+    from validation import candidate_shape_issues
+    issues = candidate_shape_issues(new_case, [a])
+    assert any(i.reason == "duration_mismatch" for i in issues)
+
+
+def test_candidate_shape_issues_catch_grid_misalignment(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    case = _case_for_candidates([a])
+    # Create a new case with a larger action_time_step_s
+    mission = case.mission
+    new_mission = mission.__class__(
+        case_id=mission.case_id,
+        horizon_start=mission.horizon_start,
+        horizon_end=mission.horizon_end,
+        action_time_step_s=7,
+        geometry_sample_step_s=mission.geometry_sample_step_s,
+        resource_sample_step_s=mission.resource_sample_step_s,
+    )
+    new_case = AeosspCase(
+        case_dir=case.case_dir,
+        mission=new_mission,
+        satellites=case.satellites,
+        tasks=case.tasks,
+    )
+    from validation import candidate_shape_issues
+    issues = candidate_shape_issues(new_case, [a])
+    assert any(i.reason == "grid_misalignment" for i in issues)

--- a/tests/solvers/test_aeossp_standard_greedy_lns.py
+++ b/tests/solvers/test_aeossp_standard_greedy_lns.py
@@ -628,7 +628,7 @@ def test_local_search_accepted_improving_move(monkeypatch) -> None:
     high = _candidate("high", satellite_id="sat_a", task_id="task_x", start_offset_s=10, end_offset_s=20, weight=5.0)
     case = _case_for_candidates([low, high])
 
-    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda *args, **kwargs: type("Idx", (), {
         "components": [
             type("Comp", (), {
                 "satellite_id": "sat_a",
@@ -654,7 +654,7 @@ def test_local_search_rejected_non_improving_move(monkeypatch) -> None:
     a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
     case = _case_for_candidates([a])
 
-    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda *args, **kwargs: type("Idx", (), {
         "components": [
             type("Comp", (), {
                 "satellite_id": "sat_a",
@@ -680,7 +680,7 @@ def test_local_search_restart_determinism(monkeypatch) -> None:
     a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
     case = _case_for_candidates([a])
 
-    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda *args, **kwargs: type("Idx", (), {
         "components": [],
         "stats": type("Stats", (), {"component_count": 0, "largest_component_size": 0})(),
     })())
@@ -691,6 +691,59 @@ def test_local_search_restart_determinism(monkeypatch) -> None:
     result2 = local_search(case, [a], greedy_solution, config=LocalSearchConfig(restart_count=2, random_seed=42))
     assert result1.stats.stop_reason == result2.stats.stop_reason
     assert result1.stats.final_objective == result2.stats.final_objective
+
+
+def test_local_search_restart_noops_on_empty_incumbent(monkeypatch) -> None:
+    case = _case_for_candidates([])
+
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda *args, **kwargs: type("Idx", (), {
+        "components": [],
+        "stats": type("Stats", (), {"component_count": 0, "largest_component_size": 0})(),
+    })())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.TransitionVectorCache", lambda *args, **kwargs: None)
+
+    result = local_search(
+        case,
+        [],
+        [],
+        config=LocalSearchConfig(max_local_search_iterations=1, restart_count=2, random_seed=42),
+    )
+
+    assert result.candidates == []
+    assert result.stats.final_objective == 0.0
+    assert result.stats.restarts_executed == 2
+
+
+def test_recompute_component_creates_missing_satellite_bucket(monkeypatch) -> None:
+    low = _candidate("low", satellite_id="sat_a", task_id="task_x", start_offset_s=10, end_offset_s=20, weight=1.0)
+    high = _candidate("high", satellite_id="sat_b", task_id="task_x", start_offset_s=10, end_offset_s=20, weight=5.0)
+    case = _case_for_candidates([low, high])
+    component = Component(
+        satellite_id="sat_b",
+        component_id="sat_b::high",
+        candidates=(high,),
+    )
+    by_satellite = {"sat_a": [low]}
+    scheduled_tasks = {"task_x": low}
+
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+
+    new_weight, failures = _recompute_component(
+        case,
+        component,
+        by_satellite,
+        scheduled_tasks,
+        propagation=None,
+        vector_cache=None,
+    )
+
+    assert failures == 0
+    assert new_weight == 5.0
+    assert by_satellite["sat_a"] == []
+    assert by_satellite["sat_b"] == [high]
+    assert scheduled_tasks == {"task_x": high}
 
 
 def test_candidate_shape_issues_catch_duration_mismatch(monkeypatch) -> None:

--- a/tests/solvers/test_aeossp_standard_greedy_lns.py
+++ b/tests/solvers/test_aeossp_standard_greedy_lns.py
@@ -723,3 +723,34 @@ def test_candidate_shape_issues_catch_grid_misalignment(monkeypatch) -> None:
     from validation import candidate_shape_issues
     issues = candidate_shape_issues(new_case, [a])
     assert any(i.reason == "grid_misalignment" for i in issues)
+
+
+def test_greedy_insertion_with_minimize_transition_increment(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=30, end_offset_s=40, weight=3.0)
+    c = _candidate("c", satellite_id="sat_a", task_id="task_c", start_offset_s=22, end_offset_s=28, weight=1.0)
+    case = _case_for_candidates([a, b, c])
+
+    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True, "required_gap_s": 1.0})())
+
+    result = greedy_insertion(case, [a, b, c], config=InsertionConfig(minimize_transition_increment=True))
+    ids = [item.candidate_id for item in result.selected]
+    assert ids == ["a", "c", "b"]
+    assert result.stats.candidates_inserted == 3
+
+
+def test_greedy_insertion_minimize_rejects_infeasible(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=25, weight=5.0)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=20, end_offset_s=30, weight=1.0)
+    case = _case_for_candidates([a, b])
+
+    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True, "required_gap_s": 1.0})())
+
+    result = greedy_insertion(case, [a, b], config=InsertionConfig(minimize_transition_increment=True))
+    assert len(result.selected) == 1
+    assert result.selected[0].candidate_id == "a"
+    assert result.stats.candidates_rejected_overlap == 1

--- a/tests/solvers/test_aeossp_standard_greedy_lns.py
+++ b/tests/solvers/test_aeossp_standard_greedy_lns.py
@@ -38,6 +38,15 @@ from transition import TransitionVectorCache, transition_gap_conflict, transitio
 from candidates import Candidate  # noqa: E402
 from insertion import greedy_insertion, InsertionConfig, InsertionResult  # noqa: E402
 from validation import RepairConfig, ValidationIssue, repair_schedule  # noqa: E402
+from components import Component, build_component_index  # noqa: E402
+from local_search import (  # noqa: E402
+    LocalSearchConfig,
+    LocalSearchResult,
+    _marginal_profit,
+    _recompute_component,
+    _by_satellite,
+    local_search,
+)
 
 
 def _mission() -> Mission:
@@ -517,3 +526,147 @@ def test_repair_passes_when_valid(monkeypatch) -> None:
     assert len(result.candidates) == 1
     assert result.terminated_reason == "valid"
     assert len(result.removals) == 0
+
+
+def test_component_graph_overlap_edge(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=25)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=20, end_offset_s=30)
+    case = _case_for_candidates([a, b])
+
+    monkeypatch.setattr("components.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("components.transition_gap_conflict", lambda *args, **kwargs: False)
+
+    index = build_component_index(case, [a, b])
+    assert index.stats.component_count == 1
+    assert index.components[0].size == 2
+
+
+def test_component_graph_no_edge_for_temporal_separation(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=100, end_offset_s=110)
+    case = _case_for_candidates([a, b])
+
+    monkeypatch.setattr("components.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("components.transition_gap_conflict", lambda *args, **kwargs: False)
+
+    index = build_component_index(case, [a, b])
+    assert index.stats.component_count == 2
+    assert index.stats.singleton_count == 2
+
+
+def test_component_graph_edge_for_insufficient_transition(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=22, end_offset_s=32)
+    case = _case_for_candidates([a, b])
+
+    monkeypatch.setattr("components.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("components.transition_gap_conflict", lambda *args, **kwargs: True)
+
+    index = build_component_index(case, [a, b])
+    assert index.stats.component_count == 1
+    assert index.components[0].size == 2
+
+
+def test_component_extraction_is_deterministic(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=22, end_offset_s=32)
+    c = _candidate("c", satellite_id="sat_a", task_id="task_c", start_offset_s=40, end_offset_s=50)
+    case = _case_for_candidates([a, b, c])
+
+    monkeypatch.setattr("components.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("components.transition_gap_conflict", lambda *args, **kwargs: True)
+
+    index1 = build_component_index(case, [a, b, c])
+    index2 = build_component_index(case, [a, b, c])
+    assert [c.component_id for c in index1.components] == [c.component_id for c in index2.components]
+
+
+def test_marginal_profit_free_task() -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", weight=5.0)
+    scheduled = {a.task_id: a}
+    free = _candidate("b", satellite_id="sat_a", task_id="task_b", weight=3.0)
+    assert _marginal_profit(free, scheduled) == 3.0
+
+
+def test_marginal_profit_external_alternative() -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_x", weight=5.0)
+    b = _candidate("b", satellite_id="sat_b", task_id="task_x", weight=3.0)
+    scheduled = {a.task_id: a}
+    assert _marginal_profit(b, scheduled) == 3.0 - 5.0
+
+
+def test_marginal_profit_internal_alternative() -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_x", weight=5.0)
+    b = _candidate("b", satellite_id="sat_a", task_id="task_x", weight=3.0)
+    scheduled = {}
+    assert _marginal_profit(b, scheduled) == 3.0
+
+
+def test_local_search_accepted_improving_move(monkeypatch) -> None:
+    low = _candidate("low", satellite_id="sat_a", task_id="task_x", start_offset_s=10, end_offset_s=20, weight=1.0)
+    high = _candidate("high", satellite_id="sat_a", task_id="task_x", start_offset_s=10, end_offset_s=20, weight=5.0)
+    case = _case_for_candidates([low, high])
+
+    monkeypatch.setattr("local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+        "components": [
+            type("Comp", (), {
+                "satellite_id": "sat_a",
+                "component_id": "sat_a::root",
+                "candidates": (low, high),
+                "size": 2,
+            })()
+        ],
+        "stats": type("Stats", (), {"component_count": 1, "largest_component_size": 2})(),
+    })())
+    monkeypatch.setattr("local_search.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("local_search.TransitionVectorCache", lambda *args, **kwargs: None)
+    monkeypatch.setattr("local_search.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+    monkeypatch.setattr("local_search.initial_slew_feasible", lambda **kwargs: True)
+
+    greedy_solution = [low]
+    result = local_search(case, [low, high], greedy_solution, config=LocalSearchConfig(max_local_search_iterations=10))
+    assert result.stats.moves_accepted >= 1
+    assert result.stats.final_objective == 5.0
+
+
+def test_local_search_rejected_non_improving_move(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    case = _case_for_candidates([a])
+
+    monkeypatch.setattr("local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+        "components": [
+            type("Comp", (), {
+                "satellite_id": "sat_a",
+                "component_id": "sat_a::root",
+                "candidates": (a,),
+                "size": 1,
+            })()
+        ],
+        "stats": type("Stats", (), {"component_count": 1, "largest_component_size": 1})(),
+    })())
+    monkeypatch.setattr("local_search.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("local_search.TransitionVectorCache", lambda *args, **kwargs: None)
+    monkeypatch.setattr("local_search.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+    monkeypatch.setattr("local_search.initial_slew_feasible", lambda **kwargs: True)
+
+    greedy_solution = [a]
+    result = local_search(case, [a], greedy_solution, config=LocalSearchConfig(max_local_search_iterations=10))
+    assert result.stats.moves_accepted == 0
+    assert result.stats.final_objective == 5.0
+
+
+def test_local_search_restart_determinism(monkeypatch) -> None:
+    a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
+    case = _case_for_candidates([a])
+
+    monkeypatch.setattr("local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+        "components": [],
+        "stats": type("Stats", (), {"component_count": 0, "largest_component_size": 0})(),
+    })())
+    monkeypatch.setattr("local_search.PropagationContext", lambda *args, **kwargs: None)
+
+    greedy_solution = [a]
+    result1 = local_search(case, [a], greedy_solution, config=LocalSearchConfig(restart_count=2, random_seed=42))
+    result2 = local_search(case, [a], greedy_solution, config=LocalSearchConfig(restart_count=2, random_seed=42))
+    assert result1.stats.stop_reason == result2.stats.stop_reason
+    assert result1.stats.final_objective == result2.stats.final_objective

--- a/tests/solvers/test_aeossp_standard_greedy_lns.py
+++ b/tests/solvers/test_aeossp_standard_greedy_lns.py
@@ -9,12 +9,16 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SOLVER_DIR = REPO_ROOT / "solvers" / "aeossp_standard" / "greedy_lns" / "src"
 sys.path.insert(0, str(REPO_ROOT))
-sys.path.insert(0, str(SOLVER_DIR))
 
-from candidates import CandidateConfig, CandidateSummary, generate_candidates, start_offsets_for_task  # noqa: E402
-from case_io import (  # noqa: E402
+from solvers.aeossp_standard.greedy_lns.src.candidates import (  # noqa: E402
+    Candidate,
+    CandidateConfig,
+    CandidateSummary,
+    generate_candidates,
+    start_offsets_for_task,
+)
+from solvers.aeossp_standard.greedy_lns.src.case_io import (  # noqa: E402
     AeosspCase,
     AttitudeModel,
     Mission,
@@ -26,26 +30,43 @@ from case_io import (  # noqa: E402
     load_solver_config,
     parse_iso_z,
 )
-from geometry import (  # noqa: E402
+from solvers.aeossp_standard.greedy_lns.src.components import (  # noqa: E402
+    Component,
+    build_component_index,
+)
+from solvers.aeossp_standard.greedy_lns.src.geometry import (  # noqa: E402
     action_sample_times,
     angle_between_deg,
     initial_slew_feasible_from_vectors,
     slew_time_s,
 )
-from solution_io import candidates_to_actions, write_empty_solution  # noqa: E402
-from transition import TransitionVectorCache, transition_gap_conflict, transition_result  # noqa: E402
-
-from candidates import Candidate  # noqa: E402
-from insertion import greedy_insertion, InsertionConfig, InsertionResult  # noqa: E402
-from validation import RepairConfig, ValidationIssue, repair_schedule  # noqa: E402
-from components import Component, build_component_index  # noqa: E402
-from local_search import (  # noqa: E402
+from solvers.aeossp_standard.greedy_lns.src.insertion import (  # noqa: E402
+    InsertionConfig,
+    InsertionResult,
+    greedy_insertion,
+)
+from solvers.aeossp_standard.greedy_lns.src.local_search import (  # noqa: E402
     LocalSearchConfig,
     LocalSearchResult,
     _marginal_profit,
     _recompute_component,
     _by_satellite,
     local_search,
+)
+from solvers.aeossp_standard.greedy_lns.src.solution_io import (  # noqa: E402
+    candidates_to_actions,
+    write_empty_solution,
+)
+from solvers.aeossp_standard.greedy_lns.src.transition import (  # noqa: E402
+    TransitionVectorCache,
+    transition_gap_conflict,
+    transition_result,
+)
+from solvers.aeossp_standard.greedy_lns.src.validation import (  # noqa: E402
+    RepairConfig,
+    ValidationIssue,
+    candidate_shape_issues,
+    repair_schedule,
 )
 
 
@@ -270,9 +291,9 @@ def test_generate_candidates_filters_sensor_and_keeps_stable_ids(monkeypatch) ->
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr("candidates.PropagationContext", DummyPropagation)
-    monkeypatch.setattr("candidates.observation_geometry_valid", lambda **kwargs: True)
-    monkeypatch.setattr("candidates.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.candidates.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.candidates.observation_geometry_valid", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.candidates.initial_slew_feasible", lambda **kwargs: True)
 
     candidates, summary = generate_candidates(case, CandidateConfig())
     candidate_ids = [item.candidate_id for item in candidates]
@@ -397,9 +418,9 @@ def test_greedy_insertion_selects_higher_utility_first(monkeypatch) -> None:
     b = _candidate("b", satellite_id="sat_a", task_id="task_a", start_offset_s=30, end_offset_s=40, weight=1.0)
     case = _case_for_candidates([a, b])
 
-    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
-    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
 
     result = greedy_insertion(case, [a, b])
     assert len(result.selected) == 1
@@ -412,9 +433,9 @@ def test_greedy_insertion_rejects_overlap(monkeypatch) -> None:
     b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=20, end_offset_s=30, weight=1.0)
     case = _case_for_candidates([a, b])
 
-    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
-    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
 
     result = greedy_insertion(case, [a, b])
     assert len(result.selected) == 1
@@ -435,9 +456,9 @@ def test_greedy_insertion_rejects_insufficient_transition(monkeypatch) -> None:
             return FakeResult()
         return type("R", (), {"feasible": True})()
 
-    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
-    monkeypatch.setattr("insertion.transition_result", fake_transition)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.transition_result", fake_transition)
 
     result = greedy_insertion(case, [a, b])
     assert len(result.selected) == 1
@@ -449,8 +470,8 @@ def test_greedy_insertion_respects_initial_slew(monkeypatch) -> None:
     a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
     case = _case_for_candidates([a])
 
-    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: False)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.initial_slew_feasible", lambda **kwargs: False)
 
     result = greedy_insertion(case, [a])
     assert len(result.selected) == 0
@@ -463,9 +484,9 @@ def test_greedy_insertion_insert_between_feasible(monkeypatch) -> None:
     b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=22, end_offset_s=28, weight=1.0)
     case = _case_for_candidates([a, b, c])
 
-    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
-    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
 
     result = greedy_insertion(case, [a, b, c])
     ids = [item.candidate_id for item in result.selected]
@@ -478,9 +499,9 @@ def test_greedy_insertion_cross_satellite_same_task_rejected(monkeypatch) -> Non
     b = _candidate("b", satellite_id="sat_b", task_id="task_x", start_offset_s=30, end_offset_s=40, weight=1.0)
     case = _case_for_candidates([a, b])
 
-    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
-    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
 
     result = greedy_insertion(case, [a, b])
     assert len(result.selected) == 1
@@ -493,8 +514,8 @@ def test_repair_removes_battery_violation(monkeypatch) -> None:
     b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=30, end_offset_s=40, weight=1.0)
     case = _case_for_candidates([a, b])
 
-    monkeypatch.setattr("validation.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("validation.schedule_issues", lambda case, candidates, **kwargs: [])
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.validation.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.validation.schedule_issues", lambda case, candidates, **kwargs: [])
 
     def fake_battery_issues(case, candidates, **kwargs):
         if any(c.candidate_id == "b" for c in candidates):
@@ -504,7 +525,7 @@ def test_repair_removes_battery_violation(monkeypatch) -> None:
             )
         return ([], {})
 
-    monkeypatch.setattr("validation.battery_issues", fake_battery_issues)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.validation.battery_issues", fake_battery_issues)
 
     result = repair_schedule(case, [a, b], config=RepairConfig(max_repair_iterations=10))
     assert len(result.candidates) == 1
@@ -518,9 +539,9 @@ def test_repair_passes_when_valid(monkeypatch) -> None:
     a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
     case = _case_for_candidates([a])
 
-    monkeypatch.setattr("validation.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("validation.schedule_issues", lambda case, candidates, **kwargs: [])
-    monkeypatch.setattr("validation.battery_issues", lambda case, candidates, **kwargs: ([], {}))
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.validation.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.validation.schedule_issues", lambda case, candidates, **kwargs: [])
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.validation.battery_issues", lambda case, candidates, **kwargs: ([], {}))
 
     result = repair_schedule(case, [a], config=RepairConfig(max_repair_iterations=10))
     assert len(result.candidates) == 1
@@ -533,8 +554,8 @@ def test_component_graph_overlap_edge(monkeypatch) -> None:
     b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=20, end_offset_s=30)
     case = _case_for_candidates([a, b])
 
-    monkeypatch.setattr("components.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("components.transition_gap_conflict", lambda *args, **kwargs: False)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.components.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.components.transition_gap_conflict", lambda *args, **kwargs: False)
 
     index = build_component_index(case, [a, b])
     assert index.stats.component_count == 1
@@ -546,8 +567,8 @@ def test_component_graph_no_edge_for_temporal_separation(monkeypatch) -> None:
     b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=100, end_offset_s=110)
     case = _case_for_candidates([a, b])
 
-    monkeypatch.setattr("components.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("components.transition_gap_conflict", lambda *args, **kwargs: False)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.components.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.components.transition_gap_conflict", lambda *args, **kwargs: False)
 
     index = build_component_index(case, [a, b])
     assert index.stats.component_count == 2
@@ -559,8 +580,8 @@ def test_component_graph_edge_for_insufficient_transition(monkeypatch) -> None:
     b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=22, end_offset_s=32)
     case = _case_for_candidates([a, b])
 
-    monkeypatch.setattr("components.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("components.transition_gap_conflict", lambda *args, **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.components.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.components.transition_gap_conflict", lambda *args, **kwargs: True)
 
     index = build_component_index(case, [a, b])
     assert index.stats.component_count == 1
@@ -573,8 +594,8 @@ def test_component_extraction_is_deterministic(monkeypatch) -> None:
     c = _candidate("c", satellite_id="sat_a", task_id="task_c", start_offset_s=40, end_offset_s=50)
     case = _case_for_candidates([a, b, c])
 
-    monkeypatch.setattr("components.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("components.transition_gap_conflict", lambda *args, **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.components.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.components.transition_gap_conflict", lambda *args, **kwargs: True)
 
     index1 = build_component_index(case, [a, b, c])
     index2 = build_component_index(case, [a, b, c])
@@ -607,7 +628,7 @@ def test_local_search_accepted_improving_move(monkeypatch) -> None:
     high = _candidate("high", satellite_id="sat_a", task_id="task_x", start_offset_s=10, end_offset_s=20, weight=5.0)
     case = _case_for_candidates([low, high])
 
-    monkeypatch.setattr("local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda case, candidates: type("Idx", (), {
         "components": [
             type("Comp", (), {
                 "satellite_id": "sat_a",
@@ -618,10 +639,10 @@ def test_local_search_accepted_improving_move(monkeypatch) -> None:
         ],
         "stats": type("Stats", (), {"component_count": 1, "largest_component_size": 2})(),
     })())
-    monkeypatch.setattr("local_search.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("local_search.TransitionVectorCache", lambda *args, **kwargs: None)
-    monkeypatch.setattr("local_search.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
-    monkeypatch.setattr("local_search.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.TransitionVectorCache", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.initial_slew_feasible", lambda **kwargs: True)
 
     greedy_solution = [low]
     result = local_search(case, [low, high], greedy_solution, config=LocalSearchConfig(max_local_search_iterations=10))
@@ -633,7 +654,7 @@ def test_local_search_rejected_non_improving_move(monkeypatch) -> None:
     a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
     case = _case_for_candidates([a])
 
-    monkeypatch.setattr("local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda case, candidates: type("Idx", (), {
         "components": [
             type("Comp", (), {
                 "satellite_id": "sat_a",
@@ -644,10 +665,10 @@ def test_local_search_rejected_non_improving_move(monkeypatch) -> None:
         ],
         "stats": type("Stats", (), {"component_count": 1, "largest_component_size": 1})(),
     })())
-    monkeypatch.setattr("local_search.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("local_search.TransitionVectorCache", lambda *args, **kwargs: None)
-    monkeypatch.setattr("local_search.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
-    monkeypatch.setattr("local_search.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.TransitionVectorCache", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True})())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.initial_slew_feasible", lambda **kwargs: True)
 
     greedy_solution = [a]
     result = local_search(case, [a], greedy_solution, config=LocalSearchConfig(max_local_search_iterations=10))
@@ -659,11 +680,11 @@ def test_local_search_restart_determinism(monkeypatch) -> None:
     a = _candidate("a", satellite_id="sat_a", task_id="task_a", start_offset_s=10, end_offset_s=20, weight=5.0)
     case = _case_for_candidates([a])
 
-    monkeypatch.setattr("local_search.build_component_index", lambda case, candidates: type("Idx", (), {
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.build_component_index", lambda case, candidates: type("Idx", (), {
         "components": [],
         "stats": type("Stats", (), {"component_count": 0, "largest_component_size": 0})(),
     })())
-    monkeypatch.setattr("local_search.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.local_search.PropagationContext", lambda *args, **kwargs: None)
 
     greedy_solution = [a]
     result1 = local_search(case, [a], greedy_solution, config=LocalSearchConfig(restart_count=2, random_seed=42))
@@ -696,7 +717,6 @@ def test_candidate_shape_issues_catch_duration_mismatch(monkeypatch) -> None:
         satellites=case.satellites,
         tasks={**case.tasks, "task_a": new_task},
     )
-    from validation import candidate_shape_issues
     issues = candidate_shape_issues(new_case, [a])
     assert any(i.reason == "duration_mismatch" for i in issues)
 
@@ -720,7 +740,6 @@ def test_candidate_shape_issues_catch_grid_misalignment(monkeypatch) -> None:
         satellites=case.satellites,
         tasks=case.tasks,
     )
-    from validation import candidate_shape_issues
     issues = candidate_shape_issues(new_case, [a])
     assert any(i.reason == "grid_misalignment" for i in issues)
 
@@ -731,9 +750,9 @@ def test_greedy_insertion_with_minimize_transition_increment(monkeypatch) -> Non
     c = _candidate("c", satellite_id="sat_a", task_id="task_c", start_offset_s=22, end_offset_s=28, weight=1.0)
     case = _case_for_candidates([a, b, c])
 
-    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
-    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True, "required_gap_s": 1.0})())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True, "required_gap_s": 1.0})())
 
     result = greedy_insertion(case, [a, b, c], config=InsertionConfig(minimize_transition_increment=True))
     ids = [item.candidate_id for item in result.selected]
@@ -746,9 +765,9 @@ def test_greedy_insertion_minimize_rejects_infeasible(monkeypatch) -> None:
     b = _candidate("b", satellite_id="sat_a", task_id="task_b", start_offset_s=20, end_offset_s=30, weight=1.0)
     case = _case_for_candidates([a, b])
 
-    monkeypatch.setattr("insertion.PropagationContext", lambda *args, **kwargs: None)
-    monkeypatch.setattr("insertion.initial_slew_feasible", lambda **kwargs: True)
-    monkeypatch.setattr("insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True, "required_gap_s": 1.0})())
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.PropagationContext", lambda *args, **kwargs: None)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.greedy_lns.src.insertion.transition_result", lambda *args, **kwargs: type("R", (), {"feasible": True, "required_gap_s": 1.0})())
 
     result = greedy_insertion(case, [a, b], config=InsertionConfig(minimize_transition_increment=True))
     assert len(result.selected) == 1

--- a/tests/solvers/test_aeossp_standard_mwis.py
+++ b/tests/solvers/test_aeossp_standard_mwis.py
@@ -9,12 +9,16 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SOLVER_DIR = REPO_ROOT / "solvers" / "aeossp_standard" / "mwis_conflict_graph" / "src"
 sys.path.insert(0, str(REPO_ROOT))
-sys.path.insert(0, str(SOLVER_DIR))
 
-from candidates import CandidateConfig, CandidateSummary, generate_candidates, start_offsets_for_task  # noqa: E402
-from case_io import (  # noqa: E402
+from solvers.aeossp_standard.mwis_conflict_graph.src.candidates import (  # noqa: E402
+    Candidate,
+    CandidateConfig,
+    CandidateSummary,
+    generate_candidates,
+    start_offsets_for_task,
+)
+from solvers.aeossp_standard.mwis_conflict_graph.src.case_io import (  # noqa: E402
     AeosspCase,
     AttitudeModel,
     Mission,
@@ -26,20 +30,28 @@ from case_io import (  # noqa: E402
     load_solver_config,
     parse_iso_z,
 )
-from geometry import (  # noqa: E402
+from solvers.aeossp_standard.mwis_conflict_graph.src.geometry import (  # noqa: E402
     action_sample_times,
     initial_slew_feasible_from_vectors,
 )
-from graph import build_conflict_graph, connected_components  # noqa: E402
-from mwis import (  # noqa: E402
+from solvers.aeossp_standard.mwis_conflict_graph.src.graph import (  # noqa: E402
+    build_conflict_graph,
+    connected_components,
+)
+from solvers.aeossp_standard.mwis_conflict_graph.src.mwis import (  # noqa: E402
     MwisConfig,
     select_weighted_independent_set,
     solve_exact_component,
     validate_independent_set,
 )
-from solution_io import candidates_to_actions  # noqa: E402
-from transition import TransitionVectorCache, transition_gap_conflict  # noqa: E402
-from validation import (  # noqa: E402
+from solvers.aeossp_standard.mwis_conflict_graph.src.solution_io import (  # noqa: E402
+    candidates_to_actions,
+)
+from solvers.aeossp_standard.mwis_conflict_graph.src.transition import (  # noqa: E402
+    TransitionVectorCache,
+    transition_gap_conflict,
+)
+from solvers.aeossp_standard.mwis_conflict_graph.src.validation import (  # noqa: E402
     RepairConfig,
     ValidationIssue,
     ValidationReport,
@@ -48,8 +60,6 @@ from validation import (  # noqa: E402
     repair_candidates,
     validate_candidates,
 )
-
-from candidates import Candidate  # noqa: E402
 
 
 def _mission() -> Mission:
@@ -281,9 +291,9 @@ def test_generate_candidates_filters_sensor_and_keeps_stable_ids(monkeypatch) ->
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr("candidates.PropagationContext", DummyPropagation)
-    monkeypatch.setattr("candidates.observation_geometry_valid", lambda **kwargs: True)
-    monkeypatch.setattr("candidates.initial_slew_feasible", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.candidates.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.candidates.observation_geometry_valid", lambda **kwargs: True)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.candidates.initial_slew_feasible", lambda **kwargs: True)
 
     candidates, summary = generate_candidates(case, CandidateConfig())
     candidate_ids = [item.candidate_id for item in candidates]
@@ -334,7 +344,7 @@ def test_conflict_graph_adds_duplicate_task_edges_across_satellites(monkeypatch)
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr("graph.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.graph.PropagationContext", DummyPropagation)
     graph = build_conflict_graph(_case_for_candidates(candidates), candidates)
 
     assert graph.has_edge("sat_a|task_a|10", "sat_b|task_a|15")
@@ -351,7 +361,7 @@ def test_conflict_graph_adds_same_satellite_overlap_edges(monkeypatch) -> None:
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr("graph.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.graph.PropagationContext", DummyPropagation)
     graph = build_conflict_graph(_case_for_candidates(candidates), candidates)
 
     assert graph.has_edge("sat_a|task_a|10", "sat_a|task_b|20")
@@ -368,7 +378,7 @@ def test_transition_gap_conflict_is_order_independent(monkeypatch) -> None:
             return np.array([1.0, 0.0, 0.0])
         return np.array([0.0, 1.0, 0.0])
 
-    monkeypatch.setattr("transition.target_vector_eci", fake_target_vector)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.transition.target_vector_eci", fake_target_vector)
     vector_cache = TransitionVectorCache(case, propagation=object())
 
     assert transition_gap_conflict(candidate_a, candidate_b, case=case, vector_cache=vector_cache)
@@ -385,7 +395,7 @@ def test_conflict_graph_omits_transition_edge_with_sufficient_gap(monkeypatch) -
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr("graph.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.graph.PropagationContext", DummyPropagation)
     graph = build_conflict_graph(_case_for_candidates(candidates), candidates)
 
     assert not graph.has_edge("sat_a|task_a|10", "sat_a|task_b|250")
@@ -539,7 +549,7 @@ def test_local_improvement_applies_weighted_two_swap(monkeypatch) -> None:
     def fake_greedy(component, candidate_by_id, adjacency_map, *, policy, reverse=False):
         return {"blocker"}
 
-    monkeypatch.setattr("mwis.solve_greedy_component", fake_greedy)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.mwis.solve_greedy_component", fake_greedy)
     selected, stats = select_weighted_independent_set(
         candidates,
         graph,
@@ -586,7 +596,7 @@ def test_recombination_can_improve_incumbent_without_local_search(monkeypatch) -
             return {"l1", "r2"}
         return {"l2", "r1"}
 
-    monkeypatch.setattr("mwis.solve_greedy_component", fake_greedy)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.mwis.solve_greedy_component", fake_greedy)
 
     selected, stats = select_weighted_independent_set(
         candidates,
@@ -653,9 +663,9 @@ def test_local_validation_rejects_duplicate_tasks(monkeypatch) -> None:
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr("validation.PropagationContext", DummyPropagation)
-    monkeypatch.setattr("validation.schedule_issues", lambda *args, **kwargs: [])
-    monkeypatch.setattr("validation.battery_issues", lambda *args, **kwargs: ([], {}))
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.schedule_issues", lambda *args, **kwargs: [])
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.battery_issues", lambda *args, **kwargs: ([], {}))
 
     report = validate_candidates(_case_for_candidates(candidates), candidates)
 
@@ -673,9 +683,9 @@ def test_local_validation_rejects_overlap(monkeypatch) -> None:
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr("validation.PropagationContext", DummyPropagation)
-    monkeypatch.setattr("validation._initial_slew_required_s", lambda *args, **kwargs: 0.0)
-    monkeypatch.setattr("validation.battery_issues", lambda *args, **kwargs: ([], {}))
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation._initial_slew_required_s", lambda *args, **kwargs: 0.0)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.battery_issues", lambda *args, **kwargs: ([], {}))
 
     report = validate_candidates(_case_for_candidates(candidates), candidates)
 
@@ -698,10 +708,10 @@ def test_local_validation_rejects_transition_gap(monkeypatch) -> None:
         available_gap_s = 1.0
         required_gap_s = 9.0
 
-    monkeypatch.setattr("validation.PropagationContext", DummyPropagation)
-    monkeypatch.setattr("validation._initial_slew_required_s", lambda *args, **kwargs: 0.0)
-    monkeypatch.setattr("validation.transition_result", lambda *args, **kwargs: FakeTransition())
-    monkeypatch.setattr("validation.battery_issues", lambda *args, **kwargs: ([], {}))
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.PropagationContext", DummyPropagation)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation._initial_slew_required_s", lambda *args, **kwargs: 0.0)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.transition_result", lambda *args, **kwargs: FakeTransition())
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.battery_issues", lambda *args, **kwargs: ([], {}))
 
     report = validate_candidates(_case_for_candidates(candidates), candidates)
 
@@ -730,8 +740,8 @@ def test_local_battery_approximation_reports_depletion(monkeypatch) -> None:
         ),
     )
 
-    monkeypatch.setattr("validation._initial_slew_required_s", lambda *args, **kwargs: 0.0)
-    monkeypatch.setattr("validation.is_sunlit", lambda *args, **kwargs: False)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation._initial_slew_required_s", lambda *args, **kwargs: 0.0)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.is_sunlit", lambda *args, **kwargs: False)
 
     issues, traces = battery_issues(case, [candidate], propagation=object())
 
@@ -777,7 +787,7 @@ def test_bounded_repair_terminates(monkeypatch) -> None:
         ],
     )
 
-    monkeypatch.setattr("validation.validate_candidates", lambda *args, **kwargs: invalid_report)
+    monkeypatch.setattr("solvers.aeossp_standard.mwis_conflict_graph.src.validation.validate_candidates", lambda *args, **kwargs: invalid_report)
 
     result = repair_candidates(
         _case_for_candidates(candidates),


### PR DESCRIPTION
## Summary

This PR implements a runnable reproduced solver for `aeossp_standard` based on Antuori, Wojtowicz, and Hebrard's greedy insertion and connected-component local-search method (CP 2025), adapted to the benchmark's observation-only action contract.

### What changed

- **Phase 1**: Contract scaffolding and candidate generation (`candidates.py`, `geometry.py`, `transition.py`, `case_io.py`)
- **Phase 2**: Greedy insertion core with deterministic utility ordering and tie-breaks (`insertion.py`)
- **Phase 3**: Connected-component local search with marginal-profit recomputation (`local_search.py`, `components.py`)
- **Phase 4**: Solver-local validation, bounded repair, and `main_solver` experiment wiring (`validation.py`, `solve.py`)
- **Phase 5**: Hardened debug artifacts, documented config knobs, optional transition-minimizing insertion, and paper-fidelity reproduction notes in `status.json`
- **Phase 6**: Comprehensive `README.md`, promotion to `finished_solvers.json`, and status-string normalization

### Standalone boundary preserved

- No imports from `benchmarks/`, `experiments/`, `runtimes/`, or other solvers
- Solver consumes case files and produces benchmark-shaped solution JSON
- Official verification happens through `experiments/main_solver` CLI contract

### Honest reproduction scope

- **Reproduced**: greedy initial construction, connected-component local search, marginal-profit recomputation
- **Omitted**: Tempo CP-SAT TSPTW fallback (proprietary), download/memory planning (benchmark is observation-only)
- **Adapted**: battery handled via solver-local simulation + bounded repair; weighted objective (maximize task weight as proxy for WCR)

Closes #80

## Validation

- Direct smoke on `case_0001`: valid, local repair removes 0 candidates
- `main_solver` smoke on `case_0001`: verifier-valid (`WCR: 0.618`, `CR: 0.666`)
- All 39 focused tests in `tests/solvers/test_aeossp_standard_greedy_lns.py` pass
- All 29 MWIS conflict-graph tests pass (no cross-solver regression)

## Notes

- Candidate generation dominates runtime (~58s on `case_0001`; total ~110s via `main_solver`). Efficiency improvements are intentionally deferred to a future issue.
- The solver defaults to deterministic behavior; stochastic ordering and restarts are opt-in via config.
- Debug artifacts (`debug/*.json`) are written only when `debug: true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new greedy local-neighborhood search solver for the AEOSSP standard benchmark, enabling acquisition-planning optimization with connected-component local search refinement and bounded repair validation.

* **Documentation**
  * Added comprehensive solver documentation including configuration examples, debugging guidance, and benchmark-specific implementation notes.

* **Tests**
  * Added extensive test coverage for the new solver with unit and integration tests for core algorithms and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->