### PR TITLE
[codex] harden solver contract validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Validate finished benchmark contract
         run: uv run python scripts/validate_benchmark_contract.py
 
+      - name: Validate finished solver contract
+        run: uv run python scripts/validate_solver_contract.py
+
       - name: Run tests
         run: uv run pytest tests/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,18 @@ venv.bak/
 .codex
 roadmap/
 
+# Solver-local setup/build artifacts
+solvers/**/.solver-env
+solvers/**/.venv/
+solvers/**/build/
+solvers/**/target/
+solvers/**/.gradle/
+solvers/**/.m2/
+solvers/**/.julia/
+solvers/**/.minizinc/
+solvers/**/solution/
+solvers/**/debug/
+
 # Benchmark intermediates or outputs
 benchmarks/*/dataset/source_data
 benchmarks/*/visualizer/plots

--- a/docs/experiment_contract.md
+++ b/docs/experiment_contract.md
@@ -75,6 +75,15 @@ aggregation. Since traditional solvers are benchmark-specific, solver-backed
 experiment profiles may be solver-centered instead of using separate benchmark
 and method axes.
 
+Experiments should not assume that a solver runs in the repository's project
+Python environment. A solver may prepare a Python virtual environment, compiled
+binary, language-native build output, or other solver-local runtime through
+`setup.sh`. If setup writes a solver-owned handoff file such as `.solver-env`,
+the experiment runner may read simple `SOLVER_*` assignments from that file and
+pass them into the `solve.sh` subprocess. Experiment profiles own evidence
+labels, verifier commands, solver-specific configs, and result layout; those
+fields do not belong in `solvers/finished_solvers.json`.
+
 ## Family Config
 
 Experiment families may keep one or more runner-owned YAML config files under `configs/`.

--- a/docs/solver_contract.md
+++ b/docs/solver_contract.md
@@ -1,19 +1,20 @@
 # Solver Contract
 
-This document defines the initial public contract for `solvers/`.
+This document defines the public contract for `solvers/`.
 
-The contract is intentionally light. It gives experiments a stable way to call traditional methods without forcing every solver into the same language, package manager, or runtime model.
+The contract gives experiments a stable way to call traditional non-agentic methods without forcing every solver into the same language, package manager, or runtime model.
 
 ## Purpose
 
 `solvers/` owns reusable traditional non-agentic methods.
 
-Examples may eventually include:
+Examples include:
 
 - heuristic solvers
 - optimization-based baselines
 - reproducible classical pipelines
-- solver-local evaluation helpers
+- fixture-backed lookup baselines
+- citation-backed literature baselines
 
 Solvers consume benchmark case files and produce benchmark-shaped solution files. Benchmarks must not depend on solvers.
 
@@ -31,13 +32,15 @@ solvers/
 └── <benchmark>/
     └── <solver>/
         ├── README.md
-        ├── setup.sh
-        ├── solve.sh
-        ├── src/      # optional
-        └── assets/   # optional
+        ├── setup.sh          # required when repro_ci is true
+        ├── solve.sh          # required when repro_ci is true
+        ├── test.sh           # optional solver-local test entrypoint
+        ├── src/              # optional
+        ├── tests/            # optional solver-local tests
+        └── assets/           # optional
 ```
 
-`finished_solvers.json` is the repository-level registry for solvers that are ready to be used by experiments or discussed in reports.
+The path for a registered solver is derived from the registry fields: `solvers/<benchmark>/<solver>/`. The registry does not carry a separate `path` field.
 
 ## Runnable Solver Contract
 
@@ -48,9 +51,7 @@ Runnable solvers expose two shell entrypoints:
 ./solve.sh <case_dir> [config_dir] [solution_dir]
 ```
 
-`setup.sh` prepares solver-local dependencies. It may be a no-op.
-
-The default expectation is that repository Python solvers run under the project environment, such as the project `uv` environment. Solvers may still use their own environments, package managers, compiled binaries, or other languages such as Rust, Julia, C++, or MiniZinc. Those choices should stay solver-local and be hidden behind `setup.sh` and `solve.sh`.
+`setup.sh` prepares solver-local dependencies, build artifacts, or runtime state. It may be a no-op.
 
 `solve.sh` receives:
 
@@ -60,17 +61,93 @@ The default expectation is that repository Python solvers run under the project 
 
 Experiments should usually pass both optional arguments explicitly. The solver should write its primary solution artifact into `solution_dir` and exit nonzero for unsupported cases or execution failures.
 
-Solver code may be Python, shell, C++, Julia, MiniZinc, Rust, or anything else. The shell entrypoints are the boundary.
+Solver code may be Python, shell, C, C++, Java, Kotlin, Julia, MiniZinc, Rust, or anything else. The shell entrypoints are the boundary.
 
-## Evidence Types
+## Setup Outputs
 
-The initial registry distinguishes:
+`setup.sh` may create or update solver-local outputs such as:
 
-- `reproduced_solver`: a runnable solver produces a solution for a case
-- `fixture_backed_lookup`: a runnable lookup emits a known reference solution
-- `citation_reported`: documented metrics copied from cited literature without a runnable solver
+- Python virtual environments under `.venv/`
+- a `.solver-env` file with simple `SOLVER_*=` assignments
+- C/C++ build directories and binaries
+- Rust `target/` artifacts and Cargo-managed dependencies
+- Java/Kotlin jars and Gradle/Maven outputs
+- Julia depots or instantiated project environments
+- MiniZinc model-local backends or availability checks
 
-Fixture-backed lookups and citation-reported entries must be labeled as such in reports. They are useful baselines, but they are not general solver claims.
+Generated setup outputs should stay solver-local and be ignored when they are machine-specific or reproducible build products.
+
+`.solver-env` is a convention, not a CI-enforced requirement. When present, it should be a simple handoff file for values such as:
+
+```text
+SOLVER_VENV_DIR=/abs/path/to/.venv
+SOLVER_PYTHON=/abs/path/to/.venv/bin/python
+```
+
+Experiment runners may read this file and pass `SOLVER_*` values into `solve.sh`, but solvers should still be directly runnable after `setup.sh`.
+
+## Solver-Local Tests
+
+`test.sh` is the optional solver-local test boundary.
+
+It may run any language-native test command, including `pytest`, `cargo test`, `ctest`, `mvn test`, `gradle test`, or Julia test runners. Test-only dependencies should be installed by the solver-local test flow or already be available in the solver's chosen environment.
+
+Top-level pytest must not collect solver-local tests. Repository-wide pytest is for benchmark and repository tooling tests. Solver tests should live under the solver directory and be reached through `test.sh`.
+
+## CI-Enforced Invariants
+
+`scripts/validate_solver_contract.py` enforces repository-wide invariants:
+
+- `solvers/finished_solvers.json` has the documented schema.
+- Each registry entry resolves to `solvers/<benchmark>/<solver>/`.
+- Each registered solver has `README.md`.
+- `repro_ci: true` entries have executable `setup.sh` and `solve.sh`.
+- `repro_ci: true` entries declare at least one case path.
+- Declared case paths and non-empty fixture paths exist.
+- Existing `test.sh` files are executable.
+- Top-level pytest is scoped away from solver-local tests.
+- Solver runtime code does not import or execute across `benchmarks/`, `experiments/`, `runtimes/`, or other solvers.
+- `repro_ci: true` entries run `setup.sh` and `solve.sh` on their declared cases.
+- Detected solver-local `test.sh` entrypoints run as part of solver contract validation.
+
+CI enforces boundaries and discoverability. It does not enforce a language, package manager, build system, or internal source layout.
+
+## Finished Solver Registry
+
+`solvers/finished_solvers.json` is a reproducibility and CI registry. It is not the evidence/reporting registry for experiments.
+
+Each entry has:
+
+```json
+{
+  "benchmark": "aeossp_standard",
+  "solver": "greedy_lns",
+  "repro_ci": false,
+  "repro_ci_reason": "too_expensive",
+  "case_and_fixture_paths": []
+}
+```
+
+For `repro_ci: true`, `case_and_fixture_paths` contains objects:
+
+```json
+{
+  "case_path": "benchmarks/spot5/dataset/cases/test/8",
+  "fixture_path": "solvers/spot5/reference_lookup/assets/solutions/8.spot_sol.txt"
+}
+```
+
+`fixture_path` may be an empty string when CI should only run setup/solve and not compare against a fixed output fixture.
+
+`repro_ci_reason` is recommended when `repro_ci` is false, but it is not enforced by CI. Useful values include:
+
+- `citation_based`
+- `too_expensive`
+- `requires_external_toolchain`
+- `requires_external_data`
+- `not_reproducible_yet`
+
+Experiment profiles own evidence type, verifier commands, result layout, solver-specific configs, and reporting metadata.
 
 ## Ownership Boundaries
 
@@ -94,11 +171,3 @@ Solvers must also not depend on those layers at runtime. Reading documented case
 Solver code should stay standalone. If similar behavior is needed in another solver, repeat the small amount of code or define a public file format instead of importing another solver's internals.
 
 If shared code is needed later, it should remain layer-local rather than introducing a repository-wide shared abstraction that weakens the benchmark and method boundaries.
-
-## What This Contract Does Not Promise Yet
-
-This document does not yet standardize:
-
-- solver result formats beyond benchmark-owned verifier contracts
-- per-language environment management
-- cross-solver shared libraries

--- a/experiments/main_solver/README.md
+++ b/experiments/main_solver/README.md
@@ -9,12 +9,9 @@ It runs benchmark-grouped solvers through the public solver contract:
 ./solve.sh <case_dir> <config_dir> <solution_dir>
 ```
 
-The experiment owns run selection, result layout, verification, and aggregation.
-Solvers own implementation details and may use any language behind their shell
-entrypoints.
+The experiment owns run selection, result layout, verification, and aggregation. Solvers own implementation details and may use any language behind their shell entrypoints.
 
-Unlike agentic runs, traditional solver entries are benchmark-specific. The
-experiment therefore keeps one solver-centered config:
+Unlike agentic runs, traditional solver entries are benchmark-specific. The experiment therefore keeps one solver-centered config:
 
 ```text
 experiments/main_solver/
@@ -22,9 +19,7 @@ experiments/main_solver/
 └── solvers/
 ```
 
-Each solver profile carries the benchmark name, case list or reported metrics,
-executable verifier command when the solver is runnable, and optional
-solver-owned config written to each job's `config/config.yaml`.
+Each solver profile carries the benchmark name, case list or reported metrics, executable verifier command when the solver is runnable, and optional solver-owned config written to each job's `config/config.yaml`.
 
 ## Evidence Types
 
@@ -77,8 +72,4 @@ results/main_solver/<benchmark>/<solver>/<case_slug>/
 └── run.json
 ```
 
-Runnable rows include setup, solve, and verifier sections. Citation-reported
-rows include reported metrics and provenance instead of execution logs.
-
-Benchmark verifiers are consumed as executables. The runner does not import
-benchmark-internal functions, classes, or modules.
+Benchmark verifiers are consumed as executables. The runner does not import benchmark-internal functions, classes, or modules.

--- a/scripts/validate_solver_contract.py
+++ b/scripts/validate_solver_contract.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = REPO_ROOT / "solvers" / "finished_solvers.json"
+ENTRY_KEYS = {
+    "benchmark",
+    "solver",
+    "repro_ci",
+    "repro_ci_reason",
+    "case_and_fixture_paths",
+}
+CASE_FIXTURE_KEYS = {"case_path", "fixture_path"}
+PYTHON_IMPORT_PATTERN = re.compile(
+    r"^\s*(?:from|import)\s+(benchmarks|experiments|runtimes|solvers)(?:\.|\s|$)",
+    re.MULTILINE,
+)
+EXECUTION_PATTERNS = (
+    re.compile(r"python(?:3)?\s+-m\s+(benchmarks|experiments|runtimes|solvers)\b"),
+    re.compile(r"\b(benchmarks|experiments|runtimes)\.[A-Za-z0-9_]"),
+)
+GENERATED_DIR_NAMES = {
+    ".gradle",
+    ".julia",
+    ".m2",
+    ".minizinc",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "debug",
+    "dist",
+    "env",
+    "node_modules",
+    "solution",
+    "target",
+    "venv",
+}
+DEFAULT_SETUP_TIMEOUT_S = 600.0
+DEFAULT_SOLVE_TIMEOUT_S = 600.0
+DEFAULT_TEST_TIMEOUT_S = 600.0
+
+
+def _load_registry(errors: list[str]) -> dict[str, Any]:
+    try:
+        payload = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{REGISTRY_PATH}: invalid JSON: {exc}")
+        return {}
+    if not isinstance(payload, dict):
+        errors.append(f"{REGISTRY_PATH}: top-level value must be an object")
+        return {}
+    unexpected = set(payload) - {"solvers"}
+    if unexpected:
+        errors.append(
+            f"{REGISTRY_PATH}: unsupported top-level keys: {', '.join(sorted(unexpected))}"
+        )
+    if not isinstance(payload.get("solvers"), list):
+        errors.append(f"{REGISTRY_PATH}: 'solvers' must be a list")
+        return {}
+    return payload
+
+
+def _solver_path(entry: dict[str, Any]) -> Path:
+    return REPO_ROOT / "solvers" / str(entry["benchmark"]) / str(entry["solver"])
+
+
+def _is_executable(path: Path) -> bool:
+    return path.exists() and path.is_file() and os.access(path, os.X_OK)
+
+
+def _validate_case_fixture_paths(
+    entry: dict[str, Any], solver_label: str, errors: list[str]
+) -> None:
+    values = entry.get("case_and_fixture_paths")
+    if not isinstance(values, list):
+        errors.append(f"{solver_label}: case_and_fixture_paths must be a list")
+        return
+    if entry.get("repro_ci") is True and not values:
+        errors.append(f"{solver_label}: repro_ci true requires at least one case path")
+    for index, item in enumerate(values):
+        where = f"{solver_label}: case_and_fixture_paths[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{where} must be an object")
+            continue
+        unexpected = set(item) - CASE_FIXTURE_KEYS
+        missing = CASE_FIXTURE_KEYS - set(item)
+        if unexpected:
+            errors.append(f"{where}: unsupported keys: {', '.join(sorted(unexpected))}")
+        if missing:
+            errors.append(f"{where}: missing keys: {', '.join(sorted(missing))}")
+            continue
+        case_path = item["case_path"]
+        fixture_path = item["fixture_path"]
+        if not isinstance(case_path, str) or not case_path:
+            errors.append(f"{where}: case_path must be a non-empty string")
+        elif not (REPO_ROOT / case_path).exists():
+            errors.append(f"{where}: case_path does not exist: {case_path}")
+        if not isinstance(fixture_path, str):
+            errors.append(f"{where}: fixture_path must be a string, or empty if unused")
+        elif fixture_path and not (REPO_ROOT / fixture_path).exists():
+            errors.append(f"{where}: fixture_path does not exist: {fixture_path}")
+
+
+def _validate_registry(errors: list[str]) -> list[dict[str, Any]]:
+    payload = _load_registry(errors)
+    entries = payload.get("solvers", [])
+    if not isinstance(entries, list):
+        return []
+
+    seen: set[tuple[str, str]] = set()
+    normalized: list[dict[str, Any]] = []
+    for index, entry in enumerate(entries):
+        where = f"{REGISTRY_PATH}: solvers[{index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{where}: entry must be an object")
+            continue
+        unexpected = set(entry) - ENTRY_KEYS
+        if unexpected:
+            errors.append(f"{where}: unsupported keys: {', '.join(sorted(unexpected))}")
+        required = {"benchmark", "solver", "repro_ci", "case_and_fixture_paths"}
+        missing = required - set(entry)
+        if missing:
+            errors.append(f"{where}: missing keys: {', '.join(sorted(missing))}")
+            continue
+        benchmark = entry["benchmark"]
+        solver = entry["solver"]
+        if not isinstance(benchmark, str) or not benchmark:
+            errors.append(f"{where}: benchmark must be a non-empty string")
+            continue
+        if not isinstance(solver, str) or not solver:
+            errors.append(f"{where}: solver must be a non-empty string")
+            continue
+        label = f"{benchmark}/{solver}"
+        key = (benchmark, solver)
+        if key in seen:
+            errors.append(f"{where}: duplicate solver entry {label}")
+        seen.add(key)
+
+        repro_ci = entry["repro_ci"]
+        if not isinstance(repro_ci, bool):
+            errors.append(f"{label}: repro_ci must be a boolean")
+
+        solver_dir = _solver_path(entry)
+        if not solver_dir.is_dir():
+            errors.append(f"{label}: expected solver directory at {solver_dir.relative_to(REPO_ROOT)}")
+        elif not (solver_dir / "README.md").is_file():
+            errors.append(f"{label}: missing README.md")
+        if repro_ci is True:
+            for script in ("setup.sh", "solve.sh"):
+                script_path = solver_dir / script
+                if not _is_executable(script_path):
+                    errors.append(f"{label}: {script} must exist and be executable")
+        test_script = solver_dir / "test.sh"
+        if test_script.exists() and not _is_executable(test_script):
+            errors.append(f"{label}: test.sh exists but is not executable")
+        _validate_case_fixture_paths(entry, label, errors)
+        normalized.append(entry)
+    return normalized
+
+
+def _iter_solver_runtime_files() -> list[Path]:
+    root = REPO_ROOT / "solvers"
+    files: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if name not in GENERATED_DIR_NAMES and name != "tests"
+        ]
+        current = Path(dirpath)
+        for filename in filenames:
+            path = current / filename
+            if path.name == "test.sh":
+                continue
+            if path.suffix == ".py" or path.suffix in {".sh", ".bash"}:
+                files.append(path)
+    return files
+
+
+def _validate_boundaries(errors: list[str]) -> None:
+    for path in _iter_solver_runtime_files():
+        text = path.read_text(encoding="utf-8")
+        rel = path.relative_to(REPO_ROOT)
+        if path.suffix == ".py":
+            for match in PYTHON_IMPORT_PATTERN.finditer(text):
+                layer = match.group(1)
+                errors.append(f"{rel}: solver runtime must not import {layer}/")
+        for pattern in EXECUTION_PATTERNS:
+            for match in pattern.finditer(text):
+                layer = match.group(1)
+                errors.append(f"{rel}: solver runtime must not execute or reference {layer}/")
+
+
+def _validate_pytest_boundary(errors: list[str]) -> None:
+    pytest_ini = REPO_ROOT / "pytest.ini"
+    if not pytest_ini.exists():
+        errors.append("pytest.ini is required so top-level pytest collection is explicit")
+        return
+    text = pytest_ini.read_text(encoding="utf-8")
+    if re.search(r"(?m)^\s*testpaths\s*=", text) is None:
+        errors.append("pytest.ini must define testpaths so top-level pytest is scoped")
+    testpaths_match = re.search(r"(?ms)^\s*testpaths\s*=\s*(.+?)(?:\n\S|\Z)", text)
+    if testpaths_match:
+        for token in testpaths_match.group(1).split():
+            first_component = token.strip("'\"").rstrip("/").split("/", 1)[0]
+            if first_component == "solvers":
+                errors.append("pytest.ini testpaths must not include solvers/")
+                break
+    solver_tests = sorted((REPO_ROOT / "tests" / "solvers").glob("test_*.py"))
+    if solver_tests:
+        listed = ", ".join(str(path.relative_to(REPO_ROOT)) for path in solver_tests)
+        errors.append(f"top-level tests/solvers must be empty; use solver-local test.sh: {listed}")
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _run_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout_s: float | None = 600.0,
+) -> tuple[int | None, str | None]:
+    print(f"+ ({_display_path(cwd)}) {' '.join(command)}", flush=True)
+    try:
+        completed = subprocess.run(command, cwd=cwd, check=False, timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        return 124, f"timed out after {timeout_s}s"
+    except OSError as exc:
+        return None, str(exc)
+    return int(completed.returncode), None
+
+
+def _run_solver_tests(entries: list[dict[str, Any]], errors: list[str]) -> None:
+    for entry in entries:
+        solver_dir = _solver_path(entry)
+        test_script = solver_dir / "test.sh"
+        if not test_script.exists():
+            continue
+        setup_script = solver_dir / "setup.sh"
+        if setup_script.exists():
+            setup_returncode, setup_error = _run_command(
+                ["./setup.sh"],
+                cwd=solver_dir,
+                timeout_s=DEFAULT_SETUP_TIMEOUT_S,
+            )
+            if setup_error is not None:
+                errors.append(
+                    f"{entry['benchmark']}/{entry['solver']}: setup.sh could not complete before test.sh: {setup_error}"
+                )
+                continue
+            if setup_returncode != 0:
+                errors.append(
+                    f"{entry['benchmark']}/{entry['solver']}: setup.sh failed before test.sh"
+                )
+                continue
+        returncode, launch_error = _run_command(
+            ["./test.sh"],
+            cwd=solver_dir,
+            timeout_s=DEFAULT_TEST_TIMEOUT_S,
+        )
+        if launch_error is not None:
+            errors.append(
+                f"{entry['benchmark']}/{entry['solver']}: test.sh could not complete: {launch_error}"
+            )
+        elif returncode != 0:
+            errors.append(f"{entry['benchmark']}/{entry['solver']}: test.sh failed")
+
+
+def _compare_fixture(solution_dir: Path, fixture_path: Path, label: str, errors: list[str]) -> None:
+    outputs = sorted(
+        path for path in solution_dir.iterdir() if path.is_file() and path.name != "status.json"
+    )
+    if not outputs:
+        errors.append(f"{label}: repro run wrote no primary solution file")
+        return
+    if len(outputs) == 1:
+        actual = outputs[0]
+    else:
+        actual = solution_dir / fixture_path.name
+        if not actual.exists():
+            names = ", ".join(path.name for path in outputs)
+            errors.append(f"{label}: cannot match fixture to outputs: {names}")
+            return
+    if actual.read_bytes() != fixture_path.read_bytes():
+        errors.append(f"{label}: solution output does not match fixture {fixture_path}")
+
+
+def _run_repro_ci(entries: list[dict[str, Any]], errors: list[str]) -> None:
+    for entry in entries:
+        if entry.get("repro_ci") is not True:
+            continue
+        label = f"{entry['benchmark']}/{entry['solver']}"
+        solver_dir = _solver_path(entry)
+        returncode, launch_error = _run_command(
+            ["./setup.sh"],
+            cwd=solver_dir,
+            timeout_s=DEFAULT_SETUP_TIMEOUT_S,
+        )
+        if launch_error is not None:
+            errors.append(f"{label}: setup.sh could not complete: {launch_error}")
+            continue
+        if returncode != 0:
+            errors.append(f"{label}: setup.sh failed")
+            continue
+        with tempfile.TemporaryDirectory(prefix="astroreason-solver-ci-") as tmp:
+            tmp_root = Path(tmp)
+            for index, item in enumerate(entry["case_and_fixture_paths"]):
+                run_dir = tmp_root / f"case_{index}"
+                config_dir = run_dir / "config"
+                solution_dir = run_dir / "solution"
+                config_dir.mkdir(parents=True)
+                solution_dir.mkdir(parents=True)
+                case_path = (REPO_ROOT / item["case_path"]).resolve()
+                command = [
+                    "./solve.sh",
+                    str(case_path),
+                    str(config_dir.resolve()),
+                    str(solution_dir.resolve()),
+                ]
+                returncode, launch_error = _run_command(
+                    command,
+                    cwd=solver_dir,
+                    timeout_s=DEFAULT_SOLVE_TIMEOUT_S,
+                )
+                if launch_error is not None:
+                    errors.append(
+                        f"{label}: solve.sh could not complete for {item['case_path']}: {launch_error}"
+                    )
+                    continue
+                if returncode != 0:
+                    errors.append(f"{label}: solve.sh failed for {item['case_path']}")
+                    continue
+                fixture = item.get("fixture_path", "")
+                if fixture:
+                    _compare_fixture(solution_dir, REPO_ROOT / fixture, label, errors)
+
+
+def main() -> int:
+    errors: list[str] = []
+    entries = _validate_registry(errors)
+    _validate_boundaries(errors)
+    _validate_pytest_boundary(errors)
+    _run_repro_ci(entries, errors)
+    _run_solver_tests(entries, errors)
+
+    if errors:
+        print("Solver contract validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Solver contract validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/solvers/aeossp_standard/greedy_lns/README.md
+++ b/solvers/aeossp_standard/greedy_lns/README.md
@@ -167,6 +167,12 @@ uv run python experiments/main_solver/run.py \
   --case test/case_0001
 ```
 
+Solver-local tests:
+
+```bash
+./solvers/aeossp_standard/greedy_lns/test.sh
+```
+
 Aggregate experiment results:
 
 ```bash

--- a/solvers/aeossp_standard/greedy_lns/solve.sh
+++ b/solvers/aeossp_standard/greedy_lns/solve.sh
@@ -10,9 +10,7 @@ SOLUTION_DIR="${3:-solution}"
 export MPLCONFIGDIR
 mkdir -p "${MPLCONFIGDIR}"
 
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-
-PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}" python -m solvers.aeossp_standard.greedy_lns.src.solve \
+PYTHONPATH="${SCRIPT_DIR}${PYTHONPATH:+:${PYTHONPATH}}" python -m src.solve \
   --case-dir "${CASE_DIR}" \
   --config-dir "${CONFIG_DIR}" \
   --solution-dir "${SOLUTION_DIR}"

--- a/solvers/aeossp_standard/greedy_lns/test.sh
+++ b/solvers/aeossp_standard/greedy_lns/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+cd "${REPO_ROOT}"
+uv run pytest "${SCRIPT_DIR}/tests"

--- a/solvers/aeossp_standard/greedy_lns/tests/test_aeossp_standard_greedy_lns.py
+++ b/solvers/aeossp_standard/greedy_lns/tests/test_aeossp_standard_greedy_lns.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(REPO_ROOT))
 
 from solvers.aeossp_standard.greedy_lns.src.candidates import (  # noqa: E402

--- a/solvers/aeossp_standard/mwis_conflict_graph/README.md
+++ b/solvers/aeossp_standard/mwis_conflict_graph/README.md
@@ -183,6 +183,12 @@ uv run python experiments/main_solver/run.py \
   --case test/case_0001
 ```
 
+Solver-local tests:
+
+```bash
+./solvers/aeossp_standard/mwis_conflict_graph/test.sh
+```
+
 Aggregate experiment results:
 
 ```bash

--- a/solvers/aeossp_standard/mwis_conflict_graph/solve.sh
+++ b/solvers/aeossp_standard/mwis_conflict_graph/solve.sh
@@ -10,9 +10,7 @@ SOLUTION_DIR="${3:-solution}"
 export MPLCONFIGDIR
 mkdir -p "${MPLCONFIGDIR}"
 
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-
-PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}" python -m solvers.aeossp_standard.mwis_conflict_graph.src.solve \
+PYTHONPATH="${SCRIPT_DIR}${PYTHONPATH:+:${PYTHONPATH}}" python -m src.solve \
   --case-dir "${CASE_DIR}" \
   --config-dir "${CONFIG_DIR}" \
   --solution-dir "${SOLUTION_DIR}"

--- a/solvers/aeossp_standard/mwis_conflict_graph/test.sh
+++ b/solvers/aeossp_standard/mwis_conflict_graph/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+cd "${REPO_ROOT}"
+uv run pytest "${SCRIPT_DIR}/tests"

--- a/solvers/aeossp_standard/mwis_conflict_graph/tests/test_aeossp_standard_mwis.py
+++ b/solvers/aeossp_standard/mwis_conflict_graph/tests/test_aeossp_standard_mwis.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(REPO_ROOT))
 
 from solvers.aeossp_standard.mwis_conflict_graph.src.candidates import (  # noqa: E402

--- a/solvers/finished_solvers.json
+++ b/solvers/finished_solvers.json
@@ -1,53 +1,50 @@
 {
-  "version": 1,
   "solvers": [
     {
       "benchmark": "spot5",
       "solver": "reference_lookup",
-      "path": "solvers/spot5/reference_lookup",
-      "evidence_type": "fixture_backed_lookup",
-      "runnable": true,
-      "ci_smoke": true
+      "repro_ci": true,
+      "case_and_fixture_paths": [
+        {
+          "case_path": "benchmarks/spot5/dataset/cases/test/8",
+          "fixture_path": "solvers/spot5/reference_lookup/assets/solutions/8.spot_sol.txt"
+        }
+      ]
     },
     {
       "benchmark": "satnet",
       "solver": "milp_claudet2022",
-      "path": "solvers/satnet/milp_claudet2022",
-      "evidence_type": "citation_reported",
-      "runnable": false,
-      "ci_smoke": false
+      "repro_ci": false,
+      "repro_ci_reason": "citation_based",
+      "case_and_fixture_paths": []
     },
     {
       "benchmark": "satnet",
       "solver": "rl_ppo_goh2021",
-      "path": "solvers/satnet/rl_ppo_goh2021",
-      "evidence_type": "citation_reported",
-      "runnable": false,
-      "ci_smoke": false
+      "repro_ci": false,
+      "repro_ci_reason": "citation_based",
+      "case_and_fixture_paths": []
     },
     {
       "benchmark": "aeossp_standard",
       "solver": "mwis_conflict_graph",
-      "path": "solvers/aeossp_standard/mwis_conflict_graph",
-      "evidence_type": "reproduced_solver",
-      "runnable": true,
-      "ci_smoke": true
+      "repro_ci": false,
+      "repro_ci_reason": "too_expensive",
+      "case_and_fixture_paths": []
     },
     {
       "benchmark": "aeossp_standard",
       "solver": "greedy_lns",
-      "path": "solvers/aeossp_standard/greedy_lns",
-      "evidence_type": "reproduced_solver",
-      "runnable": true,
-      "ci_smoke": true
+      "repro_ci": false,
+      "repro_ci_reason": "too_expensive",
+      "case_and_fixture_paths": []
     },
     {
       "benchmark": "stereo_imaging",
       "solver": "cp_local_search_stereo_insertion",
-      "path": "solvers/stereo_imaging/cp_local_search_stereo_insertion",
-      "evidence_type": "reproduced_solver",
-      "runnable": true,
-      "ci_smoke": true
+      "repro_ci": false,
+      "repro_ci_reason": "too_expensive",
+      "case_and_fixture_paths": []
     }
   ]
 }

--- a/solvers/stereo_imaging/cp_local_search_stereo_insertion/README.md
+++ b/solvers/stereo_imaging/cp_local_search_stereo_insertion/README.md
@@ -192,6 +192,12 @@ uv run python experiments/main_solver/run.py \
   --case test/case_0001
 ```
 
+Solver-local tests:
+
+```bash
+./solvers/stereo_imaging/cp_local_search_stereo_insertion/test.sh
+```
+
 Aggregate experiment results:
 
 ```bash

--- a/solvers/stereo_imaging/cp_local_search_stereo_insertion/test.sh
+++ b/solvers/stereo_imaging/cp_local_search_stereo_insertion/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+cd "${REPO_ROOT}"
+uv run pytest "${SCRIPT_DIR}/tests"

--- a/solvers/stereo_imaging/cp_local_search_stereo_insertion/tests/test_cp_local_search_stereo_insertion.py
+++ b/solvers/stereo_imaging/cp_local_search_stereo_insertion/tests/test_cp_local_search_stereo_insertion.py
@@ -13,7 +13,7 @@ import brahe
 import numpy as np
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 SOLVER_DIR = REPO_ROOT / "solvers" / "stereo_imaging" / "cp_local_search_stereo_insertion"
 CASE_DIR = REPO_ROOT / "benchmarks" / "stereo_imaging" / "dataset" / "cases" / "test" / "case_0001"
 

--- a/tests/test_solver_contract_scripts.py
+++ b/tests/test_solver_contract_scripts.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+from scripts import validate_solver_contract as solver_contract
+
+
+def test_run_command_reports_launch_errors(tmp_path: Path) -> None:
+    returncode, launch_error = solver_contract._run_command(
+        ["./missing.sh"],
+        cwd=tmp_path,
+    )
+
+    assert returncode is None
+    assert launch_error is not None
+    assert "missing.sh" in launch_error
+
+
+def test_run_command_reports_timeouts(tmp_path: Path) -> None:
+    returncode, launch_error = solver_contract._run_command(
+        [sys.executable, "-c", "import time; time.sleep(1)"],
+        cwd=tmp_path,
+        timeout_s=0.01,
+    )
+
+    assert returncode == 124
+    assert launch_error is not None
+    assert "timed out" in launch_error
+
+
+def test_boundary_scan_skips_generated_solver_dirs(tmp_path: Path, monkeypatch) -> None:
+    repo_root = tmp_path
+    solver_root = repo_root / "solvers" / "demo_benchmark" / "demo_solver"
+    generated = solver_root / ".venv" / "lib"
+    source = solver_root / "src"
+    generated.mkdir(parents=True)
+    source.mkdir(parents=True)
+    (generated / "third_party.py").write_text("import benchmarks\n", encoding="utf-8")
+    (source / "solver.py").write_text("print('ok')\n", encoding="utf-8")
+
+    monkeypatch.setattr(solver_contract, "REPO_ROOT", repo_root)
+
+    files = {path.relative_to(repo_root).as_posix() for path in solver_contract._iter_solver_runtime_files()}
+
+    assert "solvers/demo_benchmark/demo_solver/src/solver.py" in files
+    assert "solvers/demo_benchmark/demo_solver/.venv/lib/third_party.py" not in files
+
+
+def test_pytest_boundary_rejects_solver_path_prefix(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "pytest.ini").write_text(
+        "[pytest]\ntestpaths = tests solvers/foo\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(solver_contract, "REPO_ROOT", tmp_path)
+
+    errors: list[str] = []
+    solver_contract._validate_pytest_boundary(errors)
+
+    assert "pytest.ini testpaths must not include solvers/" in errors
+
+
+def test_non_executable_test_sh_is_reported_without_traceback(tmp_path: Path, monkeypatch) -> None:
+    repo_root = tmp_path
+    solver_dir = repo_root / "solvers" / "demo_benchmark" / "demo_solver"
+    solver_dir.mkdir(parents=True)
+    test_script = solver_dir / "test.sh"
+    test_script.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    test_script.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    monkeypatch.setattr(solver_contract, "REPO_ROOT", repo_root)
+
+    errors: list[str] = []
+    solver_contract._run_solver_tests(
+        [{"benchmark": "demo_benchmark", "solver": "demo_solver"}],
+        errors,
+    )
+
+    assert errors
+    assert "could not complete" in errors[0]
+
+
+def test_solver_tests_run_setup_first(tmp_path: Path, monkeypatch) -> None:
+    repo_root = tmp_path
+    solver_dir = repo_root / "solvers" / "demo_benchmark" / "demo_solver"
+    solver_dir.mkdir(parents=True)
+    setup_script = solver_dir / "setup.sh"
+    test_script = solver_dir / "test.sh"
+    marker = solver_dir / "setup.marker"
+    setup_script.write_text("#!/usr/bin/env bash\ntouch setup.marker\n", encoding="utf-8")
+    test_script.write_text(
+        "#!/usr/bin/env bash\n"
+        "test -f setup.marker\n",
+        encoding="utf-8",
+    )
+    setup_script.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+    test_script.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+    monkeypatch.setattr(solver_contract, "REPO_ROOT", repo_root)
+
+    errors: list[str] = []
+    solver_contract._run_solver_tests(
+        [{"benchmark": "demo_benchmark", "solver": "demo_solver"}],
+        errors,
+    )
+
+    assert errors == []
+    assert marker.exists()


### PR DESCRIPTION
Closes #121

## Summary

- Finalizes the solver contract around CI-enforced invariants, solver-local setup/build outputs, and solver-local test boundaries.
- Reworks `solvers/finished_solvers.json` into a reproducibility/CI registry using `benchmark`, `solver`, `repro_ci`, optional `repro_ci_reason`, and `case_and_fixture_paths`.
- Adds `scripts/validate_solver_contract.py`, which now performs static contract checks, runs `repro_ci` cases, and runs detected solver-local `test.sh` entrypoints in one invocation.
- Moves existing solver tests under their solver directories and adds `test.sh` wrappers for the three reproduced solvers.
- Updates CI to run the consolidated solver contract validator as a single step.

## Validation

- `uv run python scripts/validate_solver_contract.py`
- `uv run pytest tests/`

## Notes

- Experiment-owned evidence metadata remains in `experiments/main_solver/solvers/*.yaml`; `finished_solvers.json` is now only the solver contract / CI registry.
- Existing heavy reproduced solvers are marked `repro_ci: false` with `too_expensive`; their solver-local tests still run through detected `test.sh` entrypoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated solver contract validation in CI
  * Enabled solver-local test execution capability

* **Documentation**
  * Clarified solver isolation, environment setup, and execution boundaries
  * Updated solver contract specifications and registry format

* **Chores**
  * Updated solver registry with reproducibility controls and test case mappings
  * Expanded .gitignore for solver build and cache artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->