### PR TITLE
docs(solvers): revise stereo_imaging roadmaps to embed solver-audit spirit

### DIFF
--- a/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_1_CONTRACT_CANDIDATES_AND_PRODUCT_LIBRARY.md
+++ b/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_1_CONTRACT_CANDIDATES_AND_PRODUCT_LIBRARY.md
@@ -1,0 +1,56 @@
+# Phase 1: Contract, Candidates, And Product Library
+
+## Goal
+
+Create the standalone solver scaffold and reusable candidate/product library needed by the Lemaitre-style insertion search.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md`
+- Issue #90
+- `benchmarks/stereo_imaging/README.md`
+- `docs/solver_contract.md`
+- `solvers/stereo_imaging/literature/lemaitre-2002-cp-local-search.md`
+- `solvers/stereo_imaging/literature/summary.md`
+
+## In Scope
+
+- Add `solvers/stereo_imaging/cp_local_search_stereo_insertion/`.
+- Add `setup.sh`, `solve.sh`, `README.md` placeholder, and `config.example.yaml`.
+- Add standalone parsing for `satellites.yaml`, `targets.yaml`, and `mission.yaml`.
+- Enumerate candidate observations and group them by `(satellite_id, target_id, access_interval_id)`.
+- Enumerate valid or likely-valid pair and tri-stereo products.
+- Store each product as an atomic move unit containing all required observations, target id, estimated quality, and feasibility metadata.
+- Emit empty valid `solution.json` and candidate/product debug summaries.
+
+## Out Of Scope
+
+- Sequence propagation.
+- Greedy seed construction.
+- Local search moves.
+- Main-solver registration.
+
+## Implementation Notes
+
+- This phase can reuse conceptual candidate logic from the MILP roadmap if available, but must not import from another solver.
+- Product candidates should be sorted deterministically by coverage value, quality, target id, satellite id, access interval, and time tuple.
+- Keep tri-stereo candidates bounded per target/access interval to avoid later search blowups.
+- Record enough metadata to explain why a product failed or was not generated.
+
+## Validation
+
+- Run direct `setup.sh`.
+- Run direct `solve.sh benchmarks/stereo_imaging/dataset/cases/test/case_0001`.
+- Add focused tests for parser behavior and product library ordering.
+- Verify emitted empty or candidate-light solution with the benchmark verifier manually.
+
+## Exit Criteria
+
+- Solver scaffold is runnable and standalone.
+- Candidate and product debug summaries are deterministic.
+- Product objects contain all observations needed for atomic insertion/removal.
+- No benchmark, experiment, runtime, or other solver imports are introduced.
+
+## Suggested Prompt
+
+Read the CP/local-search stereo roadmap, this phase doc, issue #90, and the benchmark README. Implement only the standalone scaffold, public YAML parsing, candidate observation enumeration, and pair/tri product library for `solvers/stereo_imaging/cp_local_search_stereo_insertion/`. Do not implement local search yet.

--- a/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_2_SEQUENCE_PROPAGATION_AND_FEASIBILITY.md
+++ b/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_2_SEQUENCE_PROPAGATION_AND_FEASIBILITY.md
@@ -1,0 +1,58 @@
+# Phase 2: Sequence Propagation And Feasibility
+
+## Goal
+
+Implement per-satellite sequence feasibility checks with Lemaitre-style earliest/latest propagation and benchmark-shaped slew/settle constraints.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md`
+- Phase 1 implementation
+- Issue #90
+- `solvers/stereo_imaging/literature/lemaitre-2002-cp-local-search.md`
+- `tests/benchmarks/test_stereo_imaging_verifier.py`
+
+## In Scope
+
+- Add sequence data structures per satellite.
+- Implement insertion-position enumeration for a candidate observation or product.
+- Compute earliest/latest feasible timing intervals around existing sequence neighbors.
+- Check:
+  - observation duration bounds
+  - non-overlap
+  - benchmark-style slew-plus-settle gaps
+  - access interval containment
+  - product partner placement consistency
+- Implement atomic transaction/rollback helpers for product insertion and removal.
+- Write propagation debug records for rejected insertions.
+
+## Out Of Scope
+
+- Search policy.
+- Product quality tuning.
+- Official experiment wiring.
+
+## Implementation Notes
+
+- Lemaitre's LSA computes possible positions, inserts an image, then propagates earliest and latest start times through the sequence. Preserve that shape in code.
+- For this benchmark, candidates may already have fixed or narrow sampled times; propagation may choose among discrete candidate variants instead of continuously shifting starts.
+- Product insertion must fail atomically if any paired observation or tri-stereo anchor cannot be placed.
+- Keep deterministic tie-breaking even when many positions are feasible.
+
+## Validation
+
+- Unit-test empty, beginning, middle, and end insertion positions.
+- Unit-test rollback after failed partner insertion.
+- Use fixture-inspired cases for overlap and slew-too-fast rejection.
+- Run direct smoke and inspect propagation debug output.
+
+## Exit Criteria
+
+- Sequence feasibility can accept and reject product insertions deterministically.
+- Earliest/latest or equivalent discrete feasibility state is inspectable.
+- Failed insertion leaves sequence state unchanged.
+- Tests cover overlap, insufficient slew, and partner rollback.
+
+## Suggested Prompt
+
+Read the CP/local-search roadmap, Phase 1 code, Lemaitre insertion/propagation sections, and this phase doc. Implement per-satellite sequence feasibility, possible insertion positions, propagation, and atomic rollback for product insertions. Add focused tests for overlap, slew, and rollback.

--- a/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_3_DETERMINISTIC_GREEDY_SEED.md
+++ b/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_3_DETERMINISTIC_GREEDY_SEED.md
@@ -1,0 +1,60 @@
+# Phase 3: Deterministic Greedy Seed
+
+## Goal
+
+Build a reproducible initial schedule that maximizes coverage quickly before local search spends effort improving product quality.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md`
+- Phase 2 implementation
+- Issue #90
+- `benchmarks/stereo_imaging/README.md`
+- `solvers/stereo_imaging/literature/summary.md`
+
+## In Scope
+
+- Rank products by:
+  - uncovered target first
+  - scarcity of remaining products for the target
+  - valid tri-stereo potential
+  - estimated quality
+  - lower sequence disruption
+  - deterministic ids/time tie-breakers
+- Insert whole products atomically into per-satellite sequences.
+- Preserve same-satellite, same-target, same-access product semantics.
+- Emit seed debug artifacts:
+  - considered products
+  - accepted products
+  - rejected products with reason
+  - coverage and quality estimates
+
+## Out Of Scope
+
+- Randomized local search.
+- Replacement neighborhoods.
+- Final docs.
+
+## Implementation Notes
+
+- The benchmark ranks coverage before quality; greedy seed should reflect that directly.
+- A product that covers a new target should generally beat a higher-quality product for an already covered target.
+- If tri-stereo products block too many pair products, seed should prefer a configurable pair-first or tri-first policy and record the policy.
+- Keep the seed deterministic even if a config seed is present; randomization belongs only to a controlled later phase.
+
+## Validation
+
+- Unit-test ranking and deterministic tie-breaking.
+- Run seed-only mode twice and compare identical `solution.json` and `status.json`.
+- Verify direct output manually with the benchmark verifier.
+
+## Exit Criteria
+
+- Seed-only mode produces a coherent schedule and debug summary.
+- Coverage-first ranking is visible in code and docs.
+- Repeated runs are byte-stable except for allowed runtime fields.
+- Rejected products have actionable reasons.
+
+## Suggested Prompt
+
+Read the CP/local-search roadmap, Phase 2 code, benchmark ranking rules, and this phase doc. Implement deterministic greedy seed construction over whole stereo/tri products with coverage-first ordering, seed-only config, debug summaries, and repeatability checks.

--- a/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_4_LOCAL_SEARCH_PRODUCT_MOVES.md
+++ b/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_4_LOCAL_SEARCH_PRODUCT_MOVES.md
@@ -1,0 +1,57 @@
+# Phase 4: Local Search Product Moves
+
+## Goal
+
+Implement bounded, reproducible local search that improves the greedy seed through product insertions, removals, and replacements while preserving sequence feasibility.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md`
+- Phase 3 implementation
+- Issue #90
+- `solvers/stereo_imaging/literature/lemaitre-2002-cp-local-search.md`
+- `solvers/stereo_imaging/literature/vasquez-2001-logic-knapsack-tabu.md`
+
+## In Scope
+
+- Implement local moves over whole products:
+  - insert uncovered-target product
+  - replace lower-quality product for same target
+  - remove blocking product then insert one or more better products
+  - optional Vasquez-inspired short tabu on recently removed products
+- Maintain deterministic or seeded move ordering.
+- Use coverage-first, quality-second acceptance criteria.
+- Add configurable time, pass, and move-attempt limits.
+- Track incumbent schedule and rollback failed moves.
+- Write `debug/local_search_log.json`.
+
+## Out Of Scope
+
+- Exact CP-SAT model for the whole problem.
+- Non-reproducible stochastic search.
+- Large private sweeps.
+
+## Implementation Notes
+
+- Lemaitre's local search uses insertion/removal moves and attempts the corresponding stereo image, rolling back on failure. Preserve that product-coupled behavior.
+- The optional tabu layer should be framed as repair/diversification support from Vasquez and Hao, not as the solver's primary method.
+- Acceptance should never reduce coverage for quality unless the move immediately restores coverage in the same transaction.
+- Every accepted move should update product-level objective estimates and sequence state together.
+
+## Validation
+
+- Unit-test replacement and rollback behavior.
+- Run seed-only and local-search-enabled modes on the same case to compare metrics.
+- Run repeatability checks with fixed seed and deterministic mode.
+- Verify output manually with benchmark verifier.
+
+## Exit Criteria
+
+- Local search improves or preserves seed objective under the configured acceptance rule.
+- Product moves remain atomic.
+- Search stops cleanly at pass/time/move limits.
+- Debug log explains accepted and rejected moves.
+
+## Suggested Prompt
+
+Read the CP/local-search roadmap, Phase 3 code, Lemaitre local-search pseudocode, Vasquez repair notes, and this phase doc. Implement bounded product-level insertion/removal/replacement local search with deterministic replay, rollback, and debug logs. Validate seed versus improved modes.

--- a/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_5_REPAIR_EXPERIMENT_WIRING_AND_TESTS.md
+++ b/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_5_REPAIR_EXPERIMENT_WIRING_AND_TESTS.md
@@ -1,0 +1,63 @@
+# Phase 5: Repair, Experiment Wiring, And Tests
+
+## Goal
+
+Add final conservative repair, focused tests, and main-solver wiring so the local-search solver is runnable through the official experiment path.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md`
+- Phase 4 implementation
+- `docs/solver_contract.md`
+- `experiments/main_solver/README.md`
+- `experiments/main_solver/config.yaml`
+- Existing solver registration examples in `experiments/main_solver/solvers/`
+
+## In Scope
+
+- Decode per-satellite sequences into sorted benchmark actions.
+- Repair any remaining local conflicts by removing the least valuable affected product.
+- Recompute final product coverage and quality estimates after repair.
+- Add tests under `tests/solvers/` for:
+  - deterministic repeatability
+  - insertion rollback
+  - local-search acceptance
+  - repair removal
+  - output schema
+- Add `experiments/main_solver/solvers/stereo_imaging_cp_local_search_stereo_insertion.yaml`.
+- Add main-solver config entry with `evidence_type: reproduced_solver` only after the solver is runnable.
+
+## Out Of Scope
+
+- Extensive tuning.
+- README finalization.
+- Benchmark verifier imports inside solver code.
+
+## Implementation Notes
+
+- Repair should preserve coverage before improving quality.
+- If repair removes every product for a target, record that target and the blocking reason.
+- Main-solver naming should be stable and specific enough to distinguish from the MILP solver.
+
+## Validation
+
+- Run focused solver tests.
+- Run direct smoke.
+- Run official main-solver smoke:
+
+```bash
+uv run python experiments/main_solver/run.py --benchmark stereo_imaging --solver stereo_imaging_cp_local_search_stereo_insertion --case test/case_0001
+```
+
+- Run the benchmark verifier manually on a direct output if main-solver wiring is not ready.
+
+## Exit Criteria
+
+- Solver-local tests pass.
+- Direct and official smoke paths produce `solution.json`.
+- Repair is deterministic and auditable.
+- Main-solver registration uses `evidence_type: reproduced_solver`.
+
+## Suggested Prompt
+
+Read the CP/local-search roadmap, Phase 4 code, main-solver contract, and this phase doc. Implement final repair, focused tests, and main-solver registration for the Lemaitre-style stereo insertion solver. Run direct and official smoke validation.

--- a/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_6_VALIDATION_TUNING_AND_SOLVER_AUDIT.md
+++ b/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_6_VALIDATION_TUNING_AND_SOLVER_AUDIT.md
@@ -1,0 +1,87 @@
+# Phase 6: Validation, Tuning, and Solver Audit
+
+## Goal
+
+Tune and validate the solver so the team can defend "this is a valid, correct implementation of the claimed method, reasonably configured for the benchmark" rather than merely "this is a faithful paper reproduction."
+
+An unoptimized or slow implementation is not a failure if the algorithmic logic is correct. The audit should flag correctness-affecting deviations and timeout/resource misalignment, not penalize implementation style or performance gaps that do not affect validity.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md`
+- Phase 5 implementation and debug artifacts
+- Issue #90
+- `solvers/stereo_imaging/literature/lemaitre-2002-cp-local-search.md`
+- `solvers/stereo_imaging/literature/vasquez-2001-logic-knapsack-tabu.md`
+- `solvers/stereo_imaging/literature/summary.md`
+- Official verification outputs from `experiments/main_solver`
+
+## In Scope
+
+- Run a validation matrix across public cases and selected configs:
+  - seed-only
+  - deterministic local search
+  - seeded stochastic mode if implemented
+  - tabu diversification disabled/enabled if implemented
+  - pair-first and tri-aware policies
+- Track:
+  - validity
+  - `coverage_ratio`
+  - `normalized_quality`
+  - action count
+  - valid pair count
+  - valid tri count
+  - candidate/product counts
+  - accepted/rejected move counts
+  - repair removals
+  - runtime
+- Compare against earliest-pair greedy and the MILP baseline once available.
+- Calibrate solver-local product predicates against verifier diagnostics.
+- Record where benchmark adaptation intentionally differs from Lemaitre:
+  - point AOI products instead of strips
+  - tri-stereo extension
+  - benchmark convergence/overlap/pixel-scale quality
+  - no memory, energy, weather, or downlink constraints
+  - deterministic defaults instead of unbounded stochastic profiling
+- **Assess performance baseline and timeout realism:**
+  - What runtime does Lemaitre et al. report for comparable instances?
+  - What timeout and thread count does the benchmark envelope provide?
+  - Is the timeout realistic for CP-style local search with product insertion moves?
+  - Document any timeout/resource misalignment; do not flag a correct-but-slow solver as invalid.
+
+## Out Of Scope
+
+- Replacing local search with a full exact solver.
+- Hidden non-reproducible tuning.
+- Adding benchmark-only hacks that cannot be traced to paper or contract.
+- Treating performance-only differences (e.g., slower loop, simpler data structure) as correctness deviations.
+
+## Implementation Notes
+
+- Keep default knobs conservative and reproducible.
+- Preserve the paper's product-coupled insertion/rollback behavior in debug evidence.
+- Use validation notes to justify any optional Vasquez-inspired tabu or repair behavior as support, not the core method identity.
+- **Correctness vs. performance:** flag only differences that change algorithmic correctness or violate the benchmark contract. Cosmetic or performance-related differences are notes, not deviations.
+- Repeatability is part of correctness for this repository, even though Lemaitre's original LSA discusses stochastic profiles.
+
+## Validation
+
+- Run focused tests.
+- Run official smoke and all feasible public cases through `experiments/main_solver`.
+- Run deterministic repeatability checks.
+- Compare seed-only versus local-search outputs.
+- Compare solver product estimates against official `diagnostics.pair_evaluations` on at least one case.
+- **Check timeout/resource alignment:** document whether the benchmark envelope is realistic for the claimed method.
+
+## Exit Criteria
+
+- Default config is chosen and justified.
+- Validation notes explain correctness, runtime, determinism, and drift from paper assumptions.
+- Official smoke is valid.
+- At least one reproducible validation artifact supports the README's solver-audit claims.
+- Known limitations are concrete and ready for final docs.
+- **Performance baseline assessment is documented:** REALISTIC, MISALIGNED, or UNKNOWN.
+
+## Suggested Prompt
+
+Read the CP/local-search roadmap, issue #90, Lemaitre transcript, current implementation, and official main-solver outputs. Tune and validate for solver audit: compare seed-only and local-search modes, check deterministic replay, calibrate product predicates against verifier diagnostics, assess timeout/resource realism against literature baselines, record metrics, and prepare final README notes.

--- a/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_7_DOCS_CLEANUP_AND_PROMOTION.md
+++ b/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/PHASE_7_DOCS_CLEANUP_AND_PROMOTION.md
@@ -1,0 +1,95 @@
+# Phase 7: Docs, Cleanup, And Promotion
+
+## Goal
+
+Finish the Lemaitre-style stereo insertion solver with comprehensive documentation, cleanup, and promotion metadata following the standard set by `solvers/aeossp_standard/mwis_conflict_graph/README.md`.
+
+## Inputs To Read
+
+- `solvers/aeossp_standard/mwis_conflict_graph/README.md`
+- `solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md`
+- Phase 6 reproduction/tuning notes
+- `docs/solver_contract.md`
+- `experiments/main_solver/README.md`
+- `solvers/finished_solvers.json`
+
+## In Scope
+
+- Write or finalize `solvers/stereo_imaging/cp_local_search_stereo_insertion/README.md`.
+- README should include:
+  - solver identity
+  - citation and BibTeX
+  - method summary
+  - benchmark adaptation
+  - solver contract
+  - candidate/product library
+  - sequence propagation
+  - greedy seed
+  - local-search product moves
+  - optional Vasquez-inspired repair/diversification
+  - configuration
+  - debug artifacts
+  - running commands
+  - sanity baseline and tuning notes
+  - known limitations
+  - evidence type
+- Finalize `config.example.yaml`.
+- Ensure entrypoints are executable.
+- Remove temporary debug/results artifacts.
+- Add to `solvers/finished_solvers.json` only after official smoke validity and docs are complete.
+
+## Out Of Scope
+
+- New solver features.
+- Large score sweeps.
+- Benchmark or dataset edits.
+
+## Implementation Notes
+
+- Include BibTeX for Lemaitre and Vasquez:
+
+```bibtex
+@article{lemaitre2002selecting,
+  title = {Selecting and Scheduling Observations of Agile Satellites},
+  author = {Lema{\^i}tre, Michel and Verfaillie, G{\'e}rard and Jouhaud, Frank and Lachiver, Jean-Michel and Bataille, Nicolas},
+  journal = {Aerospace Science and Technology},
+  volume = {6},
+  number = {5},
+  pages = {367--381},
+  year = {2002},
+  doi = {10.1016/S1270-9638(02)01173-2}
+}
+
+@article{vasquez2001logic,
+  title = {A Logic-Constrained Knapsack Formulation and a Tabu Algorithm for the Daily Photograph Scheduling of an Earth Observation Satellite},
+  author = {Vasquez, Michel and Hao, Jin-Kao},
+  journal = {Computational Optimization and Applications},
+  volume = {20},
+  number = {2},
+  pages = {137--157},
+  year = {2001},
+  doi = {10.1023/A:1012300271919}
+}
+```
+
+- README must explain that product insertion/removal preserves Lemaitre's coupled stereoscopic request behavior.
+- README must distinguish the core Lemaitre reproduction from optional Vasquez-inspired repair ideas.
+- README must describe the validation/tuning evidence used to support solver-audit claims: correctness, benchmark contract compliance, and timeout/resource realism.
+
+## Validation
+
+- Run focused solver tests.
+- Run official main-solver smoke.
+- Run README commands.
+- Check that no generated debug/result artifacts are committed.
+
+## Exit Criteria
+
+- README is complete enough for an external reader to understand both the papers and benchmark adaptation.
+- BibTeX is included.
+- Solver is promoted only if official smoke verification passes.
+- Final handoff lists validation commands and residual limitations.
+
+## Suggested Prompt
+
+Read the CP/local-search stereo roadmap, Phase 6 notes, current solver, and `solvers/aeossp_standard/mwis_conflict_graph/README.md`. Finish documentation and cleanup for the stereo insertion solver. Include BibTeX, benchmark adaptation, config/debug docs, known limitations, and promotion metadata only after official smoke verification passes.

--- a/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md
+++ b/solvers/stereo_imaging/roadmap/cp_local_search_stereo_insertion/ROADMAP.md
@@ -1,0 +1,76 @@
+# CP/Local-Search Stereo Insertion Solver Roadmap
+
+## Goal
+
+Implement a runnable reproduced solver for `stereo_imaging` using Lemaitre-style constraint-propagated local search over same-pass stereo and tri-stereo products.
+
+The solver should be the fast reproducible baseline: enumerate benchmark-valid product candidates, build a deterministic coverage-first seed, maintain per-satellite sequences with earliest/latest propagation, and improve schedules by inserting, removing, and replacing whole products while documenting algorithmic validity, benchmark contract compliance, and reasonable timeout/resource expectations.
+
+## Source Of Truth
+
+- Issue: `https://github.com/Mtrya/astro-reason/issues/90`
+- Benchmark contract: `benchmarks/stereo_imaging/README.md`
+- Solver contract: `docs/solver_contract.md`
+- Main solver experiment: `experiments/main_solver/README.md`
+- Literature summary: `solvers/stereo_imaging/literature/summary.md`
+- Selection table: `solvers/stereo_imaging/literature/table.md`
+- Lemaitre transcript: `solvers/stereo_imaging/literature/lemaitre-2002-cp-local-search.md`
+- Vasquez support reference: `solvers/stereo_imaging/literature/vasquez-2001-logic-knapsack-tabu.md`
+- Research report: `solvers/stereo_imaging/literature/report.md`
+- Verifier tests: `tests/benchmarks/test_stereo_imaging_verifier.py`
+- Fixture notes: `tests/fixtures/stereo_imaging/README.md`
+- Solver docs style reference: `solvers/aeossp_standard/mwis_conflict_graph/README.md`
+
+## Current State
+
+`stereo_imaging` has public cases, a verifier, generator, fixtures, visualizer, and no runnable solver. Issue #90 asks for a standalone reproduced solver that treats stereo and tri-stereo products as coupled scheduling moves, keeps fixed seeds and deterministic tie-breaking, and uses CP-style earliest/latest feasibility propagation plus local insertion/removal moves.
+
+## Contract And Boundaries
+
+- Solver path: `solvers/stereo_imaging/cp_local_search_stereo_insertion/`.
+- Required entrypoints: `setup.sh` and `solve.sh <case_dir> [config_dir] [solution_dir]`.
+- Public inputs:
+  - `satellites.yaml`
+  - `targets.yaml`
+  - `mission.yaml`
+- Primary output: `solution.json` with a top-level `actions` array containing only `observation` actions.
+- Solver code may use project dependencies and optional OR-Tools for small repair subproblems, but the default path should be Python-only and deterministic.
+- Solver code must not import `benchmarks.*`, `experiments.*`, or another solver. It must not call benchmark verifiers from solver code.
+- Official verification belongs to `experiments/main_solver` or explicit developer-side validation commands.
+
+## Paper-To-Benchmark Adaptation
+
+- Lemaitre candidate image = benchmark candidate observation action.
+- Lemaitre stereoscopic coupling `x_i = x_j` = product-level insertion/removal of all observations required by a pair or tri-stereo set.
+- Lemaitre image sequence = per-satellite action sequence.
+- Lemaitre earliest/latest propagation = feasible timing interval propagation around fixed candidate windows and benchmark slew/settle gaps.
+- Lemaitre local insertion/removal = insert, remove, or replace whole products, with rollback if any partner observation or tri-stereo anchor cannot be placed.
+- Vasquez binary/ternary logic ideas may be used for repair bookkeeping, but not as a separate solver identity.
+- Benchmark scoring replaces request weight with coverage-first and normalized-quality objectives.
+
+## Phase Order
+
+1. `PHASE_1_CONTRACT_CANDIDATES_AND_PRODUCT_LIBRARY.md`
+2. `PHASE_2_SEQUENCE_PROPAGATION_AND_FEASIBILITY.md`
+3. `PHASE_3_DETERMINISTIC_GREEDY_SEED.md`
+4. `PHASE_4_LOCAL_SEARCH_PRODUCT_MOVES.md`
+5. `PHASE_5_REPAIR_EXPERIMENT_WIRING_AND_TESTS.md`
+6. `PHASE_6_VALIDATION_TUNING_AND_SOLVER_AUDIT.md`
+7. `PHASE_7_DOCS_CLEANUP_AND_PROMOTION.md`
+
+## Cross-Phase Risks
+
+- Product-level moves can hide action-level conflicts unless sequence propagation is exact enough.
+- A stochastic local search would be hard to reproduce without fixed seeds and stable tie-breakers.
+- Tri-stereo insertion can score well only if near-nadir anchors are preserved.
+- Greedy coverage can block higher-quality products unless replacement moves are strong.
+- Solver-local product predicates may drift from verifier geometry and Monte Carlo overlap estimates.
+
+## Overall Exit Criteria
+
+- Direct `setup.sh` and `solve.sh` work on the smoke case.
+- `experiments/main_solver` can run the solver with `evidence_type: reproduced_solver`.
+- Official verification passes at least the smoke case and preferably all public cases.
+- Focused tests cover product enumeration, sequence propagation, insertion rollback, removal/replacement moves, deterministic repeatability, repair, and output schema.
+- Debug artifacts explain product candidates, seed choices, propagation failures, accepted/rejected moves, repair removals, official metrics, and runtime.
+- Final README covers method summary, benchmark adaptation, solver contract, product insertion search, optional Vasquez-inspired repair, validation/tuning, known limitations, and BibTeX for Lemaitre and Vasquez.

--- a/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_1_CONTRACT_CANDIDATE_LIBRARY_AND_PRECHECKS.md
+++ b/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_1_CONTRACT_CANDIDATE_LIBRARY_AND_PRECHECKS.md
@@ -1,0 +1,62 @@
+# Phase 1: Contract, Candidate Library, And Prechecks
+
+## Goal
+
+Create the standalone solver scaffold and a deterministic observation-candidate library that reads public case files and emits locally plausible benchmark actions without using benchmark imports.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md`
+- Issue #89
+- `benchmarks/stereo_imaging/README.md`
+- `docs/solver_contract.md`
+- `solvers/stereo_imaging/literature/kim-2020-stereo-milp.md`
+- `tests/benchmarks/test_stereo_imaging_verifier.py`
+
+## In Scope
+
+- Add `solvers/stereo_imaging/time_window_pruned_stereo_milp/`.
+- Add `setup.sh`, `solve.sh`, `README.md` placeholder, and `config.example.yaml`.
+- Add solver-local parsing for `satellites.yaml`, `targets.yaml`, and `mission.yaml`.
+- Define data models for satellites, targets, mission thresholds, candidate observations, and access intervals.
+- Enumerate candidate observations per satellite-target pass with deterministic time samples and steering angles.
+- Implement solver-local prechecks for:
+  - mission horizon containment
+  - duration bounds
+  - combined off-nadir limit
+  - solar-elevation threshold approximation or sampled filter
+  - same access interval grouping
+- Emit empty valid `solution.json` when no candidates survive.
+
+## Out Of Scope
+
+- Stereo pair/tri scoring.
+- MILP model construction.
+- Main-solver registration.
+- Calling benchmark verifier from solver code.
+
+## Implementation Notes
+
+- Keep all code standalone under the solver directory.
+- Prefer small modules such as `io.py`, `models.py`, `geometry.py`, `candidates.py`, and `solve.py`.
+- Candidate generation should record why candidates were rejected, because later phases need pruning and audit diagnostics.
+- Use a configurable sample stride and cap candidates per `(satellite, target, access_interval)`.
+- If exact SGP4/access reproduction is expensive, this phase may use a conservative approximate generator, but it must flag approximation drift as a Phase 6 item.
+
+## Validation
+
+- Run direct `setup.sh`.
+- Run direct `solve.sh benchmarks/stereo_imaging/dataset/cases/test/case_0001`.
+- Run the official verifier manually on the emitted empty or candidate-light solution.
+- Add focused tests for parsing and combined off-nadir/duration checks if a solver-local test package exists.
+
+## Exit Criteria
+
+- Solver can read a public case and write schema-valid `solution.json`.
+- Candidate debug summary reports counts by satellite, target, access interval, and rejection reason.
+- No benchmark, experiment, runtime, or other solver imports are introduced.
+- The implementation is deterministic for identical config and inputs.
+
+## Suggested Prompt
+
+Read the stereo MILP roadmap, this phase doc, issue #89, and `benchmarks/stereo_imaging/README.md`. Implement only the standalone scaffold, public YAML parsing, deterministic candidate observation library, and cheap local prechecks for `solvers/stereo_imaging/time_window_pruned_stereo_milp/`. Do not import benchmark internals. Run the direct smoke command and verifier on the emitted solution.

--- a/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_2_PRODUCT_ENUMERATION_AND_SCORING.md
+++ b/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_2_PRODUCT_ENUMERATION_AND_SCORING.md
@@ -1,0 +1,61 @@
+# Phase 2: Product Enumeration And Scoring
+
+## Goal
+
+Lift candidate observations into benchmark-native stereo pair and tri-stereo product candidates with reproducible scores and explicit links to benchmark validity predicates.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md`
+- Phase 1 implementation
+- `benchmarks/stereo_imaging/README.md`
+- `solvers/stereo_imaging/literature/summary.md`
+- `tests/benchmarks/test_stereo_imaging_verifier.py`
+
+## In Scope
+
+- Add product models for pairs and tri-stereo sets.
+- Group candidates by `(satellite_id, target_id, access_interval_id)`.
+- Precompute pair feasibility using:
+  - same satellite, target, and access interval
+  - convergence angle thresholds
+  - AOI overlap fraction threshold
+  - pixel-scale ratio threshold
+  - action-level feasibility flags
+- Precompute tri-stereo feasibility using:
+  - same group
+  - at least two valid constituent pairs
+  - near-nadir anchor threshold
+  - common overlap approximation
+- Implement benchmark-shaped pair and tri quality scoring.
+- Produce debug artifacts such as `debug/product_summary.json`.
+
+## Out Of Scope
+
+- MILP construction.
+- Time-window pruning.
+- Search or repair over selected products.
+
+## Implementation Notes
+
+- The issue requires product candidates to use convergence angle, AOI overlap, pixel-scale ratio, same-access grouping, and near-nadir-anchor requirements.
+- If overlap is approximated, keep the approximation deterministic and configurable, and record calibration fields so Phase 6 can compare against verifier diagnostics.
+- Do not give mono observations objective credit except as actions linked to a valid pair/tri product.
+- Tie-break products deterministically by coverage contribution, quality, target id, satellite id, access interval, and time tuple.
+
+## Validation
+
+- Unit-test product grouping and threshold logic on synthetic candidate observations.
+- Run a smoke solve that writes product debug artifacts even if no products are selected.
+- Compare product counts and selected products against verifier `diagnostics.pair_evaluations` for at least one hand-built solution when possible.
+
+## Exit Criteria
+
+- Pair and tri product candidates are reproducible and inspectable.
+- Quality computation follows benchmark weights and scene-type preferred convergence bands.
+- Debug artifacts distinguish no-access, no-product, and product-filtered cases.
+- Known approximation drift is listed for Phase 6 instead of hidden.
+
+## Suggested Prompt
+
+Read the stereo MILP roadmap, Phase 1 code, this phase doc, and the benchmark stereo product definitions. Implement benchmark-native pair and tri-stereo product enumeration and scoring. Add deterministic debug summaries and focused tests for threshold behavior. Do not build the MILP yet.

--- a/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_3_TIME_WINDOW_CLUSTER_PRUNING.md
+++ b/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_3_TIME_WINDOW_CLUSTER_PRUNING.md
@@ -1,0 +1,56 @@
+# Phase 3: Time-Window Cluster Pruning
+
+## Goal
+
+Implement Kim-style time-window pruning so larger candidate sets remain tractable while preserving the benchmark's coverage-first objective.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md`
+- Phase 2 implementation
+- Issue #89
+- `solvers/stereo_imaging/literature/kim-2020-stereo-milp.md`
+- `solvers/stereo_imaging/literature/table.md`
+
+## In Scope
+
+- Cluster dense candidate time windows per satellite using a max-slew-time-inspired temporal gap.
+- Compute opportunity count per target and product scarcity per access interval.
+- Retain candidates by:
+  - coverage scarcity
+  - product feasibility count
+  - product quality potential
+  - lower opportunity count
+  - steering similarity within a cluster
+  - deterministic time tie-breakers
+- Add config knobs for lambda-style cluster capacity, lower-bound auto sizing, and max products per target/access interval.
+- Write `debug/pruning_summary.json`.
+
+## Out Of Scope
+
+- Solver backend model.
+- Re-tuning product scoring weights.
+- Deleting all products for a target unless unavoidable.
+
+## Implementation Notes
+
+- Kim's pruning sorted by priority and lowest observation opportunity; the benchmark has no target priority, so use uncovered-target scarcity and product potential as the faithful adaptation.
+- Steering similarity should reduce transition burden but must not eliminate the only near-nadir anchor for a tri-stereo candidate.
+- Preserve at least one feasible pair candidate per target when one exists, unless global candidate caps make that impossible and the debug summary says so.
+
+## Validation
+
+- Test pruning on synthetic clustered windows to prove it keeps scarce/high-quality opportunities.
+- Run direct smoke on public cases with pruning disabled and enabled.
+- Confirm candidate and product counts drop while at least some feasible products remain on cases that had products before pruning.
+
+## Exit Criteria
+
+- Pruning is configurable, deterministic, and explainable.
+- Debug output reports pre/post candidate and product counts by target and cluster.
+- The implementation can run with pruning disabled for audit comparisons in Phase 6.
+- No target silently loses all product opportunities without a recorded reason.
+
+## Suggested Prompt
+
+Read the stereo MILP roadmap, Kim pruning section, Phase 2 code, and this phase doc. Implement deterministic time-window cluster pruning adapted to coverage scarcity and product quality. Add debug summaries and tests that show pruning reduces model size while retaining representative product opportunities.

--- a/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_4_MILP_MODEL_AND_BACKEND_FALLBACK.md
+++ b/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_4_MILP_MODEL_AND_BACKEND_FALLBACK.md
@@ -1,0 +1,61 @@
+# Phase 4: MILP Model And Backend Fallback
+
+## Goal
+
+Build the optimization model that chooses observation and product variables, enforces per-satellite feasibility, and returns a deterministic incumbent even when the preferred backend is unavailable or times out.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md`
+- Phase 3 implementation
+- Issue #89
+- `solvers/stereo_imaging/literature/kim-2020-stereo-milp.md`
+- `experiments/main_solver/README.md`
+
+## In Scope
+
+- Add binary variables for candidate observations.
+- Add binary variables for stereo pair and tri-stereo products.
+- Link product variables to their required observation variables.
+- Limit each target to objective credit from selected valid products, preferably by explicit covered-target and best-quality proxy variables.
+- Enforce same-satellite temporal feasibility:
+  - non-overlap
+  - sequence/order constraints or pairwise conflict cuts
+  - slew/settle separation for conflicting selected observations
+- Use a lexicographic objective:
+  - maximize number of covered targets
+  - maximize normalized product quality
+  - minimize action count or use stable deterministic tie-breakers
+- Provide a documented deterministic fallback such as greedy product selection plus conflict repair.
+- Write `status.json` with backend, model size, objective components, runtime, and optimality/time-limit status.
+
+## Out Of Scope
+
+- Official experiment registration.
+- Large-case tuning.
+- Full exact proof of optimality on dense cases.
+
+## Implementation Notes
+
+- Prefer an available repo-compatible backend. If OR-Tools, SciPy MILP, PuLP, CBC, HiGHS, or another backend is absent, the solver must still emit a valid fallback solution.
+- Big-M timing constraints are acceptable only if numerically bounded by mission horizon seconds.
+- Pairwise conflict cuts are simpler and may better match the finite candidate library than continuous start variables.
+- Product variables should make the paper's stereo coupling visible in the code and debug artifacts.
+
+## Validation
+
+- Add focused tests for product-observation linking and conflict exclusion.
+- Run direct smoke with a tiny candidate cap so model construction is quick.
+- Force fallback mode through config and verify deterministic output.
+- Check that `status.json` reports objective components and backend state.
+
+## Exit Criteria
+
+- Solver selects observations through explicit product-linked optimization variables.
+- Incompatible observations cannot both be selected by the model or fallback.
+- Backend absence or timeout does not crash the solver.
+- Direct smoke emits `solution.json`, `status.json`, and optional debug artifacts.
+
+## Suggested Prompt
+
+Read the stereo MILP roadmap, Phase 3 code, Kim formulation, and this phase doc. Implement the product-linked MILP or CP-SAT model plus deterministic fallback. Preserve coverage-first objective semantics, write model/status diagnostics, and run direct smoke with both optimized and forced-fallback modes.

--- a/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_5_DECODE_REPAIR_EXPERIMENT_WIRING_AND_TESTS.md
+++ b/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_5_DECODE_REPAIR_EXPERIMENT_WIRING_AND_TESTS.md
@@ -1,0 +1,62 @@
+# Phase 5: Decode, Repair, Experiment Wiring, And Tests
+
+## Goal
+
+Decode selected products into benchmark solution actions, apply conservative local repair, add focused tests, and wire the solver into `experiments/main_solver`.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md`
+- Phase 4 implementation
+- `docs/solver_contract.md`
+- `experiments/main_solver/README.md`
+- `experiments/main_solver/config.yaml`
+- Existing solver registration examples in `experiments/main_solver/solvers/`
+
+## In Scope
+
+- Decode selected candidate observations into sorted action JSON.
+- Deduplicate observations shared by multiple products.
+- Add conservative solver-local repair:
+  - remove overlapping same-satellite actions
+  - remove actions that violate local slew/settle checks
+  - drop products whose required actions were removed
+  - prefer preserving coverage before quality
+- Add or update tests under `tests/solvers/` for solver-local behavior.
+- Add `experiments/main_solver/solvers/stereo_imaging_time_window_pruned_stereo_milp.yaml`.
+- Add main-solver config entry with `evidence_type: reproduced_solver` only after the solver is runnable.
+
+## Out Of Scope
+
+- Tuning for best scores.
+- Documentation finalization.
+- Benchmark verifier imports inside solver code.
+
+## Implementation Notes
+
+- Repair should be auditable, not magical. Write `debug/repair_log.json` when debug is enabled.
+- If repair removes an observation, remove or recompute any product credit connected to it in `status.json`.
+- Main-solver registration should use the same naming pattern as existing reproduced solvers.
+
+## Validation
+
+- Run focused solver tests.
+- Run direct smoke.
+- Run official main-solver smoke:
+
+```bash
+uv run python experiments/main_solver/run.py --benchmark stereo_imaging --solver stereo_imaging_time_window_pruned_stereo_milp --case test/case_0001
+```
+
+- Run the benchmark verifier manually on at least one direct output if main-solver wiring is not ready.
+
+## Exit Criteria
+
+- `solution.json` contains only valid observation action objects.
+- Solver-local tests pass.
+- Main-solver smoke reaches official verification.
+- Repair decisions are recorded and deterministic.
+
+## Suggested Prompt
+
+Read the stereo MILP roadmap, Phase 4 code, main-solver contract, and this phase doc. Implement decoding, conservative repair, focused tests, and main-solver registration for the Kim-style stereo MILP solver. Run direct and official smoke validation.

--- a/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_6_VALIDATION_TUNING_AND_SOLVER_AUDIT.md
+++ b/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_6_VALIDATION_TUNING_AND_SOLVER_AUDIT.md
@@ -1,0 +1,85 @@
+# Phase 6: Validation, Tuning, and Solver Audit
+
+## Goal
+
+Tune and validate the solver so the team can defend "this is a valid, correct implementation of the claimed method, reasonably configured for the benchmark" rather than merely "this is a faithful paper reproduction."
+
+An unoptimized or slow implementation is not a failure if the algorithmic logic is correct. The audit should flag correctness-affecting deviations and timeout/resource misalignment, not penalize implementation style or performance gaps that do not affect validity.
+
+## Inputs To Read
+
+- `solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md`
+- Phase 5 implementation and debug artifacts
+- Issue #89
+- `solvers/stereo_imaging/literature/kim-2020-stereo-milp.md`
+- `solvers/stereo_imaging/literature/summary.md`
+- `benchmarks/stereo_imaging/README.md`
+- Official verification outputs from `experiments/main_solver`
+
+## In Scope
+
+- Run a validation matrix across public cases and selected configs:
+  - pruning disabled
+  - low/mid/high lambda-style pruning
+  - optimized backend when available
+  - deterministic fallback mode
+- Track:
+  - validity
+  - `coverage_ratio`
+  - `normalized_quality`
+  - action count
+  - valid pair count
+  - valid tri count
+  - candidate/product counts
+  - pruned candidate/product counts
+  - runtime
+  - backend status
+- Compare against a simple greedy earliest-pair baseline if available or add a tiny internal comparison mode.
+- Calibrate product prechecks against verifier diagnostics on representative emitted solutions.
+- Record where benchmark adaptation intentionally differs from Kim:
+  - no downlink/storage constraints
+  - benchmark convergence/overlap/pixel-scale validity instead of pitch-difference-only stereo
+  - tri-stereo extension
+  - coverage-first objective
+- **Assess performance baseline and timeout realism:**
+  - What runtime does Kim et al. report for comparable instances?
+  - What timeout and thread count does the benchmark envelope provide?
+  - Is the timeout realistic for a MILP of this structure, or does it make success practically impossible?
+  - Document any timeout/resource misalignment; do not flag a correct-but-slow solver as invalid.
+
+## Out Of Scope
+
+- Rewriting the algorithm into an unrelated metaheuristic.
+- Adding non-paper features that cannot be explained as benchmark adaptation.
+- Long private sweeps that leave no reproducible config.
+- Treating performance-only differences (e.g., slower loop, simpler data structure) as correctness deviations.
+
+## Implementation Notes
+
+- Keep tuning knobs in `config.example.yaml` with documented defaults.
+- Tuning should preserve validity first, coverage second, and quality third.
+- If the backend produces infeasible or unstable results, prefer a conservative fallback and document the limitation.
+- Debug summaries should make candidate pruning and model tradeoffs visible enough for future papers or README claims.
+- **Correctness vs. performance:** flag only differences that change algorithmic correctness or violate the benchmark contract. Cosmetic or performance-related differences are notes, not deviations.
+
+## Validation
+
+- Run focused tests.
+- Run official smoke and all feasible public cases through `experiments/main_solver`.
+- Run forced fallback smoke.
+- Compare debug product counts against official `diagnostics.pair_evaluations` on at least one case.
+- Check deterministic repeatability by running the same case/config twice.
+- **Check timeout/resource alignment:** document whether the benchmark envelope is realistic for the claimed method.
+
+## Exit Criteria
+
+- Default config is chosen and justified.
+- Validation notes explain correctness, runtime, and drift from paper assumptions.
+- Official smoke is valid.
+- At least one reproducible validation artifact supports the README's solver-audit claims.
+- Known limitations are concrete and ready for final docs.
+- **Performance baseline assessment is documented:** REALISTIC, MISALIGNED, or UNKNOWN.
+
+## Suggested Prompt
+
+Read the stereo MILP roadmap, issue #89, Kim transcript, current implementation, and official main-solver outputs. Tune and validate for solver audit: compare pruning levels and fallback mode, calibrate product prechecks against verifier diagnostics, assess timeout/resource realism against literature baselines, record metrics, and prepare concrete notes for the final README.

--- a/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_7_DOCS_CLEANUP_AND_PROMOTION.md
+++ b/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/PHASE_7_DOCS_CLEANUP_AND_PROMOTION.md
@@ -1,0 +1,86 @@
+# Phase 7: Docs, Cleanup, And Promotion
+
+## Goal
+
+Finish the Kim-style stereo MILP solver with comprehensive documentation, cleanup, and promotion metadata following the standard set by `solvers/aeossp_standard/mwis_conflict_graph/README.md`.
+
+## Inputs To Read
+
+- `solvers/aeossp_standard/mwis_conflict_graph/README.md`
+- `solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md`
+- Phase 6 reproduction/tuning notes
+- `docs/solver_contract.md`
+- `experiments/main_solver/README.md`
+- `solvers/finished_solvers.json`
+
+## In Scope
+
+- Write or finalize `solvers/stereo_imaging/time_window_pruned_stereo_milp/README.md`.
+- README should include:
+  - solver identity
+  - citation and BibTeX
+  - method summary
+  - benchmark adaptation
+  - solver contract
+  - candidate observation library
+  - pair/tri product variables
+  - time-window pruning
+  - backend and fallback behavior
+  - decode and repair
+  - configuration
+  - debug artifacts
+  - running commands
+  - sanity baseline and tuning notes
+  - known limitations
+  - evidence type
+- Finalize `config.example.yaml`.
+- Ensure entrypoints are executable.
+- Remove temporary debug/results artifacts.
+- Add to `solvers/finished_solvers.json` only after official smoke validity and docs are complete.
+
+## Out Of Scope
+
+- New solver features.
+- Large score sweeps.
+- Benchmark or dataset edits.
+
+## Implementation Notes
+
+- Include BibTeX for Kim et al.:
+
+```bibtex
+@article{kim2020stereo,
+  title = {Task Scheduling of Agile Satellites with Transition Time and Stereoscopic Imaging Constraints},
+  author = {Kim, Junhong and Cho, Doo-Hyun and Ahn, Jaemyung and Choi, Han-Lim},
+  journal = {Journal of Aerospace Information Systems},
+  volume = {17},
+  number = {6},
+  pages = {285--293},
+  year = {2020},
+  doi = {10.2514/1.I010775},
+  eprint = {1912.00374},
+  archivePrefix = {arXiv}
+}
+```
+
+- README must state that benchmark product variables replace Kim's pitch-difference stereo constraint.
+- README must state that downlink/storage constraints are omitted because the benchmark excludes them.
+- README must describe the validation/tuning evidence used to support solver-audit claims: correctness, benchmark contract compliance, and timeout/resource realism.
+
+## Validation
+
+- Run focused solver tests.
+- Run official main-solver smoke.
+- Run README commands.
+- Check that no generated debug/result artifacts are committed.
+
+## Exit Criteria
+
+- README is complete enough for an external reader to understand both the paper and benchmark adaptation.
+- BibTeX is included.
+- Solver is promoted only if official smoke verification passes.
+- Final handoff lists validation commands and residual limitations.
+
+## Suggested Prompt
+
+Read the Kim stereo MILP roadmap, Phase 6 notes, current solver, and `solvers/aeossp_standard/mwis_conflict_graph/README.md`. Finish documentation and cleanup for the stereo MILP solver. Include BibTeX, benchmark adaptation, config/debug docs, known limitations, and promotion metadata only after official smoke verification passes.

--- a/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md
+++ b/solvers/stereo_imaging/roadmap/time_window_pruned_stereo_milp/ROADMAP.md
@@ -1,0 +1,76 @@
+# Time-Window-Pruned Stereo MILP Solver Roadmap
+
+## Goal
+
+Implement a runnable reproduced solver for `stereo_imaging` using Kim-style agile-satellite MILP scheduling with time-window pruning, adapted to benchmark-native stereo and tri-stereo product variables.
+
+The solver should be the higher-quality optimization baseline: enumerate benchmark-feasible observation candidates, precompute valid stereo and tri-stereo products, solve a reduced MILP or CP-SAT model that prioritizes target coverage before product quality, and document the algorithmic validity of the adaptation: correctness of the MILP structure, benchmark contract compliance, and reasonable timeout/resource expectations.
+
+## Source Of Truth
+
+- Issue: `https://github.com/Mtrya/astro-reason/issues/89`
+- Benchmark contract: `benchmarks/stereo_imaging/README.md`
+- Solver contract: `docs/solver_contract.md`
+- Main solver experiment: `experiments/main_solver/README.md`
+- Literature summary: `solvers/stereo_imaging/literature/summary.md`
+- Selection table: `solvers/stereo_imaging/literature/table.md`
+- Kim transcript: `solvers/stereo_imaging/literature/kim-2020-stereo-milp.md`
+- Research report: `solvers/stereo_imaging/literature/report.md`
+- Verifier tests: `tests/benchmarks/test_stereo_imaging_verifier.py`
+- Fixture notes: `tests/fixtures/stereo_imaging/README.md`
+- Solver docs style reference: `solvers/aeossp_standard/mwis_conflict_graph/README.md`
+
+## Current State
+
+`stereo_imaging` has public cases, a verifier, generator, fixtures, visualizer, and no runnable solver. The benchmark requires same-satellite, same-target, same-access stereo products and ranks valid solutions by `coverage_ratio` before `normalized_quality`. Issue #89 asks for a standalone reproduced solver that uses Kim et al.'s MILP structure and pruning idea while replacing the paper's pitch-difference stereo condition with verifier-aligned product feasibility.
+
+## Contract And Boundaries
+
+- Solver path: `solvers/stereo_imaging/time_window_pruned_stereo_milp/`.
+- Required entrypoints: `setup.sh` and `solve.sh <case_dir> [config_dir] [solution_dir]`.
+- Public inputs:
+  - `satellites.yaml`
+  - `targets.yaml`
+  - `mission.yaml`
+- Primary output: `solution.json` with a top-level `actions` array containing only `observation` actions.
+- Each observation action must include `satellite_id`, `target_id`, `start_time`, `end_time`, `off_nadir_along_deg`, and `off_nadir_across_deg`.
+- Solver code may use project dependencies and an optional optimization backend, but must degrade cleanly to a documented fallback if the preferred backend is unavailable.
+- Solver code must not import `benchmarks.*`, `experiments.*`, or another solver. It must not call benchmark verifiers from solver code.
+- Official verification belongs to `experiments/main_solver` or explicit developer-side validation commands.
+
+## Paper-To-Benchmark Adaptation
+
+- Kim observation task/window variables = candidate observation windows per `(satellite_id, target_id, access_interval_id, sample_time, steering)`.
+- Kim stereo selection variables = benchmark product variables for valid pairs and tri-stereo sets.
+- Kim pitch-angle separation constraint = precomputed convergence, overlap, pixel-scale, same-access, and near-nadir-anchor predicates.
+- Kim transition-time constraints = benchmark-style per-satellite overlap and slew/settle separation between selected actions.
+- Kim priority objective = lexicographic benchmark objective: maximize covered targets, then normalized product quality, then deterministic tie-breakers.
+- Kim download and onboard data capacity constraints are omitted because the benchmark explicitly excludes downlink, storage, and power.
+- Kim time-window pruning = cluster dense access windows and retain candidates by target scarcity, product potential, quality, and steering similarity.
+
+## Phase Order
+
+1. `PHASE_1_CONTRACT_CANDIDATE_LIBRARY_AND_PRECHECKS.md`
+2. `PHASE_2_PRODUCT_ENUMERATION_AND_SCORING.md`
+3. `PHASE_3_TIME_WINDOW_CLUSTER_PRUNING.md`
+4. `PHASE_4_MILP_MODEL_AND_BACKEND_FALLBACK.md`
+5. `PHASE_5_DECODE_REPAIR_EXPERIMENT_WIRING_AND_TESTS.md`
+6. `PHASE_6_VALIDATION_TUNING_AND_SOLVER_AUDIT.md`
+7. `PHASE_7_DOCS_CLEANUP_AND_PROMOTION.md`
+
+## Cross-Phase Risks
+
+- Candidate enumeration can explode if sample spacing is too fine or steering variants are too dense.
+- Simplified product prechecks may admit pairs/triples that fail official overlap, convergence, or pixel-scale checks.
+- A linear objective can accidentally optimize quality before coverage unless the lexicographic scale is explicit.
+- Pair and tri-stereo products create linking constraints that can make the MILP much larger than the paper's two-image stereo form.
+- Optional solver backends can change results unless fallback behavior and tie-breaking are deterministic.
+
+## Overall Exit Criteria
+
+- Direct `setup.sh` and `solve.sh` work on the smoke case.
+- `experiments/main_solver` can run the solver with `evidence_type: reproduced_solver`.
+- Official verification passes at least the smoke case and preferably all public cases.
+- Focused tests cover case parsing, candidate generation, product predicates, pruning, MILP decoding, deterministic fallback, and output schema.
+- Debug artifacts explain candidate counts, pruned windows, product counts, model size, backend status, selected products, repair removals, official metrics, and runtime.
+- Final README covers method summary, benchmark adaptation, solver contract, candidate/product generation, pruning, backend/fallback behavior, validation/tuning, known limitations, and BibTeX for Kim et al.


### PR DESCRIPTION
## Summary

Revises both `stereo_imaging` solver roadmaps (MILP and CP/local-search) to align with the `solver-audit\' skill: validity and correctness over narrow paper fidelity.

## Background

The previous roadmaps treated "faithful paper reproduction" as the primary goal. The `solver-audit` skill (see `.agents/skills/solver-audit/SKILL.md`) reframes the review to ask:
- Is the solver valid and correct?
- Is it reasonably configured for the benchmark?
- Are timeouts/resources realistic for the claimed method?
- Is an unoptimized but correct implementation acceptable?

## Changes

### Phase 6 renamed and rewritten
- `PHASE_6_VALIDATION_TUNING_AND_REPRODUCTION_FIDELITY.md` → `PHASE_6_VALIDATION_TUNING_AND_SOLVER_AUDIT.md` (both roadmaps)
- New goal: defend "valid, correct implementation" rather than "faithful paper reproduction"
- Added **performance baseline and timeout realism** assessment
- Added explicit rule: unoptimized or slow implementations are **not** failures
- Added `REALISTIC / MISALIGNED / UNKNOWN` performance baseline ratings
- Distinguish correctness-affecting deviations from performance/style differences

### ROADMAP.md updates
- Replaced "faithful reproduction" language with "algorithmic validity, benchmark contract compliance, and reasonable timeout/resource expectations"
- Updated phase lists to reference new PHASE_6 names

### Cross-phase updates
- PHASE_1 (MILP): "fidelity diagnostics" → "audit diagnostics"
- PHASE_3 (MILP): "fidelity comparisons" → "audit comparisons"
- PHASE_7 (both): README must support "solver-audit claims" instead of "reproduction fidelity"

## Checklist
- [x] No remaining "fidelity" / "faithful reproduction" language in these roadmaps.
- [x] Both roadmaps include timeout/resource realism and performance baseline guidance.
- [x] Correctness-vs-performance distinction is explicit.