### PR TITLE
[codex] Add Orekit and Basilisk to runtime image

### DIFF
--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -73,6 +73,25 @@ For the first slice, a runtime image may include:
 
 The exact toolset may evolve, but the contract should remain restrained.
 
+## Base Runtime Astrodynamics Tools
+
+The base runtime includes shared astrodynamics tooling that is broadly useful to
+solver and experiment workflows:
+
+- Brahe for Python-native orbital dynamics utilities used by benchmark-side and
+  solver-side checks.
+- Skyfield and scientific Python libraries for lightweight independent orbit and
+  geometry analyses.
+- Orekit through the `orekit-jpype` Python package. Because Orekit is Java-based,
+  the base image installs OpenJDK 17 and sets `JAVA_HOME`.
+- Basilisk through the `bsk` Python package as the Python 3.13-compatible
+  high-fidelity simulation framework available in this runtime.
+
+`poliastro` is intentionally omitted from the Python 3.13 base image while its
+published package metadata requires Python versions below 3.11. If a compatible
+release becomes available later, it can be reconsidered as a normal runtime
+dependency update.
+
 ## What This Contract Does Not Promise Yet
 
 This document does not yet standardize:

--- a/runtimes/base/Dockerfile
+++ b/runtimes/base/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV UV_TOOL_BIN_DIR=/usr/local/bin
 ENV UV_TOOL_DIR=/usr/local/lib/uv/tools
 ENV FACTORY_INSTALL_HOME=/usr/local/share/factory-home
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV PATH="${FACTORY_INSTALL_HOME}/.factory/bin:/usr/local/bin:${PATH}"
 ENV DISABLE_AUTOUPDATER=1
 
@@ -17,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     jq \
     less \
+    openjdk-17-jre-headless \
     ripgrep \
     tree \
     vim-tiny \
@@ -39,15 +41,17 @@ RUN npm install -g \
     opencode-ai
 
 RUN uv pip install --system \
+    'bsk==2.9.0' \
     'brahe==1.4.2' \
     'datasets==4.8.4' \
     'huggingface-hub==1.12.0' \
     'kagglehub[pandas-datasets]==1.0.0' \
-    'matplotlib==3.10.9' \
+    'matplotlib==3.10.7' \
     'networkx==3.6.1' \
-    'numpy==2.4.4' \
+    'numpy==2.2.6' \
+    'orekit-jpype==13.1.4.0' \
     'ortools==9.15.6755' \
-    'pandas==3.0.2' \
+    'pandas==2.3.3' \
     'plotly==6.7.0' \
     'pulp==3.3.0' \
     'pydantic==2.13.3' \
@@ -61,7 +65,7 @@ RUN uv pip install --system \
     'shapely==2.1.2' \
     'skyfield==1.54' \
     'sympy==1.14.0' \
-    'tqdm==4.67.3'
+    'tqdm==4.67.1'
 
 RUN uv tool install --python 3.13 kimi-cli
 
@@ -69,8 +73,10 @@ RUN set -eux; \
     for cmd in claude codex gemini jq kimi opencode pi rg tree; do \
         command -v "$cmd"; \
     done; \
+    java -version; \
     command -v pyinstaller; \
-    python -c "import brahe, datasets, huggingface_hub, kagglehub, matplotlib, networkx, numpy, ortools, pandas, plotly, pulp, pydantic, pygmo, pyproj, PyInstaller, scipy, shapely, sklearn, skyfield, sympy, tqdm, yaml, pytest" >/dev/null
+    python -c "import Basilisk, brahe, datasets, huggingface_hub, kagglehub, matplotlib, networkx, numpy, orekit_jpype, ortools, pandas, plotly, pulp, pydantic, pygmo, pyproj, PyInstaller, scipy, shapely, sklearn, skyfield, sympy, tqdm, yaml, pytest" >/dev/null; \
+    python -c "import orekit_jpype as orekit; orekit.initVM(); from org.orekit.time import AbsoluteDate; assert AbsoluteDate.J2000_EPOCH is not None"
 
 WORKDIR /app/workspace
 


### PR DESCRIPTION
## Summary

- install OpenJDK 17 in the base runtime and expose `JAVA_HOME` for Orekit
- add `orekit-jpype==13.1.4.0` and `bsk==2.9.0` to the Python 3.13 runtime image
- tune shared scientific pins to satisfy Basilisk/Orekit constraints and document why `poliastro` is omitted
- extend Dockerfile smoke checks to verify Java, Basilisk import, and Orekit JVM startup

Closes #138.

## Validation

- `uv run python runtimes/base/build.py --tag astroreason-base:issue-138`