### PR TITLE
Switch revisit constellation metric to mean of capped maxima

### DIFF
--- a/benchmarks/revisit_constellation/README.md
+++ b/benchmarks/revisit_constellation/README.md
@@ -149,7 +149,7 @@ The new benchmark is purely revisit-driven.
 
 The verifier reports these metrics for valid solutions:
 
-- `capped_max_revisit_gap_hours`: per-target max revisit gap floored at that target's expected revisit period, then aggregated by maximum
+- `capped_max_revisit_gap_hours`: per-target max revisit gap floored at that target's expected revisit period, then aggregated by mean
 - `num_satellites`
 - `target_gap_summary`: per-target breakdown with `expected_revisit_period_hours`, `max_revisit_gap_hours`, `mean_revisit_gap_hours`, and `observation_count`
 

--- a/benchmarks/revisit_constellation/dataset/cases/test/case_0001/assets.json
+++ b/benchmarks/revisit_constellation/dataset/cases/test/case_0001/assets.json
@@ -7,7 +7,7 @@
       "max_slew_velocity_deg_per_sec": 1.0,
       "settling_time_sec": 10.0
     },
-    "max_altitude_m": 850000.0,
+    "max_altitude_m": 900000.0,
     "min_altitude_m": 500000.0,
     "model_name": "balanced_leo_eo_bus_v1",
     "resource_model": {

--- a/benchmarks/revisit_constellation/dataset/cases/test/case_0002/assets.json
+++ b/benchmarks/revisit_constellation/dataset/cases/test/case_0002/assets.json
@@ -7,7 +7,7 @@
       "max_slew_velocity_deg_per_sec": 1.0,
       "settling_time_sec": 10.0
     },
-    "max_altitude_m": 850000.0,
+    "max_altitude_m": 900000.0,
     "min_altitude_m": 500000.0,
     "model_name": "balanced_leo_eo_bus_v1",
     "resource_model": {

--- a/benchmarks/revisit_constellation/dataset/cases/test/case_0003/assets.json
+++ b/benchmarks/revisit_constellation/dataset/cases/test/case_0003/assets.json
@@ -7,7 +7,7 @@
       "max_slew_velocity_deg_per_sec": 1.0,
       "settling_time_sec": 10.0
     },
-    "max_altitude_m": 850000.0,
+    "max_altitude_m": 900000.0,
     "min_altitude_m": 500000.0,
     "model_name": "balanced_leo_eo_bus_v1",
     "resource_model": {

--- a/benchmarks/revisit_constellation/dataset/cases/test/case_0004/assets.json
+++ b/benchmarks/revisit_constellation/dataset/cases/test/case_0004/assets.json
@@ -7,7 +7,7 @@
       "max_slew_velocity_deg_per_sec": 1.0,
       "settling_time_sec": 10.0
     },
-    "max_altitude_m": 850000.0,
+    "max_altitude_m": 900000.0,
     "min_altitude_m": 500000.0,
     "model_name": "balanced_leo_eo_bus_v1",
     "resource_model": {

--- a/benchmarks/revisit_constellation/dataset/cases/test/case_0005/assets.json
+++ b/benchmarks/revisit_constellation/dataset/cases/test/case_0005/assets.json
@@ -7,7 +7,7 @@
       "max_slew_velocity_deg_per_sec": 1.0,
       "settling_time_sec": 10.0
     },
-    "max_altitude_m": 850000.0,
+    "max_altitude_m": 900000.0,
     "min_altitude_m": 500000.0,
     "model_name": "balanced_leo_eo_bus_v1",
     "resource_model": {

--- a/benchmarks/revisit_constellation/splits.yaml
+++ b/benchmarks/revisit_constellation/splits.yaml
@@ -61,4 +61,4 @@ splits:
         settling_time_sec: 10.0
         maneuver_discharge_rate_w: 90.0
       min_altitude_m: 500000.0
-      max_altitude_m: 850000.0
+      max_altitude_m: 900000.0

--- a/benchmarks/revisit_constellation/verifier/engine.py
+++ b/benchmarks/revisit_constellation/verifier/engine.py
@@ -548,7 +548,9 @@ def _compute_metrics(
 
     return {
         "capped_max_revisit_gap_hours": (
-            max(target_capped_max_gaps) if target_capped_max_gaps else 0.0
+            sum(target_capped_max_gaps) / len(target_capped_max_gaps)
+            if target_capped_max_gaps
+            else 0.0
         ),
         "num_satellites": satellite_count,
         "target_gap_summary": target_gap_summary,

--- a/experiments/_fragments/prompts/revisit_constellation/README.default.md
+++ b/experiments/_fragments/prompts/revisit_constellation/README.default.md
@@ -21,9 +21,8 @@ This problem combines constellation design and scheduling in one case. You choos
 A strong solution should:
 
 - satisfy all hard validity rules
-- reduce the worst revisit gaps first
-- then reduce average revisit gaps
-- use fewer satellites when the revisit targets are already being met
+- reduce average capped per-target revisit gaps
+- then use fewer satellites when the revisit targets are already being met
 
 In practical terms, feasibility comes first. After that, the solution should drive revisit gaps down as much as possible, and efficient constellation size matters once the required revisit quality is achieved.
 
@@ -132,7 +131,7 @@ target_capped_gap = max(max_revisit_gap_hours, expected_revisit_period_hours)
 The primary metric is:
 
 ```text
-capped_max_revisit_gap_hours = max(target_capped_gap over targets)
+capped_max_revisit_gap_hours = mean(target_capped_gap over targets)
 ```
 
 Lower is better; `num_satellites` is a secondary metric after revisit quality. Poor revisit gaps do not invalidate an otherwise feasible solution. Residual ambiguity remains around numerical orbit and visibility boundaries; validate borderline states and contacts with the local helper.

--- a/tests/benchmarks/test_revisit_constellation_generator.py
+++ b/tests/benchmarks/test_revisit_constellation_generator.py
@@ -85,7 +85,7 @@ def _write_splits_yaml(path: Path) -> None:
                         "maneuver_discharge_rate_w": 90.0,
                     },
                     "min_altitude_m": 500000.0,
-                    "max_altitude_m": 850000.0,
+                    "max_altitude_m": 900000.0,
                 },
             }
         },

--- a/tests/benchmarks/test_revisit_constellation_verifier.py
+++ b/tests/benchmarks/test_revisit_constellation_verifier.py
@@ -877,4 +877,4 @@ def test_compute_metrics_capped_gap_uses_per_target_threshold(tmp_path: Path) ->
 
     assert metrics["target_gap_summary"]["t1"]["max_revisit_gap_hours"] == pytest.approx(0.75)
     assert metrics["target_gap_summary"]["t2"]["max_revisit_gap_hours"] == pytest.approx(1.0)
-    assert metrics["capped_max_revisit_gap_hours"] == pytest.approx(1.0)
+    assert metrics["capped_max_revisit_gap_hours"] == pytest.approx(0.875)


### PR DESCRIPTION
## Summary

- Changed revisit constellation verifier scoring to remove the old single-worst-target capped max metric and use the average across per-target capped maxima, while keeping the legacy output key `capped_max_revisit_gap_hours`.
- Updated docs/prompts to describe the new metric aggregation.
- Updated test split configuration and public case envelope values to 900000 max altitude where relevant.
- Added/updated benchmark tests for the new expected metric behavior.

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated satellite revisit gap metric aggregation from worst-case (maximum) to average across targets for more balanced optimization.
  * Increased maximum allowed satellite altitude parameter in benchmark configurations.

* **Documentation**
  * Updated metric definitions and scoring priorities to reflect new mean-based aggregation approach.

* **Tests**
  * Updated test fixtures and assertions to align with revised metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->