### PR TITLE
Increase base runtime Python packages and pin their version

### DIFF
--- a/runtimes/base/Dockerfile
+++ b/runtimes/base/Dockerfile
@@ -39,18 +39,29 @@ RUN npm install -g \
     opencode-ai
 
 RUN uv pip install --system \
-    'brahe>=1.3.4' \
-    'datasets>=4.8.4' \
-    'huggingface-hub>=1.10.2' \
-    'kagglehub[pandas-datasets]>=1.0.0' \
-    'matplotlib>=3.10.8' \
-    'numpy>=2.4.4' \
-    'pyproj>=3.7.2' \
-    'pyinstaller>=6.20,<7' \
-    'pyyaml>=6.0.3' \
-    'pytest>=9.0.3' \
-    'shapely>=2.1.2' \
-    'skyfield>=1.54'
+    'brahe==1.4.2' \
+    'datasets==4.8.4' \
+    'huggingface-hub==1.12.0' \
+    'kagglehub[pandas-datasets]==1.0.0' \
+    'matplotlib==3.10.9' \
+    'networkx==3.6.1' \
+    'numpy==2.4.4' \
+    'ortools==9.15.6755' \
+    'pandas==3.0.2' \
+    'plotly==6.7.0' \
+    'pulp==3.3.0' \
+    'pydantic==2.13.3' \
+    'pygmo==2.19.8' \
+    'pyproj==3.7.2' \
+    'pyinstaller==6.20.0' \
+    'pyyaml==6.0.3' \
+    'pytest==9.0.3' \
+    'scikit-learn==1.8.0' \
+    'scipy==1.17.1' \
+    'shapely==2.1.2' \
+    'skyfield==1.54' \
+    'sympy==1.14.0' \
+    'tqdm==4.67.3'
 
 RUN uv tool install --python 3.13 kimi-cli
 
@@ -59,7 +70,7 @@ RUN set -eux; \
         command -v "$cmd"; \
     done; \
     command -v pyinstaller; \
-    python -c "import brahe, datasets, huggingface_hub, kagglehub, matplotlib, numpy, pyproj, PyInstaller, yaml, pytest, shapely, skyfield" >/dev/null
+    python -c "import brahe, datasets, huggingface_hub, kagglehub, matplotlib, networkx, numpy, ortools, pandas, plotly, pulp, pydantic, pygmo, pyproj, PyInstaller, scipy, shapely, sklearn, skyfield, sympy, tqdm, yaml, pytest" >/dev/null
 
 WORKDIR /app/workspace
 


### PR DESCRIPTION
## Summary

Closes #119.

- Pins the base runtime's direct Python package set for reproducible installs.
- Updates Brahe to `1.4.2` for the TLE bug fix.
- Adds the requested optimization and scientific packages: `ortools`, `pulp`, `pygmo`, `scipy`, `pandas`, `scikit-learn`, and `sympy`.
- Adds the additional lightweight/runtime-useful packages from the issue: `networkx`, `plotly`, `pydantic`, and `tqdm`.
- Extends the Dockerfile smoke import command to cover the newly installed packages.

## Validation

- Did not build the base image, per request.
- Confirmed the pinned package set resolves for Python 3.13 on `x86_64-manylinux_2_36` with wheels only:
  `UV_CACHE_DIR=/tmp/uv-cache uv pip install --dry-run --python-version 3.13 --python-platform x86_64-manylinux_2_36 --only-binary :all: ...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build with pinned Python package versions for enhanced dependency consistency.
  * Added new Python packages to the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->