### PR TITLE
Add opaque verifier workspace contracts

### DIFF
--- a/benchmarks/spot5/verifier.py
+++ b/benchmarks/spot5/verifier.py
@@ -428,4 +428,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    raise SystemExit(main())

--- a/experiments/_fragments/opaque_verifiers/.gitignore
+++ b/experiments/_fragments/opaque_verifiers/.gitignore
@@ -1,0 +1,3 @@
+artifacts/
+__pycache__/
+*.pyc

--- a/experiments/_fragments/opaque_verifiers/README.md
+++ b/experiments/_fragments/opaque_verifiers/README.md
@@ -21,7 +21,9 @@ The tracked entrypoint is:
 uv run python experiments/_fragments/opaque_verifiers/build.py
 ```
 
-Artifacts are runtime-image-specific. The builder uses the base runtime image from `runtimes/base/runtime.yaml`, mounts the repository into a disposable container, builds the artifact inside that container, and smoke-tests the artifact inside the same image before marking it reusable.
+Artifacts are runtime-image-specific. The builder uses the base runtime image from `runtimes/base/runtime.yaml`, mounts the repository into a disposable container, builds the artifact inside that container, and smoke-tests the artifact inside the same image before marking it reusable. Reused artifacts are still checked against the verifier source hash, builder inputs, runtime image stamp, executability, and the benchmark-specific smoke case.
+
+The `artifacts/` directory may contain generated verifier binaries, `build.json` metadata, and temporary build scratch directories. All of that state is ignored; only `build.py`, `manifest.yaml`, this README, and the `.gitignore` policy are tracked.
 
 If the runtime image is missing or stale, rebuild it first:
 

--- a/experiments/_fragments/opaque_verifiers/README.md
+++ b/experiments/_fragments/opaque_verifiers/README.md
@@ -1,0 +1,30 @@
+# Opaque Verifiers
+
+This directory holds experiment-owned tooling for building opaque verifier artifacts.
+
+In this repository, opaque means:
+
+- the space agent does not receive readable verifier source code inside the assembled workspace
+- experiments may still provide a runnable local validation helper
+
+Opaque does not mean cryptographic secrecy or resistance to reverse engineering.
+
+Ownership:
+
+- canonical verifier source remains under `benchmarks/`
+- experiments own how verifier behavior is exposed inside a workspace
+- generated artifacts are ignored by git and live under `artifacts/`
+
+The tracked entrypoint is:
+
+```bash
+uv run python experiments/_fragments/opaque_verifiers/build.py
+```
+
+Artifacts are runtime-image-specific. The builder uses the base runtime image from `runtimes/base/runtime.yaml`, mounts the repository into a disposable container, builds the artifact inside that container, and smoke-tests the artifact inside the same image before marking it reusable.
+
+If the runtime image is missing or stale, rebuild it first:
+
+```bash
+uv run python runtimes/base/build.py
+```

--- a/experiments/_fragments/opaque_verifiers/build.py
+++ b/experiments/_fragments/opaque_verifiers/build.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Build experiment-owned opaque verifier artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+from typing import Any
+
+import yaml
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+OPAQUE_DIR = SCRIPT_PATH.parent
+REPO_ROOT = SCRIPT_PATH.parents[3]
+MANIFEST_PATH = OPAQUE_DIR / "manifest.yaml"
+RUNTIME_MANIFEST_PATH = REPO_ROOT / "runtimes" / "base" / "runtime.yaml"
+CONTAINER_REPO_ROOT = Path("/repo")
+SATNET_COMPACT_PATTERN = re.compile(
+    r"(VALID|INVALID):\s+(?:total_hours|score)=([+-]?(?:\d+(?:\.\d*)?|\.\d+))h,\s+tracks=(\d+)"
+)
+SPOT5_COMPACT_PATTERN = re.compile(
+    r"(VALID|INVALID):\s+profit=(\d+),\s+weight=(\d+)"
+)
+STATUS_PATTERN = re.compile(r"^Status:\s+(VALID|INVALID)\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class DataPathSpec:
+    source: str
+    target: str
+
+
+@dataclass(frozen=True)
+class BenchmarkSpec:
+    name: str
+    entry_type: str
+    entry: str
+    source_roots: tuple[str, ...]
+    artifact: str
+    smoke_case: str
+    smoke_solution: str
+    hidden_imports: tuple[str, ...]
+    data_paths: tuple[DataPathSpec, ...]
+
+
+@dataclass(frozen=True)
+class RuntimeSpec:
+    image: str
+    dockerfile: Path
+    build_context: Path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build opaque verifier artifacts")
+    parser.add_argument(
+        "--benchmark",
+        action="append",
+        dest="benchmarks",
+        help="Benchmark name from manifest.yaml; may be repeated",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force rebuild even if the existing artifact appears fresh",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SystemExit(f"Manifest does not exist: {path}")
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - surfaced as fatal CLI error
+        raise SystemExit(f"Failed to parse manifest {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit(f"Manifest must contain a mapping: {path}")
+    return data
+
+
+def _require_str(mapping: dict[str, Any], key: str, context: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"{context}.{key} must be a non-empty string")
+    return value
+
+
+def _require_list_of_str(mapping: dict[str, Any], key: str, context: str) -> tuple[str, ...]:
+    value = mapping.get(key)
+    if value is None:
+        return ()
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        raise SystemExit(f"{context}.{key} must be a list of non-empty strings")
+    return tuple(value)
+
+
+def _require_data_paths(mapping: dict[str, Any], context: str) -> tuple[DataPathSpec, ...]:
+    value = mapping.get("data_paths")
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise SystemExit(f"{context}.data_paths must be a list")
+
+    items: list[DataPathSpec] = []
+    for index, payload in enumerate(value):
+        item_context = f"{context}.data_paths[{index}]"
+        if not isinstance(payload, dict):
+            raise SystemExit(f"{item_context} must be a mapping")
+        items.append(
+            DataPathSpec(
+                source=_require_str(payload, "source", item_context),
+                target=_require_str(payload, "target", item_context),
+            )
+        )
+    return tuple(items)
+
+
+def load_manifest() -> dict[str, BenchmarkSpec]:
+    data = _load_yaml_mapping(MANIFEST_PATH)
+    benchmarks_raw = data.get("benchmarks")
+    if not isinstance(benchmarks_raw, dict) or not benchmarks_raw:
+        raise SystemExit("manifest.yaml must contain a non-empty benchmarks mapping")
+
+    specs: dict[str, BenchmarkSpec] = {}
+    for name, payload in benchmarks_raw.items():
+        context = f"benchmarks.{name}"
+        if not isinstance(payload, dict):
+            raise SystemExit(f"{context} must be a mapping")
+        entry_type = _require_str(payload, "entry_type", context)
+        if entry_type not in {"module", "script"}:
+            raise SystemExit(f"{context}.entry_type must be 'module' or 'script'")
+        specs[name] = BenchmarkSpec(
+            name=name,
+            entry_type=entry_type,
+            entry=_require_str(payload, "entry", context),
+            source_roots=_require_list_of_str(payload, "source_roots", context),
+            artifact=_require_str(payload, "artifact", context),
+            smoke_case=_require_str(payload, "smoke_case", context),
+            smoke_solution=_require_str(payload, "smoke_solution", context),
+            hidden_imports=_require_list_of_str(payload, "hidden_imports", context),
+            data_paths=_require_data_paths(payload, context),
+        )
+        if not specs[name].source_roots:
+            raise SystemExit(f"{context}.source_roots must not be empty")
+    return specs
+
+
+def load_runtime() -> RuntimeSpec:
+    data = _load_yaml_mapping(RUNTIME_MANIFEST_PATH)
+    image = _require_str(data, "image", "runtime")
+    dockerfile = REPO_ROOT / "runtimes" / "base" / _require_str(data, "dockerfile", "runtime")
+    build_context = REPO_ROOT / "runtimes" / "base" / _require_str(
+        data, "build_context", "runtime"
+    )
+    return RuntimeSpec(
+        image=image,
+        dockerfile=dockerfile.resolve(),
+        build_context=build_context.resolve(),
+    )
+
+
+def resolve_repo_path(relative_path: str) -> Path:
+    path = (REPO_ROOT / relative_path).resolve()
+    if not path.exists():
+        raise SystemExit(f"Path from manifest does not exist: {relative_path}")
+    return path
+
+
+def resolve_artifact_path(spec: BenchmarkSpec) -> Path:
+    artifact = (REPO_ROOT / spec.artifact).resolve()
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    return artifact
+
+
+def build_json_path(spec: BenchmarkSpec) -> Path:
+    return resolve_artifact_path(spec).parent / "build.json"
+
+
+def iter_source_files(spec: BenchmarkSpec) -> list[Path]:
+    files: list[Path] = []
+    for root_text in spec.source_roots:
+        root = resolve_repo_path(root_text)
+        if root.is_dir():
+            for path in sorted(root.rglob("*")):
+                if not path.is_file():
+                    continue
+                if "__pycache__" in path.parts:
+                    continue
+                files.append(path)
+        elif root.is_file():
+            files.append(root)
+        else:
+            raise SystemExit(f"Unsupported source root: {root}")
+    return sorted(set(files))
+
+
+def manifest_entry_payload(spec: BenchmarkSpec) -> dict[str, Any]:
+    return {
+        "entry_type": spec.entry_type,
+        "entry": spec.entry,
+        "source_roots": list(spec.source_roots),
+        "artifact": spec.artifact,
+        "smoke_case": spec.smoke_case,
+        "smoke_solution": spec.smoke_solution,
+        "hidden_imports": list(spec.hidden_imports),
+        "data_paths": [{"source": item.source, "target": item.target} for item in spec.data_paths],
+    }
+
+
+def compute_input_hash(spec: BenchmarkSpec) -> str:
+    blob = hashlib.sha256()
+    blob.update(json.dumps(manifest_entry_payload(spec), sort_keys=True).encode("utf-8"))
+    blob.update(b"\0")
+    blob.update(SCRIPT_PATH.read_bytes())
+    blob.update(b"\0")
+    for path in iter_source_files(spec):
+        blob.update(path.relative_to(REPO_ROOT).as_posix().encode("utf-8"))
+        blob.update(b"\0")
+        blob.update(path.read_bytes())
+        blob.update(b"\0")
+    return blob.hexdigest()
+
+
+def _truncate_output(text: str, limit: int = 2000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "\n...[truncated]..."
+
+
+def _status_valid(stdout: str) -> bool | None:
+    match = STATUS_PATTERN.search(stdout)
+    if match is None:
+        return None
+    return match.group(1) == "VALID"
+
+
+def _plain_cli_valid(spec: BenchmarkSpec, stdout: str) -> bool | None:
+    if spec.name == "satnet":
+        valid = _status_valid(stdout)
+        if valid is not None:
+            return valid
+        match = SATNET_COMPACT_PATTERN.search(stdout)
+        if match is not None:
+            return match.group(1) == "VALID"
+        return None
+
+    if spec.name == "spot5":
+        valid = _status_valid(stdout)
+        if valid is not None:
+            return valid
+        match = SPOT5_COMPACT_PATTERN.search(stdout)
+        if match is not None:
+            return match.group(1) == "VALID"
+        return None
+
+    return None
+
+
+def _container_path(host_path: Path) -> str:
+    return (CONTAINER_REPO_ROOT / host_path.resolve().relative_to(REPO_ROOT)).as_posix()
+
+
+def _docker_run(
+    runtime: RuntimeSpec,
+    command: list[str],
+    *,
+    workdir: str = "/repo",
+) -> subprocess.CompletedProcess[str]:
+    user_args: list[str] = []
+    if hasattr(os, "getuid") and hasattr(os, "getgid"):
+        user_args = ["--user", f"{os.getuid()}:{os.getgid()}"]
+    try:
+        return subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                *user_args,
+                "-v",
+                f"{REPO_ROOT}:/repo",
+                "-w",
+                workdir,
+                "-e",
+                "HOME=/tmp",
+                "-e",
+                "XDG_CACHE_HOME=/tmp/xdg-cache",
+                "-e",
+                "MPLCONFIGDIR=/tmp/mplconfig",
+                runtime.image,
+                *command,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+    except FileNotFoundError as exc:
+        raise SystemExit("Docker is required to build opaque verifier artifacts.") from exc
+
+
+def _docker_image_inspect(runtime: RuntimeSpec) -> str:
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", runtime.image, "--format", "{{.Id}}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+    except FileNotFoundError as exc:
+        raise SystemExit("Docker is required to build opaque verifier artifacts.") from exc
+    if result.returncode != 0:
+        build_command = (
+            f"uv run python {RUNTIME_MANIFEST_PATH.relative_to(REPO_ROOT).parent.as_posix()}/build.py"
+        )
+        raise SystemExit(
+            f"Runtime image is not available: {runtime.image}\n"
+            f"Build it first with: {build_command}\n"
+            f"stderr:\n{_truncate_output(result.stderr)}"
+        )
+    return result.stdout.strip()
+
+
+def container_environment_stamp(runtime: RuntimeSpec) -> dict[str, str]:
+    image_id = _docker_image_inspect(runtime)
+    payload = (
+        "import json, platform, sys; "
+        "print(json.dumps({"
+        "'platform': platform.system().lower(), "
+        "'machine': platform.machine().lower(), "
+        "'python_major_minor': f'{sys.version_info.major}.{sys.version_info.minor}', "
+        "'python_version': platform.python_version()"
+        "}, sort_keys=True))"
+    )
+    result = _docker_run(runtime, ["python", "-c", payload])
+    if result.returncode != 0:
+        raise SystemExit(
+            f"Failed to query runtime environment from {runtime.image}.\n"
+            f"stdout:\n{_truncate_output(result.stdout)}\n"
+            f"stderr:\n{_truncate_output(result.stderr)}"
+        )
+    try:
+        stamp = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"Runtime environment query emitted malformed JSON: {result.stdout}"
+        ) from exc
+    if not isinstance(stamp, dict) or not all(isinstance(k, str) and isinstance(v, str) for k, v in stamp.items()):
+        raise SystemExit(f"Runtime environment query emitted unexpected payload: {result.stdout}")
+    stamp["runtime_image"] = runtime.image
+    stamp["runtime_image_id"] = image_id
+    return stamp
+
+
+def smoke_check(spec: BenchmarkSpec, artifact_path: Path, runtime: RuntimeSpec) -> dict[str, Any]:
+    case_path = resolve_repo_path(spec.smoke_case)
+    solution_path = resolve_repo_path(spec.smoke_solution)
+    result = _docker_run(
+        runtime,
+        [
+            _container_path(artifact_path),
+            _container_path(case_path),
+            _container_path(solution_path),
+        ],
+    )
+    stdout = result.stdout.strip()
+    try:
+        parsed = json.loads(stdout) if stdout else {}
+    except json.JSONDecodeError:
+        parsed = None
+
+    valid = False
+    if isinstance(parsed, dict):
+        valid = parsed.get("valid") is True or parsed.get("is_valid") is True
+    else:
+        plain_valid = _plain_cli_valid(spec, stdout)
+        if plain_valid is not None:
+            valid = plain_valid
+    passed = result.returncode == 0 and valid
+    return {
+        "passed": passed,
+        "exit_code": result.returncode,
+        "stdout": stdout,
+        "stderr": result.stderr.strip(),
+        "parsed": parsed if isinstance(parsed, dict) else None,
+        "case": spec.smoke_case,
+        "solution": spec.smoke_solution,
+    }
+
+
+def load_existing_build_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def freshness_reason(
+    spec: BenchmarkSpec,
+    input_hash: str,
+    runtime_stamp: dict[str, str],
+    runtime: RuntimeSpec,
+) -> str | None:
+    artifact_path = resolve_artifact_path(spec)
+    metadata_path = build_json_path(spec)
+    metadata = load_existing_build_json(metadata_path)
+    if not artifact_path.exists():
+        return "artifact missing"
+    if metadata is None:
+        return "build.json missing or malformed"
+    if not os.access(artifact_path, os.X_OK):
+        return "artifact is not executable"
+    if metadata.get("input_hash") != input_hash:
+        return "input hash changed"
+    if metadata.get("build_target") != "runtime_docker_image":
+        return "build target changed"
+
+    for key, value in runtime_stamp.items():
+        if metadata.get(key) != value:
+            return f"environment changed: {key}"
+
+    smoke = smoke_check(spec, artifact_path, runtime)
+    if not smoke["passed"]:
+        return "smoke check failed"
+    return None
+
+
+def pyinstaller_version(runtime: RuntimeSpec) -> str:
+    result = _docker_run(runtime, ["python", "-m", "PyInstaller", "--version"])
+    if result.returncode != 0:
+        raise SystemExit(
+            f"Failed to query PyInstaller version from {runtime.image}.\n"
+            f"stdout:\n{_truncate_output(result.stdout)}\n"
+            f"stderr:\n{_truncate_output(result.stderr)}"
+        )
+    return result.stdout.strip()
+
+
+def build_artifact(
+    spec: BenchmarkSpec,
+    input_hash: str,
+    runtime_stamp: dict[str, str],
+    runtime: RuntimeSpec,
+) -> dict[str, Any]:
+    artifact_path = resolve_artifact_path(spec)
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifacts_root = OPAQUE_DIR / "artifacts"
+    artifacts_root.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix=f"build-{spec.name}-", dir=artifacts_root) as temp_root_text:
+        temp_root = Path(temp_root_text)
+        entry_path = resolve_repo_path(spec.entry) if spec.entry_type == "script" else temp_root / "entry.py"
+        if spec.entry_type == "module":
+            entry_path.write_text(
+                f"from {spec.entry} import main\nraise SystemExit(main())\n",
+                encoding="utf-8",
+            )
+
+        dist_dir = temp_root / "dist"
+        work_dir = temp_root / "build"
+        spec_dir = temp_root / "spec"
+
+        cmd = [
+            "python",
+            "-m",
+            "PyInstaller",
+            "--noconfirm",
+            "--clean",
+            "--onefile",
+            "--name",
+            "verifier",
+            "--distpath",
+            _container_path(dist_dir),
+            "--workpath",
+            _container_path(work_dir),
+            "--specpath",
+            _container_path(spec_dir),
+            "--paths",
+            "/repo",
+        ]
+        for hidden_import in spec.hidden_imports:
+            cmd.extend(["--hidden-import", hidden_import])
+        for data_path in spec.data_paths:
+            source = resolve_repo_path(data_path.source)
+            cmd.extend(["--add-data", f"{_container_path(source)}:{data_path.target}"])
+        cmd.append(_container_path(entry_path))
+
+        result = _docker_run(runtime, cmd)
+        if result.returncode != 0:
+            raise SystemExit(
+                f"PyInstaller build failed for {spec.name} in {runtime.image}.\n"
+                f"stdout:\n{_truncate_output(result.stdout)}\n"
+                f"stderr:\n{_truncate_output(result.stderr)}"
+            )
+
+        built_artifact = dist_dir / "verifier"
+        if not built_artifact.exists():
+            raise SystemExit(f"PyInstaller did not produce the expected artifact: {built_artifact}")
+
+        shutil.move(str(built_artifact), artifact_path)
+        artifact_path.chmod(artifact_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    smoke = smoke_check(spec, artifact_path, runtime)
+    smoke_valid = False
+    smoke_metrics = None
+    if smoke["parsed"]:
+        smoke_valid = smoke["parsed"].get("valid") is True or smoke["parsed"].get("is_valid") is True
+        smoke_metrics = smoke["parsed"].get("metrics")
+    metadata = {
+        "benchmark": spec.name,
+        "artifact_path": artifact_path.relative_to(REPO_ROOT).as_posix(),
+        "build_target": "runtime_docker_image",
+        "entry_type": spec.entry_type,
+        "entry": spec.entry,
+        "source_roots": list(spec.source_roots),
+        "input_hash": input_hash,
+        **runtime_stamp,
+        "pyinstaller_version": pyinstaller_version(runtime),
+        "built_at_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "build_command": [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{REPO_ROOT}:/repo",
+            runtime.image,
+            "python",
+            "-m",
+            "PyInstaller",
+            "--noconfirm",
+            "--clean",
+            "--onefile",
+            "--name",
+            "verifier",
+        ],
+        "smoke_case": spec.smoke_case,
+        "smoke_solution": spec.smoke_solution,
+        "smoke_exit_code": smoke["exit_code"],
+        "smoke_passed": smoke["passed"],
+        "smoke_valid": smoke_valid,
+        "smoke_metrics": smoke_metrics,
+    }
+
+    build_json_path(spec).write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if not smoke["passed"]:
+        raise SystemExit(
+            f"Smoke check failed for {spec.name}.\n"
+            f"stdout:\n{_truncate_output(smoke['stdout'])}\n"
+            f"stderr:\n{_truncate_output(smoke['stderr'])}"
+        )
+    return metadata
+
+
+def selected_specs(specs: dict[str, BenchmarkSpec], names: list[str] | None) -> list[BenchmarkSpec]:
+    if not names:
+        return [specs[name] for name in sorted(specs)]
+    missing = [name for name in names if name not in specs]
+    if missing:
+        raise SystemExit(f"Unknown benchmark(s): {', '.join(sorted(missing))}")
+    ordered_unique_names = list(dict.fromkeys(names))
+    return [specs[name] for name in ordered_unique_names]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    specs = load_manifest()
+    runtime = load_runtime()
+    runtime_stamp = container_environment_stamp(runtime)
+    targets = selected_specs(specs, args.benchmarks)
+
+    for spec in targets:
+        input_hash = compute_input_hash(spec)
+        stale_reason = (
+            "forced rebuild"
+            if args.force
+            else freshness_reason(spec, input_hash, runtime_stamp, runtime)
+        )
+        if stale_reason is None:
+            print(f"[reuse] {spec.name}: artifact is fresh and container smoke check passed")
+            continue
+
+        print(f"[build] {spec.name}: {stale_reason}")
+        metadata = build_artifact(spec, input_hash, runtime_stamp, runtime)
+        print(
+            f"[built] {spec.name}: {metadata['artifact_path']} "
+            f"(smoke_case={metadata['smoke_case']}, smoke_passed={metadata['smoke_passed']})"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/_fragments/opaque_verifiers/manifest.yaml
+++ b/experiments/_fragments/opaque_verifiers/manifest.yaml
@@ -1,0 +1,77 @@
+benchmarks:
+  aeossp_standard:
+    entry_type: module
+    entry: benchmarks.aeossp_standard.verifier.run
+    source_roots:
+      - benchmarks/aeossp_standard/verifier
+    artifact: experiments/_fragments/opaque_verifiers/artifacts/aeossp_standard/verifier
+    smoke_case: benchmarks/aeossp_standard/dataset/cases/test/case_0001
+    smoke_solution: benchmarks/aeossp_standard/dataset/example_solution.json
+    hidden_imports: []
+    data_paths: []
+
+  regional_coverage:
+    entry_type: script
+    entry: benchmarks/regional_coverage/verifier.py
+    source_roots:
+      - benchmarks/regional_coverage/verifier.py
+    artifact: experiments/_fragments/opaque_verifiers/artifacts/regional_coverage/verifier
+    smoke_case: benchmarks/regional_coverage/dataset/cases/test/case_0001
+    smoke_solution: benchmarks/regional_coverage/dataset/example_solution.json
+    hidden_imports: []
+    data_paths: []
+
+  relay_constellation:
+    entry_type: module
+    entry: benchmarks.relay_constellation.verifier.run
+    source_roots:
+      - benchmarks/relay_constellation/verifier
+    artifact: experiments/_fragments/opaque_verifiers/artifacts/relay_constellation/verifier
+    smoke_case: benchmarks/relay_constellation/dataset/cases/test/case_0005
+    smoke_solution: benchmarks/relay_constellation/dataset/example_solution.json
+    hidden_imports: []
+    data_paths: []
+
+  revisit_constellation:
+    entry_type: module
+    entry: benchmarks.revisit_constellation.verifier.run
+    source_roots:
+      - benchmarks/revisit_constellation/verifier
+    artifact: experiments/_fragments/opaque_verifiers/artifacts/revisit_constellation/verifier
+    smoke_case: benchmarks/revisit_constellation/dataset/cases/test/case_0001
+    smoke_solution: benchmarks/revisit_constellation/dataset/example_solution.json
+    hidden_imports: []
+    data_paths: []
+
+  satnet:
+    entry_type: script
+    entry: benchmarks/satnet/verifier.py
+    source_roots:
+      - benchmarks/satnet/verifier.py
+    artifact: experiments/_fragments/opaque_verifiers/artifacts/satnet/verifier
+    smoke_case: benchmarks/satnet/dataset/cases/test/W10_2018
+    smoke_solution: benchmarks/satnet/dataset/example_solution.json
+    hidden_imports: []
+    data_paths: []
+
+  spot5:
+    entry_type: script
+    entry: benchmarks/spot5/verifier.py
+    source_roots:
+      - benchmarks/spot5/verifier.py
+    artifact: experiments/_fragments/opaque_verifiers/artifacts/spot5/verifier
+    smoke_case: benchmarks/spot5/dataset/cases/single_orbit/8
+    smoke_solution: benchmarks/spot5/dataset/example_solution.json
+    hidden_imports: []
+    data_paths: []
+
+  stereo_imaging:
+    entry_type: module
+    entry: benchmarks.stereo_imaging.verifier.run
+    source_roots:
+      - benchmarks/stereo_imaging/verifier
+    artifact: experiments/_fragments/opaque_verifiers/artifacts/stereo_imaging/verifier
+    smoke_case: benchmarks/stereo_imaging/dataset/cases/test/case_0001
+    smoke_solution: benchmarks/stereo_imaging/dataset/example_solution.json
+    hidden_imports: []
+    data_paths: []

--- a/experiments/_fragments/prompts/aeossp_standard/README.default.md
+++ b/experiments/_fragments/prompts/aeossp_standard/README.default.md
@@ -49,16 +49,63 @@ Each action should represent one observation interval with:
 
 Do not submit visibility claims, maneuver windows, power traces, or completion claims. Those are derived during validation.
 
-## Important Task Semantics
+## Modeling Contract
 
-- Each task is a point target with one required sensor type, one release time, one due time, and one exact required dwell time.
-- Observation windows must stay inside the mission horizon and task time windows.
-- Observation duration must match the requested duration exactly.
-- A task is binary-complete rather than partially creditable.
-- The schedule should contain only observation actions.
-- The constellation is fixed for this problem. Do not add satellites or redesign orbits.
-- The verifier propagates the frozen TLEs, checks continuous target visibility through the whole interval, and inserts required slew-plus-settle windows between same-satellite observations.
-- Battery feasibility is judged over the full horizon from idle load, imaging load, slew load, and sunlit charging. You do not need to submit any of those internal traces, but the timing you choose must make them feasible.
+Use SI units, degrees, and timezone-aware ISO 8601 timestamps. A trailing `Z` is the safest UTC form. `case/mission.yaml` is a top-level `mission` mapping. Let `H0 = mission.horizon_start`, `H1 = mission.horizon_end`, and `dt = mission.action_time_step_s`. Every action `start_time` and `end_time` must satisfy:
+
+```text
+H0 <= start_time < end_time <= H1
+(start_time - H0) / dt is an integer
+(end_time - H0) / dt is an integer
+```
+
+Each task in `case/tasks.yaml` has `release_time`, `due_time`, and `required_duration_s` on the same grid. A valid observation action must use `type: "observation"`, reference a known `satellite_id` and `task_id`, satisfy `release_time <= start_time` and `end_time <= due_time`, and have:
+
+```text
+end_time - start_time = required_duration_s
+```
+
+Longer or shorter observations do not partially complete the task. The satellite's `sensor.sensor_type` must exactly equal the task's `required_sensor_type`.
+
+The constellation is fixed by `case/satellites.yaml`. Satellite states are propagated only from each satellite's `tle_line1` and `tle_line2`; do not add satellites, change TLEs, or submit attitude trajectories. Inertial quantities use the case's GCRF convention, Earth-fixed geometry uses ITRF/ECEF, target coordinates use WGS84 geodetic `longitude_deg`, `latitude_deg`, and `altitude_m`, and Earth orientation is deterministic for a given case.
+
+Observation visibility is checked at `start_time`, `end_time`, and every `geometry_sample_step_s` grid instant strictly inside the action. At every checked instant, the target line of sight must be above the target local horizon and the off-nadir angle from satellite nadir to target line of sight must be no greater than `attitude_model.max_off_nadir_deg`, allowing only tiny numerical tolerance at the boundary.
+
+For a satellite, observation intervals are half-open for overlap purposes: `[start_time, end_time)`. Same-satellite actions must not overlap. For consecutive same-satellite observations, the required retargeting gap is computed from the angle `theta` between the previous target vector at the previous `end_time` and the next target vector at the next `start_time`, both in the inertial frame. With `omega = max_slew_velocity_deg_per_s` and `alpha = max_slew_acceleration_deg_per_s2`:
+
+```text
+if theta <= omega^2 / alpha:
+  slew_time_s = 2 * sqrt(theta / alpha)
+else:
+  slew_time_s = 2 * (omega / alpha) + (theta - omega^2 / alpha) / omega
+
+required_gap_s = slew_time_s + settling_time_s
+```
+
+The required gap is reserved immediately before the later observation. The solution is invalid if the available idle gap is shorter than `required_gap_s`.
+
+Battery feasibility is simulated for each satellite over the full mission horizon using `resource_sample_step_s` grid points plus all action and retargeting-window boundaries. Each segment uses its midpoint to decide whether an observation, retargeting window, and sunlight are active. Battery starts at `resource_model.initial_battery_wh`, is capped after each segment at `battery_capacity_wh`, and invalidates the solution if it drops below zero. Segment load is:
+
+```text
+load_power_w = idle_power_w
+             + imaging_power_w if the segment midpoint is inside an observation
+             + slew_power_w if the segment midpoint is inside a retargeting window
+
+battery_next_wh = battery_wh + (charge_power_w - load_power_w) * duration_s / 3600
+```
+
+`charge_power_w` is `sunlit_charge_power_w` in sunlight and `0` in eclipse. `PC` is gross consumed watt-hours summed over satellites that pass the battery check.
+
+Task completion is binary. For each `task_id`, the earliest valid completing observation by `end_time` counts once; duplicates do not add credit. For valid solutions:
+
+```text
+CR  = completed_task_count / total_task_count
+WCR = sum(weight for completed tasks) / sum(weight for all tasks)
+TAT = mean(completion_time - release_time) over completed tasks, in seconds, or null if none complete
+PC  = gross consumed watt-hours
+```
+
+Validity is the hard gate before these metrics matter. Residual ambiguity remains only for borderline propagation, geometry, and battery cases at numerical tolerances; use the local helper for final checks rather than treating this prose as a replacement for full validation.
 
 ## Validation Notes
 

--- a/experiments/_fragments/prompts/regional_coverage/README.default.md
+++ b/experiments/_fragments/prompts/regional_coverage/README.default.md
@@ -11,7 +11,7 @@ You are given:
 
 Your job is to produce `solution.json`, a schedule of `strip_observation` actions that maximizes unique weighted regional coverage while remaining valid.
 
-This problem is modeled as roll-only pushbroom strip imaging. Each action chooses a satellite, a start time, a duration, and a signed off-nadir roll angle. From that, the validator propagates the orbit, traces the strip centerline and strip edges against the Earth, and computes which weighted grid samples are newly covered. You are not submitting arbitrary polygons or claiming your own swath geometry; you are selecting timed strip acquisitions in the benchmark's strip model.
+This problem is modeled as roll-only pushbroom strip imaging. Each action chooses a satellite, a start time, a duration, and a signed off-nadir roll angle. From that, the validator propagates the orbit, traces the strip centerline and strip edges against the Earth, and computes which weighted grid samples are newly covered. You are not submitting arbitrary polygons or claiming your own swath geometry; you are selecting timed strip acquisitions in the case's strip model.
 
 ## What Good Solutions Do
 
@@ -21,7 +21,7 @@ A strong solution should:
 - maximize covered weighted area across the regions
 - avoid wasteful energy use, excessive slew, and unnecessary action count when tie-breaking matters
 
-Repeatedly covering the same samples does not help much in the current canonical setting, so broad valid coverage is usually better than redundant passes.
+Repeatedly covering the same samples does not improve the coverage metrics, so broad valid coverage is usually better than redundant passes.
 
 ## Files In This Workspace
 
@@ -50,18 +50,74 @@ Each action should describe one strip observation with:
 
 Do not submit your own strip polygons, coverage claims, or access-window identifiers. Strip geometry and coverage are derived during validation.
 
-## Important Task Semantics
+## Modeling Contract
 
-- `start_time` must align to the public action grid.
-- `duration_s` must be a positive integer multiple of the public time step.
-- `roll_deg` is the signed strip-center off-nadir angle, so it controls where the pushbroom strip is pointed cross-track rather than naming a region directly.
-- The sensor is valid only when the strip's inner and outer edges both stay within the allowed off-nadir band implied by `roll_deg` and the sensor field of view.
-- Strip validity depends on the sensor off-nadir band, slew feasibility, battery feasibility, and successful Earth intersection of the strip rays.
-- The workspace does not expose precomputed access windows; visibility is derived during validation.
-- Coverage is computed on the weighted sample grid in `case/coverage_grid.json`, and repeated coverage of the same samples does not create equal new value.
-- Region polygons define where samples live, while the coverage grid defines what is actually scored.
-- If a region declares a minimum required coverage ratio, failing it makes the whole solution invalid.
-- Some cases also enforce per-orbit imaging duty limits in addition to battery limits, so very aggressive strip usage on one satellite may become invalid even if time windows appear open.
+Use SI units, degrees, and timezone-aware ISO 8601 timestamps. Let `H0 = manifest.json.horizon_start`, `H1 = manifest.json.horizon_end`, and `dt = manifest.json.time_step_s`. A `strip_observation` action is interpreted only from these solution fields: `type`, `satellite_id`, `start_time`, `duration_s`, and `roll_deg`. It must satisfy:
+
+```text
+type = "strip_observation"
+H0 <= start_time < start_time + duration_s <= H1
+(start_time - H0) / dt is an integer
+duration_s > 0
+duration_s / dt is an integer
+```
+
+If `manifest.json.scoring.max_actions_total` is present, the number of submitted actions may not exceed it. Actions with another `type` are not strip observations and do not create coverage; use only `strip_observation` entries.
+
+The satellite set is fixed by `case/satellites.yaml`; each `satellite_id` must reference one of those entries. Satellite TLEs are propagated with SGP4, Earth-fixed geometry uses WGS84, and the only attitude command is signed `roll_deg`, the cross-track off-nadir angle of the strip center. Positive and negative signs look to opposite sides of the ground track.
+
+For a satellite with `sensor.cross_track_fov_deg = f`, the commanded center roll is converted to strip-edge angles:
+
+```text
+theta_inner_deg = abs(roll_deg) - 0.5 * f
+theta_outer_deg = abs(roll_deg) + 0.5 * f
+```
+
+The action is sensor-valid only if:
+
+```text
+theta_inner_deg >= sensor.min_edge_off_nadir_deg
+theta_outer_deg <= sensor.max_edge_off_nadir_deg
+sensor.min_strip_duration_s <= duration_s <= sensor.max_strip_duration_s
+```
+
+Angle and duration comparisons allow only tiny numerical tolerance. The signed inner and outer edge rays use the same sign as `roll_deg`.
+
+Strip geometry is derived from the propagated satellite state at `start_time`, `end_time`, and every `coverage_sample_step_s` inside the action. At each sample, the center ray and both edge rays must intersect the WGS84 ellipsoid. Consecutive inner/outer edge hits form strip segment polygons in longitude/latitude. If any ray misses Earth, fewer than two sample times exist, or a segment has zero area, the action is invalid. Coverage is not accepted from submitted polygons or claims.
+
+Same-satellite strip intervals are half-open `[start_time, end_time)` and must not overlap. For consecutive strips on the same satellite, retargeting depends only on commanded roll change:
+
+```text
+theta = abs(current.roll_deg - previous.roll_deg)
+omega = agility.max_roll_rate_deg_per_s
+alpha = agility.max_roll_acceleration_deg_per_s2
+
+if theta <= omega^2 / alpha:
+  slew_time_s = 2 * sqrt(theta / alpha)
+else:
+  slew_time_s = theta / omega + omega / alpha
+
+required_gap_s = slew_time_s + agility.settling_time_s
+```
+
+The gap from the previous `end_time` to the current `start_time` must be at least `required_gap_s`.
+
+Power is simulated per satellite over the full horizon on the `coverage_sample_step_s` mesh plus action and retargeting-window boundaries. Segment midpoints decide active state. The battery starts at `power.initial_battery_wh`, is capped at `power.battery_capacity_wh`, and invalidates the solution if it becomes negative. Load is `idle_power_w`, plus `imaging_power_w` during strips, plus `slew_power_w` during retargeting; charge is `sunlit_charge_power_w` in sunlight and `0` in eclipse. If `power.imaging_duty_limit_s_per_orbit` is not null, then for each action boundary the total imaging time in the preceding one-orbit window, using the satellite TLE mean motion, must not exceed that limit.
+
+Coverage is scored only on `case/coverage_grid.json`. A sample contributes `weight_m2` to its region once if any valid strip segment covers its point; repeated coverage increments diagnostics but adds no score. For each `region_id`:
+
+```text
+region_coverage_ratio = covered_sample_weight_m2 / total_weight_m2
+```
+
+If the matching feature in `case/regions.geojson` declares `min_required_coverage_ratio`, then `region_coverage_ratio` below that threshold invalidates the whole solution. Reported aggregate metrics are:
+
+```text
+coverage_ratio = sum(properties.weight * region_coverage_ratio) / sum(properties.weight)
+weighted_coverage_ratio = sum(covered_sample_weight_m2 over all regions) / sum(total_weight_m2 over all regions)
+```
+
+The first metric is the region-weighted objective; the second is raw grid-weight coverage. Residual ambiguity is limited to numerical geometry near strip edges and the deterministic polygon/grid approximation; use the local helper for boundary cases.
 
 ## Validation Notes
 

--- a/experiments/_fragments/prompts/relay_constellation/README.default.md
+++ b/experiments/_fragments/prompts/relay_constellation/README.default.md
@@ -74,17 +74,77 @@ For inter-satellite links, also include:
 
 Do not submit end-to-end routes, latency claims, or service claims. Routing and service are derived during validation.
 
-## Important Task Semantics
+## Modeling Contract
 
-- Existing backbone satellites are immutable.
-- Added satellites must satisfy the orbit constraints in `case/manifest.json`.
-- Actions must stay on the public time grid and inside the mission horizon.
-- A `ground_link` action turns on one endpoint-to-satellite link; an `inter_satellite_link` action turns on one satellite-to-satellite link.
-- Links must be geometrically feasible when active.
-- The same physical link cannot be overbooked, and per-sample endpoint/satellite link limits are enforced during validation.
-- Ground endpoints are communication endpoints, not arbitrary intermediate relay nodes.
-- Service is sampled inside the demanded windows. A demand is served at a sample only if the active links create a feasible end-to-end path between the demanded endpoints at that time.
-- Latency is derived from total routed path length, so shorter useful paths matter only after basic service is achieved.
+Use SI units, degrees, and timezone-aware ISO 8601 timestamps. Let `H0 = manifest.json.horizon_start`, `H1 = manifest.json.horizon_end`, and `dt = manifest.json.routing_step_s`. Link actions and demanded windows are grid sampled:
+
+```text
+sample_index(t) = (t - H0) / dt
+```
+
+`start_time` and `end_time` must land exactly on this grid, and an action covers integer samples `start_index, ..., end_index - 1`. Therefore:
+
+```text
+H0 <= start_time < end_time <= H1
+start_index and end_index are integers
+```
+
+Backbone satellites in `case/network.json.backbone_satellites` are immutable GCRF Cartesian states at `manifest.json.epoch`. Entries in `added_satellites` use the same frame and units. Added `satellite_id` values must be unique, must not collide with backbone IDs, and `len(added_satellites) <= manifest.json.constraints.max_added_satellites`.
+
+For each added satellite, orbit validity is derived from `x_m`, `y_m`, `z_m`, `vx_m_s`, `vy_m_s`, and `vz_m_s`. With position norm `r`, speed `v`, Earth parameter `mu`, specific energy `epsilon = 0.5 * v^2 - mu / r`, semi-major axis `a = -mu / (2 * epsilon)`, eccentricity `e`, and inclination `i`, hard constraints are:
+
+```text
+epsilon < 0
+0 <= e < 1
+min_altitude_m <= a * (1 - e) - R_earth
+a * (1 + e) - R_earth <= max_altitude_m
+e <= max_eccentricity, if present
+min_inclination_deg <= i, if present
+i <= max_inclination_deg, if present
+```
+
+Propagation uses GCRF states from `manifest.json.epoch`, UTC time, deterministic Earth orientation, and a J2-only gravity model. Link geometry is evaluated in Earth-fixed coordinates at each covered routing sample.
+
+Actions activate physical links, not routes. A `ground_link` requires `endpoint_id` from `network.json.ground_endpoints` and any known `satellite_id` from the backbone or added set. An `inter_satellite_link` requires distinct known `satellite_id_1` and `satellite_id_2`. The physical identity of an inter-satellite link is unordered, so `A-B` and `B-A` are the same link. Unsupported `action_type`, unknown endpoints or satellites, off-grid intervals, zero-duration intervals, out-of-horizon intervals, and overlapping intervals on the same physical link are invalid.
+
+At every covered sample, a `ground_link` is feasible only if the endpoint-to-satellite elevation is at least the endpoint's `min_elevation_deg`; if `constraints.max_ground_range_m` exists, slant range must also be no greater than that value. An `inter_satellite_link` is feasible only if satellite separation is no greater than `constraints.max_isl_range_m` and the straight segment between satellites is clear of Earth. The feasible link distance at that sample is retained for routing latency.
+
+At each routing sample, active feasible links must also satisfy:
+
+```text
+active links incident to any satellite <= max_links_per_satellite
+active links incident to any ground endpoint <= max_links_per_endpoint
+```
+
+Ground endpoints are terminal endpoints only. In a route for one demand, a ground endpoint may appear only as that demand's source or destination, never as an intermediate transit node.
+
+Service is sampled on the same routing grid. For each demanded window in `case/demands.json.demanded_windows`, requested samples are `start_index, ..., end_index - 1`. A demand sample is served if the active feasible graph contains an allocated path from `source_endpoint_id` to `destination_endpoint_id`. Do not submit routes, service assignments, or latency claims.
+
+Each active physical link has unit capacity per sample and can be allocated to at most one demand route. With one active demand, the chosen path is the shortest feasible path. With multiple active demands, allocation maximizes total served demand `weight`, then minimizes total latency, then uses deterministic path ordering as a tie-breaker. For a served sample:
+
+```text
+latency_ms = 1000 * total_path_length_m / 299792458
+```
+
+Unserved samples reduce service fractions but do not add artificial latency.
+
+For each demand:
+
+```text
+demand_service_fraction = served_sample_count / requested_sample_count
+```
+
+Reported metrics are:
+
+```text
+service_fraction = sum(weight * demand_service_fraction) / sum(weight)
+worst_demand_service_fraction = min(demand_service_fraction over demands)
+mean_latency_ms = mean latency over served samples, or null if none are served
+latency_p95_ms = 95th percentile latency over served samples, or null if none are served
+num_added_satellites = len(added_satellites)
+```
+
+Validity is required before service metrics are meaningful. Residual ambiguity is limited to numerical orbit/link geometry at hard boundaries; check close range, elevation, and Earth-blockage cases with the local helper.
 
 ## Validation Notes
 

--- a/experiments/_fragments/prompts/revisit_constellation/README.default.md
+++ b/experiments/_fragments/prompts/revisit_constellation/README.default.md
@@ -61,15 +61,81 @@ Each observation action should reference:
 - `start`
 - `end`
 
-## Important Task Semantics
+## Modeling Contract
 
-- You are choosing the initial satellite states, not redesigning the satellite hardware model.
-- The number of satellites cannot exceed the case limit.
-- Initial states must satisfy the orbit constraints.
-- The visibility model is intentionally simple: a target is observable when its line of sight stays inside the sensor's nadir-centered pointing cone and range/elevation bounds.
-- Observation geometry, power feasibility, and required maneuver gaps are enforced during validation.
-- Revisit quality is computed from the midpoints of successful observations, with mission start and mission end treated as boundary times when gaps are measured.
-- Poor revisit performance does not automatically invalidate the solution, but invalid geometry, timing, or resource use still does.
+Use SI units, degrees, and timezone-aware ISO 8601 timestamps. Let `H0 = case/mission.json.horizon_start` and `H1 = case/mission.json.horizon_end`. There is no public action grid, but every timestamp must include a timezone. Observation actions must satisfy:
+
+```text
+action_type = "observation"
+H0 <= start < end <= H1
+end - start >= target.min_duration_sec
+```
+
+Each `satellites` entry defines one initial state at `H0` using GCRF Cartesian `x_m`, `y_m`, `z_m`, `vx_m_s`, `vy_m_s`, and `vz_m_s`. `satellite_id` values must be unique, actions may reference only submitted satellites, and `len(satellites) <= case/assets.json.max_num_satellites`. All submitted satellites share the hardware limits in `assets.json.satellite_model`; do not submit per-satellite sensor, power, or attitude changes.
+
+Every submitted state must be a bound closed Earth orbit and must satisfy both instantaneous and orbital-altitude bounds from `satellite_model.min_altitude_m` and `satellite_model.max_altitude_m`. With Earth gravitational parameter `mu`, position norm `r`, speed `v`, specific energy `epsilon = 0.5 * v^2 - mu / r`, semi-major axis `a = -mu / (2 * epsilon)`, and eccentricity `e`, validity requires:
+
+```text
+epsilon < 0
+0 <= e < 1
+min_altitude_m <= r - R_earth <= max_altitude_m
+min_altitude_m <= a * (1 - e) - R_earth
+a * (1 + e) - R_earth <= max_altitude_m
+```
+
+Propagation uses the submitted GCRF state at `H0`, UTC time, a deterministic Earth orientation convention, and a J2-only Earth gravity model. Geometry checks use Earth-fixed target positions converted from target `longitude_deg`, `latitude_deg`, and `altitude_m`.
+
+Observation geometry is sampled every 10 seconds from `start` up to but not including `end`. At each sampled instant, the target must satisfy:
+
+```text
+elevation_deg >= target.min_elevation_deg
+slant_range_m <= target.max_slant_range_m
+slant_range_m <= satellite_model.sensor.max_range_m
+off_nadir_deg <= satellite_model.sensor.max_off_nadir_angle_deg
+```
+
+Same-satellite actions are half-open `[start, end)` and must not overlap. For consecutive observations on the same satellite, let `theta` be the inertial angle between the previous target vector at the previous observation midpoint and the current target vector at the current observation midpoint. With `omega = max_slew_velocity_deg_per_sec` and `alpha = max_slew_acceleration_deg_per_sec2` from `satellite_model.attitude_model`:
+
+```text
+if theta <= omega^2 / alpha:
+  slew_time_sec = 2 * sqrt(theta / alpha)
+else:
+  slew_time_sec = 2 * (omega / alpha) + (theta - omega^2 / alpha) / omega
+
+required_gap_sec = slew_time_sec + settling_time_sec
+```
+
+The gap from the previous `end` to the current `start` must be at least `required_gap_sec`. The reserved retargeting window immediately before the current observation must not overlap any other action.
+
+Battery feasibility is simulated for each submitted satellite over the full horizon at action boundaries, reserved retargeting-window boundaries, and 30-second grid points. Segment midpoints decide active observation, active retargeting, and sunlight. Battery starts at `resource_model.initial_battery_wh`, is capped at `resource_model.battery_capacity_wh`, and invalidates the solution if it drops below zero:
+
+```text
+discharge_w = idle_discharge_rate_w
+            + obs_discharge_rate_w if inside an observation
+            + maneuver_discharge_rate_w if inside a retargeting window
+
+battery_next_wh = battery_wh + (charge_w - discharge_w) * duration_sec / 3600
+```
+
+`charge_w` is `sunlight_charge_rate_w` in sunlight and `0` in eclipse.
+
+Revisit scoring uses only successful observation midpoints. For each target, duplicate midpoint instants count once. Let the sorted time list be `[H0, midpoint_1, ..., midpoint_n, H1]`; if `n = 0`, the only gap is `H1 - H0`. For each target:
+
+```text
+gaps_hours = consecutive differences in that list, in hours
+max_revisit_gap_hours = max(gaps_hours)
+mean_revisit_gap_hours = mean(gaps_hours)
+observation_count = n
+target_capped_gap = max(max_revisit_gap_hours, expected_revisit_period_hours)
+```
+
+The primary metric is:
+
+```text
+capped_max_revisit_gap_hours = max(target_capped_gap over targets)
+```
+
+Lower is better; `num_satellites` is a secondary metric after revisit quality. Poor revisit gaps do not invalidate an otherwise feasible solution. Residual ambiguity remains around numerical orbit and visibility boundaries; validate borderline states and contacts with the local helper.
 
 ## Validation Notes
 

--- a/experiments/_fragments/prompts/satnet/README.default.md
+++ b/experiments/_fragments/prompts/satnet/README.default.md
@@ -49,17 +49,76 @@ Each array element should describe one scheduled track with:
 
 The verifier checks timing consistency between setup, transmission, and teardown, so those fields must align exactly with the request parameters.
 
-## Important Task Semantics
+## Modeling Contract
 
-- `START_TIME -> TRACKING_ON -> TRACKING_OFF -> END_TIME` is a strict timing chain: setup occupies the first segment, actual communication occupies the middle segment, and teardown occupies the last segment.
-- A scheduled transmission must fit fully inside at least one valid view period for the chosen antenna.
-- Tracks on the same antenna cannot overlap, including setup and teardown time.
-- Tracks cannot overlap with maintenance windows on the same antenna.
-- `TRACK_ID` must refer to a real request.
-- The chosen `RESOURCE` must be compatible with that request.
-- Some requests allow arrayed resources, so the resource key must match the request's allowed resource combinations rather than an arbitrary antenna label.
-- Communication hours come only from `TRACKING_ON` to `TRACKING_OFF`; setup and teardown help validity but add no direct objective value.
-- For very long requests, the verifier allows a single scheduled track to satisfy a capped per-track minimum of 4 hours instead of the full original minimum duration.
+Use Unix timestamps in integer seconds. `case/problem.json` is a JSON array of requests for one week, and `case/maintenance.csv` contains downtime windows for the same week. Request fields `duration` and `duration_min` are in hours; `setup_time` and `teardown_time` are in minutes. Solution rows use absolute Unix seconds.
+
+Each solution row is one antenna allocation with fields `RESOURCE`, `SC`, `START_TIME`, `TRACKING_ON`, `TRACKING_OFF`, `END_TIME`, and `TRACK_ID`. `TRACK_ID` must equal a request `track_id` in `problem.json`. `RESOURCE` must be an antenna ID used by the case and must appear as a component of at least one resource-combination key in that request's `resource_vp_dict`. `SC` must parse as an integer, but hard validity is driven by `TRACK_ID`, resources, timing, view periods, maintenance, and overlaps.
+
+For the referenced request, timing must satisfy exactly:
+
+```text
+TRACKING_ON = START_TIME + 60 * setup_time
+END_TIME = TRACKING_OFF + 60 * teardown_time
+```
+
+Setup and teardown consume antenna time but do not count as communication time.
+
+Rows with the same `TRACK_ID`, `START_TIME`, `TRACKING_ON`, `TRACKING_OFF`, and `END_TIME` are grouped as one logical track. A single-antenna logical track has one row. An arrayed logical track has multiple rows, one per antenna. The antenna names in the group are sorted and joined with `_` to form the combination key, such as `DSS-34_DSS-35`; that key must exist in the request's `resource_vp_dict`. Do not submit the joined key as one row's `RESOURCE`.
+
+View periods are the hard visibility windows. For each logical track, the communication interval must fit inside at least one view-period interval for the chosen combination key:
+
+```text
+view_period["TRX ON"] <= TRACKING_ON <= TRACKING_OFF <= view_period["TRX OFF"]
+```
+
+`RISE`/`SET` may exist in `problem.json`, but normalized `TRX ON`/`TRX OFF` bounds are the operative communication bounds. Request-level `time_window_start` and `time_window_end` are broader request metadata and are not the hard containment interval when resource view periods are present.
+
+Antenna exclusivity uses half-open occupied intervals:
+
+```text
+[START_TIME, END_TIME)
+```
+
+Two rows on the same `RESOURCE` may not overlap, and a row may not overlap any `maintenance.csv` interval `[starttime, endtime)` for that antenna. These checks include setup and teardown.
+
+Each logical track must meet a per-track communication minimum:
+
+```text
+track_duration_s = TRACKING_OFF - TRACKING_ON
+requested_s = int(duration * 3600)
+minimum_s = int(duration_min * 3600)
+
+if requested_s >= 28800:
+  per_track_min_s = min(minimum_s, 14400)
+else:
+  per_track_min_s = minimum_s
+
+track_duration_s >= per_track_min_s
+```
+
+Request satisfaction is stricter than per-track validity. For each `TRACK_ID`, communication time is summed across logical tracks, counted once per logical track even if arrayed, then capped at `requested_s`:
+
+```text
+allocated_s = min(sum(TRACKING_OFF - TRACKING_ON over logical tracks), requested_s)
+satisfied if allocated_s >= minimum_s
+```
+
+The main communication-hours report is antenna-time:
+
+```text
+total_hours = sum((TRACKING_OFF - TRACKING_ON) / 3600 over solution rows)
+```
+
+Arrayed contacts therefore add one row's communication time per participating antenna. Fairness metrics group requests by `subject`. For each subject:
+
+```text
+subject_requested_s = sum(int(duration * 3600) for requests with that subject)
+subject_allocated_s = sum(allocated_s for those requests)
+U_i = max(subject_requested_s - subject_allocated_s, 0) / subject_requested_s
+```
+
+`U_max = max(U_i)`, and `U_rms = sqrt(mean(U_i^2))`. `n_satisfied_requests` counts requests whose capped allocation reaches `duration_min`. Residual ambiguity is mostly inherited from integer truncation of hour/minute request fields; when in doubt, use the equations above and then confirm with the local helper.
 
 ## Validation Notes
 

--- a/experiments/_fragments/prompts/spot5/README.default.md
+++ b/experiments/_fragments/prompts/spot5/README.default.md
@@ -52,15 +52,45 @@ Allowed assignment values are:
 
 Header mismatches in `claimed_profit` or `claimed_weight` may produce warnings rather than immediate invalidity, but the assignment vector itself must still satisfy all domain, conflict, and capacity rules.
 
-## Important Task Semantics
+## Modeling Contract
 
-- If a photograph is not selected, assign `0`.
-- For selected photographs, the chosen value must belong to that variable’s allowed domain.
-- Values `1`, `2`, and `3` represent mono-camera choices, while `13` is the special dual-camera choice used only when that variable's domain allows it.
-- Binary and ternary forbidden tuples must not be activated.
-- A binary or ternary forbidden tuple matters only when all participating photographs are selected with exactly that value combination.
-- Some larger instances also enforce a memory-capacity limit of `200` after normalization from the per-value recorder-consumption numbers in the instance.
-- Single-orbit instances effectively have zero memory usage, but the logical conflict constraints still matter.
+This is an assignment-and-selection problem over the variables in the `.spot` file. The first non-empty line is `n_variables`. The next `n_variables` lines define candidate photographs in file order, and `assignments[i]` is the assignment for the `i`th variable. Your `assignments` array must contain exactly `n_variables` integers.
+
+Assignment `0` rejects the photograph. A nonzero assignment selects it and must be in that variable's domain. Values `1`, `2`, and `3` are mono-camera choices. Value `13` is the dual-camera choice and is legal only when the variable's domain explicitly contains `13`.
+
+Each variable line is interpreted as:
+
+```text
+var_id profit domain_size value_1 consumption_1 ... value_domain_size consumption_domain_size [ignored extra fields...]
+```
+
+Only the first `domain_size` value/consumption pairs define the allowed domain and per-value recorder consumption. Later fields on the line are ignored. Profit is counted once for every selected variable, regardless of which allowed nonzero value is chosen:
+
+```text
+computed_profit = sum(profit_i for i where assignments[i] != 0)
+```
+
+After the variable block, the file gives `n_constraints`, followed by binary or ternary forbidden-tuple constraints:
+
+```text
+arity var_id_1 ... var_id_arity forbidden_tuple_values...
+```
+
+For `arity = 2`, forbidden values are read as pairs; for `arity = 3`, they are read as triples. Constraint `var_id` values index the assignment vector. A forbidden tuple applies only when every involved assignment is nonzero and the tuple exactly matches the involved assignment values in the listed order. If any involved assignment is `0`, that constraint is satisfied.
+
+Single-orbit cases have no active recorder-capacity limit and their computed weight is `0`. Multi-orbit cases are exactly `1021`, `1401`, `1403`, `1405`, `1502`, `1504`, and `1506`. For those cases, the capacity line in the `.spot` file is ignored and the hard capacity is fixed at `200`.
+
+For a selected variable in a multi-orbit case, use the recorder consumption attached to the chosen assignment value:
+
+```text
+normalized_weight_i = round(recorder_consumption_i_value / 451)
+computed_weight = sum(normalized_weight_i for selected variables)
+computed_weight <= 200
+```
+
+Different values for the same variable may have different consumption. Hard invalidity comes from assignment-count mismatch, assignment outside a variable domain, any violated forbidden tuple, or multi-orbit `computed_weight > 200`.
+
+`claimed_profit`, `claimed_weight`, `n_candidates`, and `n_selected` are bookkeeping fields. The result recomputes profit, weight, and selected count from `assignments`. Mismatched `claimed_profit`, `claimed_weight`, `n_candidates`, or `n_selected` produce warnings, not invalidity, as long as the assignment vector itself is valid. Residual ambiguity is minimal; the only non-obvious behavior is that normalized weights are rounded to the nearest integer with ties to even, so confirm close capacity cases with the local helper.
 
 ## Validation Notes
 

--- a/experiments/_fragments/prompts/stereo_imaging/README.default.md
+++ b/experiments/_fragments/prompts/stereo_imaging/README.default.md
@@ -10,7 +10,7 @@ You are given:
 
 Your job is to produce `solution.json`, a schedule of observation actions that creates as many valid stereo or tri-stereo products as possible with good geometry and quality.
 
-This problem is modeled as scheduling raw optical observations, not explicitly choosing image pairs. You submit individual observation actions with boresight steering angles, and the validator later decides which combinations form valid stereo or tri-stereo products for the same target. In other words, the solution should create a set of observations that can be paired or grouped well under the benchmark's stereo geometry rules.
+This problem is modeled as scheduling raw optical observations, not explicitly choosing image pairs. You submit individual observation actions with boresight steering angles, and the validator later decides which combinations form valid stereo or tri-stereo products for the same target. In other words, the solution should create a set of observations that can be paired or grouped well under the case's stereo geometry rules.
 
 ## What Good Solutions Do
 
@@ -48,19 +48,105 @@ Each action should describe one observation with:
 - `off_nadir_along_deg`
 - `off_nadir_across_deg`
 
-The output should schedule raw observations only. Stereo pairing, tri-stereo grouping, overlap checks, convergence checks, and quality evaluation are derived during validation.
+The output should schedule raw observations only. Stereo pairing, tri-stereo grouping, overlap checks, convergence checks, and quality scoring are derived during validation.
 
-## Important Task Semantics
+## Modeling Contract
 
-- Each action chooses one target, one time interval, and two boresight steering angles in the satellite local frame.
-- The underlying footprint model is a pushbroom strip approximation. Target access, overlap, and pixel-scale quality are derived from propagated geometry rather than from solver-submitted footprints.
-- Two observations only count as a valid stereo pair when they satisfy the shared-target, shared-satellite, access-window, overlap, convergence, and pixel-scale conditions.
-- Tri-stereo needs three compatible observations and a near-nadir anchor.
-- Same-pass consistency matters: by default the products are expected to come from the same satellite and the same continuous access interval.
-- Same-satellite overlap and insufficient slew-plus-settle gaps invalidate the solution.
-- Observation geometry and solar-elevation constraints are enforced during validation.
-- Coverage comes from valid stereo or tri-stereo products, not from single isolated observations alone.
-- Quality depends on the benchmark's geometry heuristics, especially overlap, convergence angle, and pixel-scale compatibility, so it is usually better to create a few strong compatible looks than many isolated ones.
+Use SI units, degrees, and timezone-aware ISO 8601 timestamps. Naive timestamps are rejected; a trailing `Z` is the safest UTC form. `case/mission.yaml` contains a top-level `mission` mapping. Actions whose `type` is not `"observation"` are ignored; submit only observation actions. Each interpreted action must reference `satellite_id` from `case/satellites.yaml`, `target_id` from `case/targets.yaml`, and satisfy:
+
+```text
+mission.horizon_start <= start_time < end_time <= mission.horizon_end
+min_obs_duration_s <= end_time - start_time <= max_obs_duration_s
+```
+
+The satellite set is fixed by TLEs in `case/satellites.yaml`; you choose only raw observation windows and two boresight steering angles. `off_nadir_along_deg` tilts along the flight direction and `off_nadir_across_deg` tilts cross-track in the satellite local frame. The boresight vector is proportional to:
+
+```text
+nadir_hat
++ tan(off_nadir_along_deg) * along_hat
++ tan(off_nadir_across_deg) * across_hat
+```
+
+with tangent inputs in radians. The combined tilt compared to `max_off_nadir_deg` is:
+
+```text
+combined_deg = degrees(atan(sqrt(tan(along_rad)^2 + tan(across_rad)^2)))
+combined_deg <= max_off_nadir_deg
+```
+
+At the observation midpoint, the commanded boresight ray must intersect the WGS84 ellipsoid. Effective pixel scale is:
+
+```text
+effective_pixel_scale_m = slant_range_m * pixel_ifov_deg * pi / 180
+```
+
+Target access is derived from the target center at `longitude_deg`, `latitude_deg`, and `elevation_ref_m`; it is not a submitted claim. The full observation interval must lie inside one continuous access interval for the same satellite-target pair. Access is sampled at:
+
+```text
+access_step_s = max(0.25, min(1.0, min_obs_duration_s / 2))
+```
+
+including both action boundaries. At every sampled instant, access requires clear line of sight to the target center, target-center off-nadir no greater than `max_off_nadir_deg`, and target solar elevation at least `mission.validity_thresholds.min_solar_elevation_deg`.
+
+Same-satellite observation intervals are half-open `[start_time, end_time)` and must not overlap. For consecutive same-satellite observations, let `theta` be the angle between the commanded boresight vector at the previous `end_time` and the commanded boresight vector at the next `start_time`. With `omega = max_slew_velocity_deg_per_s` and `alpha = max_slew_acceleration_deg_per_s2`:
+
+```text
+if theta <= omega^2 / alpha:
+  slew_time_s = 2 * sqrt(theta / alpha)
+else:
+  slew_time_s = theta / omega + omega / alpha
+
+required_gap_s = slew_time_s + settling_time_s
+```
+
+The gap between observations must be at least `required_gap_s`.
+
+Validated observations are grouped by common `target_id`, common `satellite_id`, and membership in the same continuous access interval for that satellite-target pair. The current mission files set cross-satellite and cross-date stereo aside, so useful products are same-satellite, same-pass groups. For a pair, convergence angle `gamma_deg` is the angle at the target between the two target-to-satellite midpoint directions. Pixel scale ratio is:
+
+```text
+pixel_scale_ratio = max(scale_i, scale_j) / min(scale_i, scale_j)
+```
+
+A valid stereo pair requires:
+
+```text
+overlap_fraction >= min_overlap_fraction
+min_convergence_deg <= gamma_deg <= max_convergence_deg
+pixel_scale_ratio <= max_pixel_scale_ratio
+```
+
+A valid tri-stereo set requires three observations in the same group, common overlap at least `min_overlap_fraction`, at least two valid constituent pairs under the same pair rules, and at least one observation with `boresight_off_nadir_deg <= near_nadir_anchor_max_off_nadir_deg`.
+
+Overlap is a deterministic approximation inside each target's circular AOI of radius `aoi_radius_m`. Each observation footprint is a pushbroom strip in the target-centered local tangent plane. The strip centerline is sampled every 8 seconds between observation start and end using the commanded boresight, and half-width is:
+
+```text
+strip_half_width_m = slant_range_m * tan(radians(0.5 * cross_track_pixels * pixel_ifov_deg))
+```
+
+Pair overlap uses 100 deterministic Monte Carlo samples; tri common overlap uses 100 samples; pair checks inside tri-product scoring use 80 samples. Do not submit footprints, overlap fractions, product choices, or quality scores.
+
+Coverage comes only from valid stereo or tri-stereo products. For each target, the retained score is the best valid product quality. Pair quality is:
+
+```text
+Q_pair = pair_weights.geometry * Q_geom
+       + pair_weights.overlap * min(1, overlap_fraction / 0.95)
+       + pair_weights.resolution * max(0, 1 - (pixel_scale_ratio - 1) / 0.5)
+```
+
+`Q_geom` is best when `gamma_deg` falls in the scene-type preference band for `scene_type` and decays outside it. Tri-stereo quality is:
+
+```text
+Q_tri = min(1, best_valid_pair_quality + tri_stereo_bonus_by_scene[scene_type] * R)
+```
+
+where `R` is `0.6` for having at least two valid pairs plus `0.4` for a near-nadir anchor, capped at `1`. Reported metrics are:
+
+```text
+coverage_ratio = number of targets with at least one valid product / number of targets
+normalized_quality = sum(best target product quality over all targets) / number of targets
+```
+
+Residual ambiguity is the intentional deterministic overlap approximation: exact continuous AOI overlap is not the scored quantity, so use the local helper to check close overlap-threshold cases.
 
 ## Validation Notes
 

--- a/experiments/main_agentic/README.md
+++ b/experiments/main_agentic/README.md
@@ -171,6 +171,44 @@ External verification is performed through benchmark-owned verifier executable e
 The agent workspace may include an opaque local verifier helper assembled from `experiments/_fragments/opaque_verifiers/artifacts/`, but official evaluation still runs through the benchmark-owned verifier CLIs outside the workspace.
 Most verifiers emit JSON; SatNet and SPOT5 currently emit text CLI reports, so the runner parses their verbose output into the same `run.json` verifier section used by aggregation.
 
+## Smoke Checks
+
+Before running a matrix after verifier-source or prompt-contract changes, refresh or validate the opaque helpers:
+
+```bash
+uv run python experiments/_fragments/opaque_verifiers/build.py
+```
+
+That command rebuilds stale artifacts and reruns each artifact's smoke case inside the base runtime image. For workspace-inspection smoke checks, interactive mode is the most direct path because it leaves the assembled workspace in `.runtime/interactive_workspaces/`:
+
+```bash
+uv run python experiments/main_agentic/run.py \
+  --interactive \
+  --benchmark aeossp_standard \
+  --harness codex \
+  --split test \
+  --case case_0001
+```
+
+The same check should be repeated for a single-file verifier profile, for example:
+
+```bash
+uv run python experiments/main_agentic/run.py \
+  --interactive \
+  --benchmark satnet \
+  --harness codex \
+  --split test \
+  --case W10_2018
+```
+
+Confirm the workspace contains `README.md`, `case/`, `verifier`, `AGENTS.md`, and no readable verifier source copied from `benchmarks/`. The corresponding `run.json` assembly records should point at `experiments/_fragments/opaque_verifiers/artifacts/<benchmark>/verifier` and at the harness-specific Brahe skill target. Batch smoke results can then be aggregated with:
+
+```bash
+uv run python experiments/main_agentic/aggregate.py
+```
+
+This is not full-matrix validation. Remaining risks after a smoke pass include platform-specific binary behavior, less common verifier import/data-path cases beyond the manifest smoke cases, and future README drift if verifier semantics change. When verifier behavior changes, update the benchmark-facing `README.default.md` fragment in the same pass so it stays as precise as the code.
+
 ## Aggregation
 
 Summarize completed batch artifacts:

--- a/experiments/main_agentic/README.md
+++ b/experiments/main_agentic/README.md
@@ -120,7 +120,7 @@ Each concrete run is assembled from benchmark and harness profiles.
 
 Benchmark profiles own:
 
-- case and verifier workspace assembly
+- case assembly and local verifier-helper exposure
 - benchmark-facing `README.md` and `PROMPT.md` fragments
 - benchmark-native aggregation metadata
 
@@ -168,6 +168,7 @@ Interactive workspaces live under:
 Every concrete run writes one `run.json`. Aggregation reads `run.json` artifacts, not raw session logs.
 
 External verification is performed through benchmark-owned verifier executable entrypoints. `main_agentic` does not import benchmark-internal verifier APIs.
+The agent workspace may include an opaque local verifier helper assembled from `experiments/_fragments/opaque_verifiers/artifacts/`, but official evaluation still runs through the benchmark-owned verifier CLIs outside the workspace.
 Most verifiers emit JSON; SatNet and SPOT5 currently emit text CLI reports, so the runner parses their verbose output into the same `run.json` verifier section used by aggregation.
 
 ## Aggregation

--- a/experiments/main_agentic/benchmarks/aeossp_standard.yaml
+++ b/experiments/main_agentic/benchmarks/aeossp_standard.yaml
@@ -6,7 +6,7 @@ assemble:
     render: true
   - source: benchmarks/{benchmark}/dataset/cases/{split}/{case_id}
     target: /app/workspace/case
-  - source: benchmarks/{benchmark}/verifier
+  - source: experiments/_fragments/opaque_verifiers/artifacts/{benchmark}/verifier
     target: /app/workspace/verifier
   - source: experiments/_fragments/prompts/aeossp_standard/PROMPT.default.md
     target: /home/korolev/PROMPT.md

--- a/experiments/main_agentic/benchmarks/regional_coverage.yaml
+++ b/experiments/main_agentic/benchmarks/regional_coverage.yaml
@@ -6,8 +6,8 @@ assemble:
     render: true
   - source: benchmarks/{benchmark}/dataset/cases/{split}/{case_id}
     target: /app/workspace/case
-  - source: benchmarks/{benchmark}/verifier.py
-    target: /app/workspace/verifier.py
+  - source: experiments/_fragments/opaque_verifiers/artifacts/{benchmark}/verifier
+    target: /app/workspace/verifier
   - source: experiments/_fragments/prompts/regional_coverage/PROMPT.default.md
     target: /home/korolev/PROMPT.md
     render: true

--- a/experiments/main_agentic/benchmarks/relay_constellation.yaml
+++ b/experiments/main_agentic/benchmarks/relay_constellation.yaml
@@ -6,7 +6,7 @@ assemble:
     render: true
   - source: benchmarks/{benchmark}/dataset/cases/{split}/{case_id}
     target: /app/workspace/case
-  - source: benchmarks/{benchmark}/verifier
+  - source: experiments/_fragments/opaque_verifiers/artifacts/{benchmark}/verifier
     target: /app/workspace/verifier
   - source: experiments/_fragments/prompts/relay_constellation/PROMPT.default.md
     target: /home/korolev/PROMPT.md

--- a/experiments/main_agentic/benchmarks/revisit_constellation.yaml
+++ b/experiments/main_agentic/benchmarks/revisit_constellation.yaml
@@ -6,7 +6,7 @@ assemble:
     render: true
   - source: benchmarks/{benchmark}/dataset/cases/{split}/{case_id}
     target: /app/workspace/case
-  - source: benchmarks/{benchmark}/verifier
+  - source: experiments/_fragments/opaque_verifiers/artifacts/{benchmark}/verifier
     target: /app/workspace/verifier
   - source: experiments/_fragments/prompts/revisit_constellation/PROMPT.default.md
     target: /home/korolev/PROMPT.md

--- a/experiments/main_agentic/benchmarks/satnet.yaml
+++ b/experiments/main_agentic/benchmarks/satnet.yaml
@@ -6,8 +6,8 @@ assemble:
     render: true
   - source: benchmarks/{benchmark}/dataset/cases/{split}/{case_id}
     target: /app/workspace/case
-  - source: benchmarks/{benchmark}/verifier.py
-    target: /app/workspace/verifier.py
+  - source: experiments/_fragments/opaque_verifiers/artifacts/{benchmark}/verifier
+    target: /app/workspace/verifier
   - source: experiments/_fragments/prompts/satnet/PROMPT.default.md
     target: /home/korolev/PROMPT.md
     render: true

--- a/experiments/main_agentic/benchmarks/spot5.yaml
+++ b/experiments/main_agentic/benchmarks/spot5.yaml
@@ -6,8 +6,8 @@ assemble:
     render: true
   - source: benchmarks/{benchmark}/dataset/cases/{split}/{case_id}
     target: /app/workspace/case
-  - source: benchmarks/{benchmark}/verifier.py
-    target: /app/workspace/verifier.py
+  - source: experiments/_fragments/opaque_verifiers/artifacts/{benchmark}/verifier
+    target: /app/workspace/verifier
   - source: experiments/_fragments/prompts/spot5/PROMPT.default.md
     target: /home/korolev/PROMPT.md
     render: true

--- a/experiments/main_agentic/benchmarks/stereo_imaging.yaml
+++ b/experiments/main_agentic/benchmarks/stereo_imaging.yaml
@@ -6,7 +6,7 @@ assemble:
     render: true
   - source: benchmarks/{benchmark}/dataset/cases/{split}/{case_id}
     target: /app/workspace/case
-  - source: benchmarks/{benchmark}/verifier
+  - source: experiments/_fragments/opaque_verifiers/artifacts/{benchmark}/verifier
     target: /app/workspace/verifier
   - source: experiments/_fragments/prompts/stereo_imaging/PROMPT.default.md
     target: /home/korolev/PROMPT.md

--- a/experiments/main_agentic/harnesses/claude_code.yaml
+++ b/experiments/main_agentic/harnesses/claude_code.yaml
@@ -5,6 +5,8 @@ assemble:
   - source: experiments/_fragments/configs/claude_code/.claude
     target: /home/korolev/.claude
     example: experiments/_fragments/configs/claude_code/.claude.example
+  - source: .agents/skills/brahe
+    target: /home/korolev/.claude/skills/brahe
 
 commands:
   headless_shell_command: >-
@@ -25,3 +27,4 @@ forward_env_keys: []
 notes:
   - Claude Code stores additional per-session state under /home/korolev/.claude/session-env and /home/korolev/.claude/sessions; collect more later if a run needs deeper replay artifacts.
   - Provider and auth details should stay in the real settings file or environment rather than in tracked configs.
+  - The Brahe skill is assembled into /home/korolev/.claude/skills/brahe for native skill discovery.

--- a/experiments/main_agentic/harnesses/codex.yaml
+++ b/experiments/main_agentic/harnesses/codex.yaml
@@ -5,6 +5,8 @@ assemble:
   - source: experiments/_fragments/configs/codex/.codex
     target: /home/korolev/.codex
     example: experiments/_fragments/configs/codex/.codex.example
+  - source: .agents/skills/brahe
+    target: /home/korolev/.codex/skills/brahe
 
 commands:
   headless_shell_command: >-
@@ -29,3 +31,4 @@ forward_env_keys:
 notes:
   - Codex keeps additional state in sqlite files under /home/korolev/.codex; keep those out of default collected artifacts unless a follow-up phase needs lower-level debugging.
   - The dangerous bypass flag is intentional here because the outer Docker runtime is the actual sandbox boundary for this family.
+  - The Brahe skill is assembled into /home/korolev/.codex/skills/brahe for native skill discovery.

--- a/experiments/main_agentic/harnesses/gemini_cli.yaml
+++ b/experiments/main_agentic/harnesses/gemini_cli.yaml
@@ -5,6 +5,8 @@ assemble:
   - source: experiments/_fragments/configs/gemini_cli/.gemini
     target: /home/korolev/.gemini
     example: experiments/_fragments/configs/gemini_cli/.gemini.example
+  - source: .agents/skills/brahe
+    target: /home/korolev/.gemini/skills/brahe
 
 commands:
   headless_shell_command: >-
@@ -27,3 +29,4 @@ notes:
   - Gemini CLI spreads state across /home/korolev/.gemini/tmp, /home/korolev/.gemini/history, and /home/korolev/.gemini/antigravity; this profile collects the most run-relevant parts without copying the browser-profile cache.
   - Headless Gemini runs should pass --yolo explicitly; unlike Kimi print mode, Gemini headless mode does not imply blanket approval by default.
   - Gemini auth usually lives in environment variables or cached Google login state rather than in settings.json. If OAuth is used, the runner will likely need to mount more than settings.json.
+  - The Brahe skill is assembled into /home/korolev/.gemini/skills/brahe for native skill discovery.

--- a/experiments/main_agentic/harnesses/kimi_cli.yaml
+++ b/experiments/main_agentic/harnesses/kimi_cli.yaml
@@ -5,6 +5,8 @@ assemble:
   - source: experiments/_fragments/configs/kimi_cli/.kimi
     target: /home/korolev/.kimi
     example: experiments/_fragments/configs/kimi_cli/.kimi.example
+  - source: .agents/skills/brahe
+    target: /home/korolev/.kimi/skills/brahe
 
 commands:
   headless_shell_command: >-
@@ -25,3 +27,4 @@ forward_env_keys: []
 notes:
   - Kimi print mode is the canonical non-interactive path and implicitly enables auto-approval.
   - Kimi also keeps credential material under /home/korolev/.kimi/credentials; do not collect that by default.
+  - The Brahe skill is assembled into /home/korolev/.kimi/skills/brahe for native skill discovery.

--- a/experiments/main_agentic/harnesses/opencode_glm.yaml
+++ b/experiments/main_agentic/harnesses/opencode_glm.yaml
@@ -5,6 +5,8 @@ assemble:
   - source: experiments/_fragments/configs/opencode_glm/opencode
     target: /home/korolev/.config/opencode
     example: experiments/_fragments/configs/opencode_glm/opencode.example
+  - source: .agents/skills/brahe
+    target: /home/korolev/.config/opencode/skills/brahe
 
 commands:
   headless_shell_command: >-
@@ -18,3 +20,4 @@ forward_env_keys: []
 
 notes:
   - OpenCode GLM uses the shared OpenCode runtime path under /home/korolev/.config/opencode with a GLM-flavored local config.
+  - The Brahe skill is assembled into /home/korolev/.config/opencode/skills/brahe for OpenCode skill discovery.

--- a/experiments/main_agentic/harnesses/opencode_nex.yaml
+++ b/experiments/main_agentic/harnesses/opencode_nex.yaml
@@ -5,6 +5,8 @@ assemble:
   - source: experiments/_fragments/configs/opencode_nex/opencode
     target: /home/korolev/.config/opencode
     example: experiments/_fragments/configs/opencode_nex/opencode.example
+  - source: .agents/skills/brahe
+    target: /home/korolev/.config/opencode/skills/brahe
 
 commands:
   headless_shell_command: >-
@@ -18,3 +20,4 @@ forward_env_keys: []
 
 notes:
   - OpenCode Nex uses the shared OpenCode runtime path under /home/korolev/.config/opencode with a Nex-flavored local config.
+  - The Brahe skill is assembled into /home/korolev/.config/opencode/skills/brahe for OpenCode skill discovery.

--- a/experiments/main_agentic/plan.py
+++ b/experiments/main_agentic/plan.py
@@ -18,6 +18,12 @@ DEFAULT_INTERACTIVE_CONFIG = FAMILY_DIR / "configs" / "interactive.yaml"
 SHARED_AGENTS_FRAGMENT = (
     REPO_ROOT / "experiments" / "_fragments" / "prompts" / "_shared" / "AGENTS.main_agentic.default.md"
 )
+OPAQUE_VERIFIER_ARTIFACTS_ROOT = (
+    REPO_ROOT / "experiments" / "_fragments" / "opaque_verifiers" / "artifacts"
+)
+OPAQUE_VERIFIER_BUILD_SCRIPT = (
+    REPO_ROOT / "experiments" / "_fragments" / "opaque_verifiers" / "build.py"
+)
 INTERACTIVE_WORKSPACES_ROOT = REPO_ROOT / ".runtime" / "interactive_workspaces"
 
 
@@ -155,6 +161,15 @@ class RunItem:
 
 
 @dataclass(frozen=True)
+class OpaqueVerifierArtifactStatus:
+    benchmark: str
+    path: Path
+    state: str
+    present: bool
+    note: str | None
+
+
+@dataclass(frozen=True)
 class BatchPlan:
     config: BatchConfig
     selected_benchmarks: tuple[str, ...]
@@ -162,6 +177,7 @@ class BatchPlan:
     effective_split: str
     items: tuple[RunItem, ...]
     unavailable_configs: tuple[tuple[str, Path], ...]
+    opaque_verifier_artifacts: tuple[OpaqueVerifierArtifactStatus, ...]
 
 
 @dataclass(frozen=True)
@@ -175,6 +191,7 @@ class InteractivePlan:
     effective_case_id: str
     results_root: Path
     unavailable_configs: tuple[tuple[str, Path], ...]
+    opaque_verifier_artifacts: tuple[OpaqueVerifierArtifactStatus, ...]
 
 
 @dataclass(frozen=True)
@@ -201,6 +218,61 @@ class BatchPreview:
 
 def family_relpath() -> Path:
     return FAMILY_DIR.relative_to(REPO_ROOT)
+
+
+def opaque_verifier_benchmark(path: Path) -> str | None:
+    try:
+        relative = path.resolve().relative_to(OPAQUE_VERIFIER_ARTIFACTS_ROOT)
+    except ValueError:
+        return None
+    return relative.parts[0] if relative.parts else None
+
+
+def opaque_verifier_rebuild_command(benchmarks: tuple[str, ...]) -> str:
+    ordered = tuple(dict.fromkeys(benchmarks))
+    command = [
+        "uv",
+        "run",
+        "python",
+        OPAQUE_VERIFIER_BUILD_SCRIPT.relative_to(REPO_ROOT).as_posix(),
+    ]
+    for benchmark in ordered:
+        command.extend(["--benchmark", benchmark])
+    return " ".join(command)
+
+
+def _opaque_verifier_metadata_state(path: Path) -> tuple[str, str | None]:
+    metadata_path = path.parent / "build.json"
+    if not metadata_path.exists():
+        return "missing_metadata", f"missing metadata: {metadata_path}"
+    try:
+        data = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return "malformed_metadata", f"malformed metadata: {metadata_path}: {exc}"
+    if not isinstance(data, dict):
+        return "malformed_metadata", f"metadata is not a mapping: {metadata_path}"
+    if data.get("build_target") != "runtime_docker_image":
+        return "stale_metadata", "artifact was not built inside the runtime Docker image"
+    return "present", None
+
+
+def _opaque_verifier_artifact_status(benchmark: str, path: Path) -> OpaqueVerifierArtifactStatus:
+    if not path.exists():
+        return OpaqueVerifierArtifactStatus(
+            benchmark=benchmark,
+            path=path,
+            state="missing",
+            present=False,
+            note=None,
+        )
+    state, note = _opaque_verifier_metadata_state(path)
+    return OpaqueVerifierArtifactStatus(
+        benchmark=benchmark,
+        path=path,
+        state=state,
+        present=state == "present",
+        note=note,
+    )
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -766,6 +838,118 @@ def _collect_missing_configs(harnesses: tuple[HarnessProfile, ...]) -> tuple[tup
     return tuple(missing)
 
 
+def _benchmark_assemble_replacements(
+    benchmark: str,
+    *,
+    split: str,
+    case_id: str,
+    config_name: str,
+) -> dict[str, str]:
+    return {
+        "benchmark": benchmark,
+        "split": split,
+        "case_id": case_id,
+        "family": FAMILY_DIR.name,
+        "config_name": config_name,
+    }
+
+
+def _opaque_verifier_artifacts_for_benchmark(
+    profile: BenchmarkProfile,
+    *,
+    split: str,
+    case_id: str,
+    config_name: str,
+) -> tuple[OpaqueVerifierArtifactStatus, ...]:
+    assemble_specs = materialize_assemble_templates(
+        profile.assemble,
+        _benchmark_assemble_replacements(
+            profile.benchmark,
+            split=split,
+            case_id=case_id,
+            config_name=config_name,
+        ),
+        owner_path=profile.profile_path,
+    )
+    artifacts: list[OpaqueVerifierArtifactStatus] = []
+    seen_paths: set[Path] = set()
+    for spec in assemble_specs:
+        benchmark = opaque_verifier_benchmark(spec.source)
+        if benchmark is None or spec.source in seen_paths:
+            continue
+        seen_paths.add(spec.source)
+        artifacts.append(_opaque_verifier_artifact_status(benchmark, spec.source))
+    return tuple(sorted(artifacts, key=lambda item: (item.benchmark, item.path.as_posix())))
+
+
+def _collect_opaque_verifier_artifacts_for_batch(
+    benchmark_profiles: dict[str, BenchmarkProfile],
+    selected_benchmarks: tuple[str, ...],
+    *,
+    split: str,
+    case_ids_by_benchmark: dict[str, tuple[str, ...]],
+    config_name: str,
+) -> tuple[OpaqueVerifierArtifactStatus, ...]:
+    artifacts: list[OpaqueVerifierArtifactStatus] = []
+    for benchmark in selected_benchmarks:
+        case_ids = case_ids_by_benchmark[benchmark]
+        artifacts.extend(
+            _opaque_verifier_artifacts_for_benchmark(
+                benchmark_profiles[benchmark],
+                split=split,
+                case_id=case_ids[0],
+                config_name=config_name,
+            )
+        )
+    return tuple(artifacts)
+
+
+def _collect_opaque_verifier_artifacts_for_interactive(
+    benchmark_profile: BenchmarkProfile,
+    *,
+    split: str,
+    case_id: str,
+    config_name: str,
+) -> tuple[OpaqueVerifierArtifactStatus, ...]:
+    return _opaque_verifier_artifacts_for_benchmark(
+        benchmark_profile,
+        split=split,
+        case_id=case_id,
+        config_name=config_name,
+    )
+
+
+def raise_if_unusable_opaque_verifiers(
+    artifacts: tuple[OpaqueVerifierArtifactStatus, ...],
+) -> None:
+    unusable = tuple(artifact for artifact in artifacts if not artifact.present)
+    if not unusable:
+        return
+    benchmarks = tuple(artifact.benchmark for artifact in unusable)
+    lines = ["Unusable required opaque verifier artifacts:"]
+    for artifact in unusable:
+        note = f" ({artifact.note})" if artifact.note else ""
+        lines.append(f"- {artifact.benchmark}: {artifact.state} at {artifact.path}{note}")
+    lines.append(f"Rebuild with: {opaque_verifier_rebuild_command(benchmarks)}")
+    raise SystemExit("\n".join(lines))
+
+
+def _append_opaque_verifier_lines(
+    lines: list[str],
+    artifacts: tuple[OpaqueVerifierArtifactStatus, ...],
+) -> None:
+    if not artifacts:
+        lines.append("Opaque verifier artifacts: none")
+        return
+    lines.append("Opaque verifier artifacts:")
+    for artifact in artifacts:
+        note = f" ({artifact.note})" if artifact.note else ""
+        lines.append(f"  - {artifact.benchmark}: {artifact.state} at {artifact.path}{note}")
+    unusable = tuple(artifact.benchmark for artifact in artifacts if not artifact.present)
+    if unusable:
+        lines.append(f"Rebuild command: {opaque_verifier_rebuild_command(unusable)}")
+
+
 def _unique_requested_cases(case_filters: tuple[str, ...]) -> tuple[str, ...]:
     seen: set[str] = set()
     selected: list[str] = []
@@ -946,6 +1130,7 @@ def build_batch_plan(
         raise SystemExit("\n".join(lines))
 
     items: list[RunItem] = []
+    case_ids_by_benchmark: dict[str, tuple[str, ...]] = {}
     for benchmark in selected_benchmarks:
         case_ids = _select_case_ids(
             _enumerate_case_ids(benchmark, effective_split),
@@ -953,6 +1138,7 @@ def build_batch_plan(
             split=effective_split,
             case_filters=_unique_requested_cases(case_filters),
         )
+        case_ids_by_benchmark[benchmark] = case_ids
         benchmark_profile = benchmark_profiles[benchmark]
         for case_id in case_ids:
             for harness in selected_harnesses:
@@ -972,6 +1158,15 @@ def build_batch_plan(
                         harness_profile=harness_profile,
                     )
                 )
+    opaque_verifier_artifacts = _collect_opaque_verifier_artifacts_for_batch(
+        benchmark_profiles,
+        selected_benchmarks,
+        split=effective_split,
+        case_ids_by_benchmark=case_ids_by_benchmark,
+        config_name=config.config_path.stem,
+    )
+    if require_real_configs:
+        raise_if_unusable_opaque_verifiers(opaque_verifier_artifacts)
 
     return BatchPlan(
         config=config,
@@ -980,6 +1175,7 @@ def build_batch_plan(
         effective_split=effective_split,
         items=tuple(items),
         unavailable_configs=unavailable,
+        opaque_verifier_artifacts=opaque_verifier_artifacts,
     )
 
 
@@ -1036,6 +1232,14 @@ def build_interactive_plan(
     case_dir = REPO_ROOT / "benchmarks" / config.benchmark / "dataset" / "cases" / effective_split / effective_case_id
     if not case_dir.is_dir():
         raise SystemExit(f"Case directory does not exist: {case_dir}")
+    opaque_verifier_artifacts = _collect_opaque_verifier_artifacts_for_interactive(
+        benchmark_profile,
+        split=effective_split,
+        case_id=effective_case_id,
+        config_name=config.config_path.stem,
+    )
+    if require_real_configs:
+        raise_if_unusable_opaque_verifiers(opaque_verifier_artifacts)
     return InteractivePlan(
         config=config,
         benchmark_profile=benchmark_profile,
@@ -1046,6 +1250,7 @@ def build_interactive_plan(
         effective_case_id=effective_case_id,
         results_root=REPO_ROOT / "results" / "agent_runs" / family_relpath(),
         unavailable_configs=unavailable,
+        opaque_verifier_artifacts=opaque_verifier_artifacts,
     )
 
 
@@ -1137,6 +1342,7 @@ def describe_batch_preview(preview: BatchPreview, *, include_items: bool = True)
             lines.append(f"  - {harness}: {path}")
     else:
         lines.append("Unavailable harness configs: none")
+    _append_opaque_verifier_lines(lines, plan.opaque_verifier_artifacts)
     lines.append(
         "Artifact states: "
         + ", ".join(f"{key}={value}" for key, value in artifact_counts.items())
@@ -1181,6 +1387,7 @@ def describe_interactive_plan(plan: InteractivePlan) -> str:
             lines.append(f"  - {harness}: {path}")
     else:
         lines.append("Unavailable harness configs: none")
+    _append_opaque_verifier_lines(lines, plan.opaque_verifier_artifacts)
     return "\n".join(lines)
 
 

--- a/experiments/main_agentic/run.py
+++ b/experiments/main_agentic/run.py
@@ -325,36 +325,19 @@ def _workspace_example_solution_name(
     return "No example solution is provided for this workspace."
 
 
-def _workspace_module_name(relative: Path) -> str:
-    return ".".join(part for part in relative.parts if part)
-
-
 def _workspace_verifier_info(
-    benchmark: str,
     assemble_specs: tuple[family_plan.AssembleSpec, ...],
 ) -> tuple[str, str]:
-    verifier = _verifier_repo_path(benchmark)
-    if verifier is None:
-        return (
-            "Verifier is not exposed in this workspace.",
-            "No verifier helper is available in this workspace.",
-        )
-
     for spec in assemble_specs:
-        if spec.source != verifier:
-            continue
         try:
             relative = spec.target.relative_to(WORKSPACE_MOUNT)
         except ValueError:
             continue
-
-        location = relative.as_posix() + ("/" if verifier.is_dir() else "")
-        if verifier.is_dir():
-            module_name = _workspace_module_name(relative)
-            command = f"python -m {module_name}.run case/ solution.json"
-        else:
-            command = f"python {relative.as_posix()} case/ solution.json"
-        return location, command
+        relative_text = relative.as_posix()
+        if relative_text == "verifier":
+            return relative_text, f"./{relative_text} case/ solution.json"
+        if relative_text == "verifier.py":
+            return relative_text, f"python {relative_text} case/ solution.json"
 
     return (
         "Verifier is not exposed in this workspace.",
@@ -368,7 +351,7 @@ def _template_context(
     case_id: str,
     assemble_specs: tuple[family_plan.AssembleSpec, ...],
 ) -> dict[str, str]:
-    verifier_location, verifier_command = _workspace_verifier_info(benchmark, assemble_specs)
+    verifier_location, verifier_command = _workspace_verifier_info(assemble_specs)
     return {
         "benchmark": benchmark,
         "split": split,
@@ -510,6 +493,13 @@ def _assemble_workspace(
                     }
                 )
                 continue
+            opaque_benchmark = family_plan.opaque_verifier_benchmark(spec.source)
+            if opaque_benchmark is not None:
+                rebuild_command = family_plan.opaque_verifier_rebuild_command((opaque_benchmark,))
+                raise SystemExit(
+                    "Required opaque verifier artifact does not exist: "
+                    f"{spec.source}. Rebuild it with: {rebuild_command}"
+                )
             example_note = f" Copy the example file {spec.example} and fill it in." if spec.example else ""
             raise SystemExit(f"Required assemble source does not exist: {spec.source}.{example_note}")
 
@@ -1494,6 +1484,7 @@ def main(argv: list[str] | None = None) -> int:
         for harness, path in plan.unavailable_configs:
             lines.append(f"- {harness}: {path}")
         raise SystemExit("\n".join(lines))
+    family_plan.raise_if_unusable_opaque_verifiers(plan.opaque_verifier_artifacts)
     return _run_batch(args, preview)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,5 @@ dependencies = [
     "skyfield>=1.54",
     "shapely>=2.1.2",
     "pyproj>=3.7.2",
+    "pyinstaller>=6.20.0",
 ]

--- a/runtimes/base/Dockerfile
+++ b/runtimes/base/Dockerfile
@@ -46,6 +46,7 @@ RUN uv pip install --system \
     'matplotlib>=3.10.8' \
     'numpy>=2.4.4' \
     'pyproj>=3.7.2' \
+    'pyinstaller>=6.20,<7' \
     'pyyaml>=6.0.3' \
     'pytest>=9.0.3' \
     'shapely>=2.1.2' \
@@ -57,7 +58,8 @@ RUN set -eux; \
     for cmd in claude codex gemini jq kimi opencode pi rg tree; do \
         command -v "$cmd"; \
     done; \
-    python -c "import brahe, datasets, huggingface_hub, kagglehub, matplotlib, numpy, pyproj, yaml, pytest, shapely, skyfield" >/dev/null
+    command -v pyinstaller; \
+    python -c "import brahe, datasets, huggingface_hub, kagglehub, matplotlib, numpy, pyproj, PyInstaller, yaml, pytest, shapely, skyfield" >/dev/null
 
 WORKDIR /app/workspace
 

--- a/uv.lock
+++ b/uv.lock
@@ -92,6 +92,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -123,6 +132,7 @@ dependencies = [
     { name = "kagglehub", extra = ["pandas-datasets"] },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "pyinstaller" },
     { name = "pyproj" },
     { name = "pytest" },
     { name = "pyyaml" },
@@ -138,6 +148,7 @@ requires-dist = [
     { name = "kagglehub", extras = ["pandas-datasets"], specifier = ">=1.0.0" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.4.4" },
+    { name = "pyinstaller", specifier = ">=6.20.0" },
     { name = "pyproj", specifier = ">=3.7.2" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -788,6 +799,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1100,6 +1123,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1337,6 +1369,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/60/d03d52e6690d4e9caf333dcd14550cde634ce6c118b3bc8fa3112c3186fd/pyinstaller-6.20.0.tar.gz", hash = "sha256:95c5c7e03d5d61e9dfb8ef259c699cf492bb1041beb6dbe83696608cec07347a", size = 4048728, upload-time = "2026-04-22T20:59:36.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/e4/e228d6d1bbb7fd62dc660a8fb202a583b023d3a3624ca95d1a9290ee4d6a/pyinstaller-6.20.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:bf3be4e1284ee78ddccba5e29f99443a12a7b4673168288ffc4c9d38c6f7b90e", size = 1047642, upload-time = "2026-04-22T20:58:32.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bd/afb631bcb3f9040efebd4f6d067f0828b51710818f69fb41a2d4b7787f52/pyinstaller-6.20.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:72ae9c1fdea134afa791f58bdc9a1934d5c7609753c111e0026bfc272b32b712", size = 742494, upload-time = "2026-04-22T20:58:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/76/08/0729a5bac14754150e5d83b39d87d842eb42b0bffcaa03dbad6252e23a39/pyinstaller-6.20.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1031bcc307f3fbeffd4e162723e64d46dbf591c82dd0997413afb2a07328b941", size = 754191, upload-time = "2026-04-22T20:58:40.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/82/bc0ee4c7b97db1958eb651e0da9fb1e672e5ae53ca8867fd97701de52906/pyinstaller-6.20.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:8df3b3f347659fa2562d8d193a98ad4600133b8b8d07c268df89e4154376750e", size = 751902, upload-time = "2026-04-22T20:58:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/770002d6aaa54173881cb2c49bb195ba67b97bf39bac1cdf320f28401629/pyinstaller-6.20.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:b0d3cc9dd8120d448459bd3880a12e2f9774c51443af49047801446377999a59", size = 748634, upload-time = "2026-04-22T20:58:48.579Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/db/68ba1fccb71278b2124fb90b37b7c8c0bc4c1173fba45b94466df3d9cb7f/pyinstaller-6.20.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:03696bb6350177c6bc23bcaf78e71a33c4a89b6754dd90d1be2f318e978c918b", size = 748490, upload-time = "2026-04-22T20:58:52.749Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0f/ac77ffa996a56be3d5c8f85734a007f8347240691657f9704e7de2527fa3/pyinstaller-6.20.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:6357f1699f6af84f37e7367f031d4f68abdba65543b83990c9e8f5a4cebed0b7", size = 747650, upload-time = "2026-04-22T20:58:57.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/56/1ee91c3a2bc10ca1f36da10a6fd55ff7efc4dec367171eb25992a827874f/pyinstaller-6.20.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0ab39c690abad26ba148e8f664f0478acc82a733997f4f22e757774832802da9", size = 747413, upload-time = "2026-04-22T20:59:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/55/ae264339996953c4cdf9d89d916a0a8fa26a83cf917a742fff8b9d5f3fe8/pyinstaller-6.20.0-py3-none-win32.whl", hash = "sha256:9a7637e8e44b4387b13667fdcaac86ab6b29c446c16d34d8401539b81838759c", size = 1331584, upload-time = "2026-04-22T20:59:07.201Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/300f57578882cce259bfb5ae56fda3b69caa3fe9df40a176c719920ea6e2/pyinstaller-6.20.0-py3-none-win_amd64.whl", hash = "sha256:d588844e890ee80c4365867f98146636e1849bbca8e4284bbf0c809aff0f161a", size = 1391851, upload-time = "2026-04-22T20:59:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ea/b2f8e1642aecda78c0b75c7321f708e49e10bb3c00dd4f148c40761a1527/pyinstaller-6.20.0-py3-none-win_arm64.whl", hash = "sha256:bd53282c0a73e5c95573e1ddc8e5d564d4932bec91efbaed4dc5fdff9c2ae7f2", size = 1332259, upload-time = "2026-04-22T20:59:20.509Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/fe/9278c29394bf69169febc21f96b4252c3ee7c8ec22c2fc545004bed47e71/pyinstaller_hooks_contrib-2026.4.tar.gz", hash = "sha256:766c281acb1ecc32e21c8c667056d7ebf5da0aabd5e30c219f9c2a283620eeaa", size = 173050, upload-time = "2026-03-31T14:10:51.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/f4/035fb8c06deff827f540a9a4ed9122c54e5376fca3e42eddf0c263730775/pyinstaller_hooks_contrib-2026.4-py3-none-any.whl", hash = "sha256:1de1a5e49a878122010b88c7e295502bc69776c157c4a4dc78741a4e6178b00f", size = 455496, upload-time = "2026-03-31T14:10:49.867Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1451,6 +1524,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1512,6 +1594,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR contains the four commits on `feat/opaque-verifier` for issue #97:

- Add the opaque verifier builder scaffold.
- Wire main agentic workspace assembly to use opaque verifier artifacts.
- Assemble the Brahe skill for agent harnesses.
- Tighten benchmark-facing README contracts so opaque-verifier workspaces stay precise without exposing verifier source internals.

## Validation

Focused checks run during the branch work:

- Built/reused opaque verifier artifacts with container smoke checks.
- Ran focused main-agentic workspace assembly smoke checks for `aeossp_standard` and `satnet`.
- Confirmed assembled workspaces point to opaque verifier artifacts and do not copy readable verifier source.
- Confirmed external evaluation still uses benchmark-owned verifier CLIs.
- Ran `uv run python experiments/main_agentic/aggregate.py`.
- Ran benchmark-owned CLI smoke fixtures for all seven opaque-verifier benchmarks.
- Ran final README/prompt leakage scans and `git diff --check`.

Residual risk: this is focused smoke validation, not a full matrix run across every benchmark, harness, split, and case.

Closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark verifiers are now provided as opaque prebuilt artifacts.
  * Brahe skill is staged into all harness runtimes for native discovery.

* **Documentation**
  * Prompts and benchmark docs rewritten as formal modeling contracts with precise validation rules.

* **Chores**
  * Added PyInstaller and build tooling to produce and manage opaque verifier artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->