### PR TITLE
[codex] Add main_agentic harness cooldown

### DIFF
--- a/experiments/main_agentic/README.md
+++ b/experiments/main_agentic/README.md
@@ -76,11 +76,7 @@ uv run python experiments/main_agentic/run.py --dry-run --harness-cooldown 30
 uv run python experiments/main_agentic/plan.py --harness-cooldown 30
 ```
 
-`--harness-cooldown` is batch-only and must be a non-negative integer. A value of
-`0` preserves the current no-cooldown configuration. Nonzero cooldown is measured
-from a harness run's finish time to the next same-harness submission; while one
-harness is cooling down, ready runs from other harnesses can fill free worker
-slots.
+`--harness-cooldown` is batch-only and must be a non-negative integer. A value of `0` preserves the current no-cooldown configuration. Nonzero cooldown is measured from a harness run's finish time to the next same-harness submission; while one harness is cooling down, ready runs from other harnesses can fill free worker slots.
 
 ## Resume And Rerun Controls
 

--- a/experiments/main_agentic/README.md
+++ b/experiments/main_agentic/README.md
@@ -62,6 +62,26 @@ uv run python experiments/main_agentic/plan.py --max-concurrency 2
 
 `--max-concurrency` is batch-only. The run queue is case-major within each benchmark, so concurrent workers are less likely to start several jobs from the same harness at once.
 
+Configure an optional per-harness cooldown in `configs/matrix.yaml`:
+
+```yaml
+batch:
+  harness_cooldown_seconds: 30
+```
+
+Preview or override the configured value for one invocation:
+
+```bash
+uv run python experiments/main_agentic/run.py --dry-run --harness-cooldown 30
+uv run python experiments/main_agentic/plan.py --harness-cooldown 30
+```
+
+`--harness-cooldown` is batch-only and must be a non-negative integer. A value of
+`0` preserves the current no-cooldown configuration. Nonzero cooldown is measured
+from a harness run's finish time to the next same-harness submission; while one
+harness is cooling down, ready runs from other harnesses can fill free worker
+slots.
+
 ## Resume And Rerun Controls
 
 Default batch behavior is artifact-first:

--- a/experiments/main_agentic/configs/matrix.yaml
+++ b/experiments/main_agentic/configs/matrix.yaml
@@ -29,6 +29,7 @@ defaults:
 batch:
   max_concurrency: 6
   max_retries: 1
+  harness_cooldown_seconds: 0
   skip_completed: true
   retry_statuses:
     - runner_error

--- a/experiments/main_agentic/plan.py
+++ b/experiments/main_agentic/plan.py
@@ -63,6 +63,7 @@ class ResourceLimits:
 class BatchSettings:
     max_concurrency: int
     max_retries: int
+    harness_cooldown_seconds: int
     skip_completed: bool
     retry_statuses: tuple[str, ...]
 
@@ -315,6 +316,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--max-concurrency",
         type=int,
         help="Override matrix.yaml batch.max_concurrency for this planning pass.",
+    )
+    parser.add_argument(
+        "--harness-cooldown",
+        type=int,
+        help="Override matrix.yaml batch.harness_cooldown_seconds for this planning pass.",
     )
     parser.add_argument(
         "--rerun-status",
@@ -572,6 +578,13 @@ def load_batch_config(config_path: Path) -> BatchConfig:
 
     max_concurrency = _optional_int(batch, "max_concurrency", None, "Batch config", config_path)
     max_retries = _optional_int(batch, "max_retries", None, "Batch config", config_path)
+    harness_cooldown_seconds = _optional_int(
+        batch,
+        "harness_cooldown_seconds",
+        0,
+        "Batch config",
+        config_path,
+    )
     if max_concurrency is None or max_concurrency <= 0:
         raise SystemExit(
             f"Batch config field 'max_concurrency' must be a positive integer: {config_path}"
@@ -579,6 +592,10 @@ def load_batch_config(config_path: Path) -> BatchConfig:
     if max_retries is None or max_retries < 0:
         raise SystemExit(
             f"Batch config field 'max_retries' must be a non-negative integer: {config_path}"
+        )
+    if harness_cooldown_seconds is None or harness_cooldown_seconds < 0:
+        raise SystemExit(
+            f"Batch config field 'harness_cooldown_seconds' must be a non-negative integer: {config_path}"
         )
 
     retry_statuses_value = batch.get("retry_statuses")
@@ -602,6 +619,7 @@ def load_batch_config(config_path: Path) -> BatchConfig:
         batch=BatchSettings(
             max_concurrency=max_concurrency,
             max_retries=max_retries,
+            harness_cooldown_seconds=harness_cooldown_seconds,
             skip_completed=_optional_bool(
                 batch, "skip_completed", True, "Batch config", config_path
             ),
@@ -1090,6 +1108,7 @@ def build_batch_plan(
     split_override: str | None = None,
     case_filters: tuple[str, ...] = (),
     max_concurrency_override: int | None = None,
+    harness_cooldown_override: int | None = None,
     require_real_configs: bool = False,
 ) -> BatchPlan:
     config = load_batch_config(config_path.resolve())
@@ -1099,6 +1118,16 @@ def build_batch_plan(
         config = replace(
             config,
             batch=replace(config.batch, max_concurrency=max_concurrency_override),
+        )
+    if harness_cooldown_override is not None:
+        if harness_cooldown_override < 0:
+            raise SystemExit("--harness-cooldown must be a non-negative integer.")
+        config = replace(
+            config,
+            batch=replace(
+                config.batch,
+                harness_cooldown_seconds=harness_cooldown_override,
+            ),
         )
     effective_split = split_override or config.split
     selected_benchmarks = _select_names(
@@ -1335,6 +1364,7 @@ def describe_batch_preview(preview: BatchPreview, *, include_items: bool = True)
         f"Runnable queue length: {len(runnable_items)}",
         f"Max concurrency: {plan.config.batch.max_concurrency}",
         f"Max retries: {plan.config.batch.max_retries}",
+        f"Harness cooldown seconds: {plan.config.batch.harness_cooldown_seconds}",
     ]
     if plan.unavailable_configs:
         lines.append("Unavailable harness configs:")
@@ -1402,9 +1432,14 @@ def main(argv: list[str] | None = None) -> int:
     case_filters = tuple(args.case)
 
     if args.interactive:
-        if args.rerun_status or args.no_skip_completed or args.max_concurrency is not None:
+        if (
+            args.rerun_status
+            or args.no_skip_completed
+            or args.max_concurrency is not None
+            or args.harness_cooldown is not None
+        ):
             raise SystemExit(
-                "--rerun-status, --no-skip-completed, and --max-concurrency are batch-only controls and cannot be used with --interactive."
+                "--rerun-status, --no-skip-completed, --max-concurrency, and --harness-cooldown are batch-only controls and cannot be used with --interactive."
             )
         plan = build_interactive_plan(
             config_path=config_path,
@@ -1424,6 +1459,7 @@ def main(argv: list[str] | None = None) -> int:
         split_override=args.split,
         case_filters=case_filters,
         max_concurrency_override=args.max_concurrency,
+        harness_cooldown_override=args.harness_cooldown,
         require_real_configs=False,
     )
     preview = build_batch_preview(

--- a/experiments/main_agentic/plan.py
+++ b/experiments/main_agentic/plan.py
@@ -379,7 +379,7 @@ def _optional_int(
     value = data.get(key, default)
     if value is None:
         return None
-    if not isinstance(value, int):
+    if not isinstance(value, int) or isinstance(value, bool):
         raise SystemExit(f"{kind} field '{key}' must be an integer: {path}")
     return value
 

--- a/experiments/main_agentic/run.py
+++ b/experiments/main_agentic/run.py
@@ -1216,25 +1216,49 @@ def _execute_run_item(
             exit_code=0 if preview_item.existing_overall_status == "success" else 1,
         )
 
-    last_result: RunExecutionResult | None = None
     attempts = batch_settings.max_retries + 1
+    last_result: RunExecutionResult | None = None
     for attempt in range(1, attempts + 1):
-        print(
-            f"Running {item.benchmark}/{item.harness}/{item.case_id} "
-            f"(attempt {attempt}/{attempts})"
+        last_result = _execute_run_item_attempt(
+            preview_item,
+            timeout_override=timeout_override,
+            attempt=attempt,
+            attempts=attempts,
         )
-        last_result = _run_headless_once(item, timeout_override=timeout_override)
         if last_result.overall_status not in batch_settings.retry_statuses:
             return last_result
         if attempt < attempts:
-            print(
-                f"Retrying {item.benchmark}/{item.harness}/{item.case_id} "
-                f"after retryable status {last_result.overall_status}"
-            )
+            _print_retry_line(preview_item, last_result)
 
     if last_result is None:
         raise SystemExit("Internal error: no run result was produced.")
     return last_result
+
+
+def _execute_run_item_attempt(
+    preview_item: family_plan.BatchPreviewItem,
+    *,
+    timeout_override: int | None,
+    attempt: int,
+    attempts: int,
+) -> RunExecutionResult:
+    item = preview_item.item
+    print(
+        f"Running {item.benchmark}/{item.harness}/{item.case_id} "
+        f"(attempt {attempt}/{attempts})"
+    )
+    return _run_headless_once(item, timeout_override=timeout_override)
+
+
+def _print_retry_line(
+    preview_item: family_plan.BatchPreviewItem,
+    result: RunExecutionResult,
+) -> None:
+    item = preview_item.item
+    print(
+        f"Retrying {item.benchmark}/{item.harness}/{item.case_id} "
+        f"after retryable status {result.overall_status}"
+    )
 
 
 def _record_batch_result(
@@ -1402,8 +1426,9 @@ def _run_runnable_items_with_harness_cooldown(
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_map: dict[
             concurrent.futures.Future[RunExecutionResult],
-            family_plan.BatchPreviewItem,
+            tuple[family_plan.BatchPreviewItem, int],
         ] = {}
+        attempts_by_item: dict[int, int] = {}
         while pending or future_map:
             while pending and len(future_map) < max_workers:
                 ready_index = _next_ready_item_index(
@@ -1416,13 +1441,15 @@ def _run_runnable_items_with_harness_cooldown(
                 if ready_index is None:
                     break
                 preview_item = pending.pop(ready_index)
+                attempt = attempts_by_item.get(id(preview_item), 1)
                 future = executor.submit(
-                    _execute_run_item,
+                    _execute_run_item_attempt,
                     preview_item,
-                    batch_settings=batch_settings,
                     timeout_override=timeout_override,
+                    attempt=attempt,
+                    attempts=batch_settings.max_retries + 1,
                 )
-                future_map[future] = preview_item
+                future_map[future] = (preview_item, attempt)
                 active_harnesses.add(preview_item.item.harness)
 
             if not future_map:
@@ -1463,10 +1490,18 @@ def _run_runnable_items_with_harness_cooldown(
             if not done:
                 continue
             for future in done:
-                preview_item = future_map.pop(future)
+                preview_item, attempt = future_map.pop(future)
                 result = future.result()
                 active_harnesses.discard(preview_item.item.harness)
                 last_finish_by_harness[preview_item.item.harness] = _utc_now()
+                if (
+                    result.overall_status in batch_settings.retry_statuses
+                    and attempt < batch_settings.max_retries + 1
+                ):
+                    attempts_by_item[id(preview_item)] = attempt + 1
+                    pending.append(preview_item)
+                    _print_retry_line(preview_item, result)
+                    continue
                 _record_batch_result(
                     progress=progress,
                     total_items=total_items,

--- a/experiments/main_agentic/run.py
+++ b/experiments/main_agentic/run.py
@@ -13,8 +13,9 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -71,6 +72,15 @@ class RunExecutionResult:
     skipped: bool
     output_dir: Path
     exit_code: int
+
+
+@dataclass
+class BatchProgress:
+    results: list[RunExecutionResult]
+    completed: int
+    executed_count: int
+    skipped_count: int
+    status_counts: dict[str, int]
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -132,6 +142,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--max-concurrency",
         type=int,
         help="Override matrix.yaml batch.max_concurrency for this batch execution.",
+    )
+    parser.add_argument(
+        "--harness-cooldown",
+        type=int,
+        help="Override matrix.yaml batch.harness_cooldown_seconds for this batch execution.",
     )
     return parser.parse_args(argv)
 
@@ -1222,17 +1237,257 @@ def _execute_run_item(
     return last_result
 
 
+def _record_batch_result(
+    *,
+    progress: BatchProgress,
+    total_items: int,
+    preview_item: family_plan.BatchPreviewItem,
+    result: RunExecutionResult,
+) -> None:
+    progress.results.append(result)
+    progress.completed += 1
+    if result.skipped:
+        progress.skipped_count += 1
+    else:
+        progress.executed_count += 1
+    progress.status_counts[result.overall_status] = (
+        progress.status_counts.get(result.overall_status, 0) + 1
+    )
+    _print_progress_line(
+        index=progress.completed,
+        total=total_items,
+        preview_item=preview_item,
+        result=result,
+        executed_count=progress.executed_count,
+        skipped_count=progress.skipped_count,
+        status_counts=progress.status_counts,
+    )
+
+
+def _skip_result(preview_item: family_plan.BatchPreviewItem) -> RunExecutionResult:
+    return RunExecutionResult(
+        overall_status=preview_item.existing_overall_status or preview_item.artifact_state,
+        skipped=True,
+        output_dir=family_plan.run_output_dir(preview_item.item),
+        exit_code=0 if preview_item.existing_overall_status == "success" else 1,
+    )
+
+
+def _harness_ready_at(
+    harness: str,
+    *,
+    last_finish_by_harness: dict[str, datetime],
+    cooldown_seconds: int,
+) -> datetime | None:
+    last_finish = last_finish_by_harness.get(harness)
+    if last_finish is None:
+        return None
+    return last_finish + timedelta(seconds=cooldown_seconds)
+
+
+def _next_ready_item_index(
+    pending: list[family_plan.BatchPreviewItem],
+    *,
+    active_harnesses: set[str],
+    last_finish_by_harness: dict[str, datetime],
+    cooldown_seconds: int,
+    now: datetime,
+) -> int | None:
+    for index, preview_item in enumerate(pending):
+        harness = preview_item.item.harness
+        if harness in active_harnesses:
+            continue
+        ready_at = _harness_ready_at(
+            harness,
+            last_finish_by_harness=last_finish_by_harness,
+            cooldown_seconds=cooldown_seconds,
+        )
+        if ready_at is None or ready_at <= now:
+            return index
+    return None
+
+
+def _earliest_pending_ready_at(
+    pending: list[family_plan.BatchPreviewItem],
+    *,
+    active_harnesses: set[str],
+    last_finish_by_harness: dict[str, datetime],
+    cooldown_seconds: int,
+    now: datetime,
+) -> datetime | None:
+    ready_times: list[datetime] = []
+    for preview_item in pending:
+        harness = preview_item.item.harness
+        if harness in active_harnesses:
+            continue
+        ready_at = _harness_ready_at(
+            harness,
+            last_finish_by_harness=last_finish_by_harness,
+            cooldown_seconds=cooldown_seconds,
+        )
+        if ready_at is None or ready_at <= now:
+            return now
+        ready_times.append(ready_at)
+    if not ready_times:
+        return None
+    return min(ready_times)
+
+
+def _seconds_until(moment: datetime, *, now: datetime) -> float:
+    return max(0.0, (moment - now).total_seconds())
+
+
+def _run_runnable_items_upfront(
+    *,
+    runnable_items: tuple[family_plan.BatchPreviewItem, ...],
+    batch_settings: family_plan.BatchSettings,
+    timeout_override: int | None,
+    max_workers: int,
+    progress: BatchProgress,
+    total_items: int,
+) -> None:
+    if max_workers <= 1:
+        for preview_item in runnable_items:
+            result = _execute_run_item(
+                preview_item,
+                batch_settings=batch_settings,
+                timeout_override=timeout_override,
+            )
+            _record_batch_result(
+                progress=progress,
+                total_items=total_items,
+                preview_item=preview_item,
+                result=result,
+            )
+        return
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_map = {
+            executor.submit(
+                _execute_run_item,
+                preview_item,
+                batch_settings=batch_settings,
+                timeout_override=timeout_override,
+            ): preview_item
+            for preview_item in runnable_items
+        }
+        for future in concurrent.futures.as_completed(future_map):
+            preview_item = future_map[future]
+            result = future.result()
+            _record_batch_result(
+                progress=progress,
+                total_items=total_items,
+                preview_item=preview_item,
+                result=result,
+            )
+
+
+def _run_runnable_items_with_harness_cooldown(
+    *,
+    runnable_items: tuple[family_plan.BatchPreviewItem, ...],
+    batch_settings: family_plan.BatchSettings,
+    timeout_override: int | None,
+    max_workers: int,
+    progress: BatchProgress,
+    total_items: int,
+) -> None:
+    if not runnable_items:
+        return
+
+    pending = list(runnable_items)
+    active_harnesses: set[str] = set()
+    last_finish_by_harness: dict[str, datetime] = {}
+    cooldown_seconds = batch_settings.harness_cooldown_seconds
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_map: dict[
+            concurrent.futures.Future[RunExecutionResult],
+            family_plan.BatchPreviewItem,
+        ] = {}
+        while pending or future_map:
+            while pending and len(future_map) < max_workers:
+                ready_index = _next_ready_item_index(
+                    pending,
+                    active_harnesses=active_harnesses,
+                    last_finish_by_harness=last_finish_by_harness,
+                    cooldown_seconds=cooldown_seconds,
+                    now=_utc_now(),
+                )
+                if ready_index is None:
+                    break
+                preview_item = pending.pop(ready_index)
+                future = executor.submit(
+                    _execute_run_item,
+                    preview_item,
+                    batch_settings=batch_settings,
+                    timeout_override=timeout_override,
+                )
+                future_map[future] = preview_item
+                active_harnesses.add(preview_item.item.harness)
+
+            if not future_map:
+                ready_at = _earliest_pending_ready_at(
+                    pending,
+                    active_harnesses=active_harnesses,
+                    last_finish_by_harness=last_finish_by_harness,
+                    cooldown_seconds=cooldown_seconds,
+                    now=_utc_now(),
+                )
+                if ready_at is None:
+                    raise SystemExit("Internal error: no pending batch item can become ready.")
+                delay = _seconds_until(ready_at, now=_utc_now())
+                if delay > 0:
+                    time.sleep(delay)
+                continue
+
+            if len(future_map) >= max_workers:
+                timeout = None
+            else:
+                next_ready_at = _earliest_pending_ready_at(
+                    pending,
+                    active_harnesses=active_harnesses,
+                    last_finish_by_harness=last_finish_by_harness,
+                    cooldown_seconds=cooldown_seconds,
+                    now=_utc_now(),
+                )
+                timeout = (
+                    None
+                    if next_ready_at is None
+                    else _seconds_until(next_ready_at, now=_utc_now())
+                )
+            done, _ = concurrent.futures.wait(
+                future_map,
+                timeout=timeout,
+                return_when=concurrent.futures.FIRST_COMPLETED,
+            )
+            if not done:
+                continue
+            for future in done:
+                preview_item = future_map.pop(future)
+                result = future.result()
+                active_harnesses.discard(preview_item.item.harness)
+                last_finish_by_harness[preview_item.item.harness] = _utc_now()
+                _record_batch_result(
+                    progress=progress,
+                    total_items=total_items,
+                    preview_item=preview_item,
+                    result=result,
+                )
+
+
 def _run_batch(
     args: argparse.Namespace,
     preview: family_plan.BatchPreview,
 ) -> int:
     runnable_items = family_plan.runnable_preview_items(preview)
-    results: list[RunExecutionResult] = []
     total_items = len(preview.items)
-    completed = 0
-    executed_count = 0
-    skipped_count = 0
-    status_counts: dict[str, int] = {}
+    progress = BatchProgress(
+        results=[],
+        completed=0,
+        executed_count=0,
+        skipped_count=0,
+        status_counts={},
+    )
     batch_start = _utc_now()
     max_workers = min(preview.plan.config.batch.max_concurrency, len(runnable_items))
     print(
@@ -1240,96 +1495,48 @@ def _run_batch(
         f"(runnable={len(runnable_items)}, max_concurrency={max_workers or 0})"
     )
 
-    if max_workers <= 1:
-        for preview_item in runnable_items:
-            result = _execute_run_item(
-                preview_item,
-                batch_settings=preview.plan.config.batch,
-                timeout_override=args.timeout,
-            )
-            results.append(result)
-            completed += 1
-            if result.skipped:
-                skipped_count += 1
-            else:
-                executed_count += 1
-            status_counts[result.overall_status] = status_counts.get(result.overall_status, 0) + 1
-            _print_progress_line(
-                index=completed,
-                total=total_items,
-                preview_item=preview_item,
-                result=result,
-                executed_count=executed_count,
-                skipped_count=skipped_count,
-                status_counts=status_counts,
-            )
+    if preview.plan.config.batch.harness_cooldown_seconds == 0:
+        _run_runnable_items_upfront(
+            runnable_items=runnable_items,
+            batch_settings=preview.plan.config.batch,
+            timeout_override=args.timeout,
+            max_workers=max_workers,
+            progress=progress,
+            total_items=total_items,
+        )
     else:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_map = {
-                executor.submit(
-                    _execute_run_item,
-                    preview_item,
-                    batch_settings=preview.plan.config.batch,
-                    timeout_override=args.timeout,
-                ): preview_item
-                for preview_item in runnable_items
-            }
-            for future in concurrent.futures.as_completed(future_map):
-                preview_item = future_map[future]
-                result = future.result()
-                results.append(result)
-                completed += 1
-                if result.skipped:
-                    skipped_count += 1
-                else:
-                    executed_count += 1
-                status_counts[result.overall_status] = status_counts.get(result.overall_status, 0) + 1
-                _print_progress_line(
-                    index=completed,
-                    total=total_items,
-                    preview_item=preview_item,
-                    result=result,
-                    executed_count=executed_count,
-                    skipped_count=skipped_count,
-                    status_counts=status_counts,
-                )
+        _run_runnable_items_with_harness_cooldown(
+            runnable_items=runnable_items,
+            batch_settings=preview.plan.config.batch,
+            timeout_override=args.timeout,
+            max_workers=max_workers,
+            progress=progress,
+            total_items=total_items,
+        )
 
     for preview_item in preview.items:
         if preview_item.action != "skip":
             continue
-        result = RunExecutionResult(
-            overall_status=preview_item.existing_overall_status or preview_item.artifact_state,
-            skipped=True,
-            output_dir=family_plan.run_output_dir(preview_item.item),
-            exit_code=0 if preview_item.existing_overall_status == "success" else 1,
-        )
-        results.append(result)
-        completed += 1
-        skipped_count += 1
-        status_counts[result.overall_status] = status_counts.get(result.overall_status, 0) + 1
-        _print_progress_line(
-            index=completed,
-            total=total_items,
+        _record_batch_result(
+            progress=progress,
+            total_items=total_items,
             preview_item=preview_item,
-            result=result,
-            executed_count=executed_count,
-            skipped_count=skipped_count,
-            status_counts=status_counts,
+            result=_skip_result(preview_item),
         )
 
     exit_code = 0
-    for result in results:
+    for result in progress.results:
         if not result.skipped and result.overall_status != "success":
             exit_code = 1
 
     batch_end = _utc_now()
     print("Batch summary:")
-    print(f"  Total runs considered: {len(results)}")
-    print(f"  Executed runs: {executed_count}")
-    print(f"  Skipped runs: {skipped_count}")
+    print(f"  Total runs considered: {len(progress.results)}")
+    print(f"  Executed runs: {progress.executed_count}")
+    print(f"  Skipped runs: {progress.skipped_count}")
     print(f"  Wall-clock seconds: {_duration_seconds(batch_start, batch_end)}")
-    for status in sorted(status_counts):
-        print(f"  {status}: {status_counts[status]}")
+    for status in sorted(progress.status_counts):
+        print(f"  {status}: {progress.status_counts[status]}")
     return exit_code
 
 
@@ -1445,9 +1652,14 @@ def main(argv: list[str] | None = None) -> int:
     case_filters = tuple(args.case)
 
     if args.interactive:
-        if args.rerun_status or args.no_skip_completed or args.max_concurrency is not None:
+        if (
+            args.rerun_status
+            or args.no_skip_completed
+            or args.max_concurrency is not None
+            or args.harness_cooldown is not None
+        ):
             raise SystemExit(
-                "--rerun-status, --no-skip-completed, and --max-concurrency are batch-only controls and cannot be used with --interactive."
+                "--rerun-status, --no-skip-completed, --max-concurrency, and --harness-cooldown are batch-only controls and cannot be used with --interactive."
             )
         plan = family_plan.build_interactive_plan(
             config_path=config_path,
@@ -1469,6 +1681,7 @@ def main(argv: list[str] | None = None) -> int:
         split_override=args.split,
         case_filters=case_filters,
         max_concurrency_override=args.max_concurrency,
+        harness_cooldown_override=args.harness_cooldown,
         require_real_configs=False,
     )
     preview = family_plan.build_batch_preview(

--- a/tests/experiments/test_main_agentic_plan.py
+++ b/tests/experiments/test_main_agentic_plan.py
@@ -66,6 +66,13 @@ def test_load_batch_config_rejects_negative_harness_cooldown(tmp_path: Path) -> 
         )
 
 
+def test_load_batch_config_rejects_boolean_harness_cooldown(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="harness_cooldown_seconds"):
+        plan.load_batch_config(
+            _write_batch_config(tmp_path, batch_extra="  harness_cooldown_seconds: true")
+        )
+
+
 def test_build_batch_plan_applies_harness_cooldown_override() -> None:
     batch_plan = plan.build_batch_plan(
         config_path=plan.DEFAULT_BATCH_CONFIG,

--- a/tests/experiments/test_main_agentic_plan.py
+++ b/tests/experiments/test_main_agentic_plan.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from experiments.main_agentic import plan
+
+
+def _write_batch_config(tmp_path: Path, *, batch_extra: str = "") -> Path:
+    config_path = tmp_path / "matrix.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: test_matrix",
+                "mode: batch",
+                "benchmarks:",
+                "  - satnet",
+                "harnesses:",
+                "  - codex",
+                "defaults:",
+                "  split: test",
+                "  timeout_seconds: 7200",
+                "batch:",
+                "  max_concurrency: 2",
+                "  max_retries: 1",
+                "  skip_completed: true",
+                "  retry_statuses:",
+                "    - runner_error",
+                "    - timeout",
+                batch_extra.rstrip(),
+                "resources: {}",
+                "results:",
+                "  root: results/agent_runs/experiments/main_agentic",
+                "  aggregate_dir: summaries",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_load_batch_config_defaults_harness_cooldown_to_zero(tmp_path: Path) -> None:
+    config = plan.load_batch_config(_write_batch_config(tmp_path))
+
+    assert config.batch.harness_cooldown_seconds == 0
+
+
+def test_load_batch_config_parses_harness_cooldown(tmp_path: Path) -> None:
+    config = plan.load_batch_config(
+        _write_batch_config(tmp_path, batch_extra="  harness_cooldown_seconds: 30")
+    )
+
+    assert config.batch.harness_cooldown_seconds == 30
+
+
+def test_load_batch_config_rejects_negative_harness_cooldown(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="harness_cooldown_seconds"):
+        plan.load_batch_config(
+            _write_batch_config(tmp_path, batch_extra="  harness_cooldown_seconds: -1")
+        )
+
+
+def test_build_batch_plan_applies_harness_cooldown_override() -> None:
+    batch_plan = plan.build_batch_plan(
+        config_path=plan.DEFAULT_BATCH_CONFIG,
+        benchmark_filters=("satnet",),
+        harness_filters=("codex",),
+        split_override="test",
+        case_filters=("W10_2018",),
+        harness_cooldown_override=45,
+    )
+
+    assert batch_plan.config.batch.harness_cooldown_seconds == 45
+    assert "Harness cooldown seconds: 45" in plan.describe_batch_preview(
+        plan.build_batch_preview(batch_plan)
+    )
+
+
+def test_build_batch_plan_rejects_negative_harness_cooldown_override() -> None:
+    with pytest.raises(SystemExit, match="--harness-cooldown"):
+        plan.build_batch_plan(
+            config_path=plan.DEFAULT_BATCH_CONFIG,
+            benchmark_filters=("satnet",),
+            harness_filters=("codex",),
+            split_override="test",
+            case_filters=("W10_2018",),
+            harness_cooldown_override=-1,
+        )

--- a/tests/experiments/test_main_agentic_run.py
+++ b/tests/experiments/test_main_agentic_run.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from experiments.main_agentic import plan, run
+
+
+def _preview_item(harness: str, case_id: str = "case_0001") -> SimpleNamespace:
+    return SimpleNamespace(
+        action="run",
+        existing_overall_status=None,
+        artifact_state="missing",
+        item=SimpleNamespace(
+            benchmark="satnet",
+            harness=harness,
+            split="test",
+            case_id=case_id,
+        ),
+    )
+
+
+def test_next_ready_item_skips_cooling_harness_when_other_harness_is_ready() -> None:
+    now = datetime(2026, 4, 28, tzinfo=timezone.utc)
+    pending = [
+        _preview_item("codex", "case_a"),
+        _preview_item("gemini_cli", "case_b"),
+        _preview_item("codex", "case_c"),
+    ]
+
+    ready_index = run._next_ready_item_index(
+        pending,
+        active_harnesses=set(),
+        last_finish_by_harness={"codex": now},
+        cooldown_seconds=30,
+        now=now + timedelta(seconds=10),
+    )
+
+    assert ready_index == 1
+
+
+def test_earliest_pending_ready_at_ignores_active_harnesses() -> None:
+    now = datetime(2026, 4, 28, tzinfo=timezone.utc)
+    ready_at = run._earliest_pending_ready_at(
+        [_preview_item("codex"), _preview_item("gemini_cli")],
+        active_harnesses={"gemini_cli"},
+        last_finish_by_harness={"codex": now},
+        cooldown_seconds=30,
+        now=now + timedelta(seconds=10),
+    )
+
+    assert ready_at == now + timedelta(seconds=30)
+
+
+def test_harness_cooldown_scheduler_waits_between_same_harness_runs(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    fake_now = [datetime(2026, 4, 28, tzinfo=timezone.utc)]
+    starts: dict[str, datetime] = {}
+
+    def fake_utc_now() -> datetime:
+        return fake_now[0]
+
+    def fake_sleep(seconds: float) -> None:
+        fake_now[0] += timedelta(seconds=seconds)
+
+    def fake_execute_run_item(
+        preview_item: SimpleNamespace,
+        *,
+        batch_settings: plan.BatchSettings,
+        timeout_override: int | None,
+    ) -> run.RunExecutionResult:
+        starts[preview_item.item.case_id] = fake_now[0]
+        return run.RunExecutionResult(
+            overall_status="success",
+            skipped=False,
+            output_dir=tmp_path / preview_item.item.case_id,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(run, "_utc_now", fake_utc_now)
+    monkeypatch.setattr(run.time, "sleep", fake_sleep)
+    monkeypatch.setattr(run, "_execute_run_item", fake_execute_run_item)
+
+    batch_settings = plan.BatchSettings(
+        max_concurrency=2,
+        max_retries=0,
+        harness_cooldown_seconds=30,
+        skip_completed=True,
+        retry_statuses=(),
+    )
+    progress = run.BatchProgress(
+        results=[],
+        completed=0,
+        executed_count=0,
+        skipped_count=0,
+        status_counts={},
+    )
+
+    run._run_runnable_items_with_harness_cooldown(
+        runnable_items=(
+            _preview_item("codex", "codex_first"),
+            _preview_item("codex", "codex_second"),
+            _preview_item("gemini_cli", "gemini_first"),
+        ),
+        batch_settings=batch_settings,
+        timeout_override=None,
+        max_workers=2,
+        progress=progress,
+        total_items=3,
+    )
+
+    assert starts["gemini_first"] == starts["codex_first"]
+    assert starts["codex_second"] >= starts["codex_first"] + timedelta(seconds=30)
+    assert progress.executed_count == 3
+    assert progress.status_counts == {"success": 3}
+
+
+def test_harness_cooldown_scheduler_measures_from_finish_time(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    fake_now = [datetime(2026, 4, 28, tzinfo=timezone.utc)]
+    starts: dict[str, datetime] = {}
+    durations = {
+        "codex_first": timedelta(seconds=7),
+        "codex_second": timedelta(seconds=0),
+    }
+
+    def fake_utc_now() -> datetime:
+        return fake_now[0]
+
+    def fake_sleep(seconds: float) -> None:
+        fake_now[0] += timedelta(seconds=seconds)
+
+    def fake_execute_run_item(
+        preview_item: SimpleNamespace,
+        *,
+        batch_settings: plan.BatchSettings,
+        timeout_override: int | None,
+    ) -> run.RunExecutionResult:
+        starts[preview_item.item.case_id] = fake_now[0]
+        fake_now[0] += durations[preview_item.item.case_id]
+        return run.RunExecutionResult(
+            overall_status="success",
+            skipped=False,
+            output_dir=tmp_path / preview_item.item.case_id,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(run, "_utc_now", fake_utc_now)
+    monkeypatch.setattr(run.time, "sleep", fake_sleep)
+    monkeypatch.setattr(run, "_execute_run_item", fake_execute_run_item)
+
+    batch_settings = plan.BatchSettings(
+        max_concurrency=1,
+        max_retries=0,
+        harness_cooldown_seconds=30,
+        skip_completed=True,
+        retry_statuses=(),
+    )
+    progress = run.BatchProgress(
+        results=[],
+        completed=0,
+        executed_count=0,
+        skipped_count=0,
+        status_counts={},
+    )
+
+    run._run_runnable_items_with_harness_cooldown(
+        runnable_items=(
+            _preview_item("codex", "codex_first"),
+            _preview_item("codex", "codex_second"),
+        ),
+        batch_settings=batch_settings,
+        timeout_override=None,
+        max_workers=1,
+        progress=progress,
+        total_items=2,
+    )
+
+    assert starts["codex_second"] == (
+        starts["codex_first"] + durations["codex_first"] + timedelta(seconds=30)
+    )
+
+
+def test_run_batch_preserves_upfront_submission_when_cooldown_is_zero(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    preview_item = _preview_item("codex", "case_0001")
+    batch_settings = plan.BatchSettings(
+        max_concurrency=2,
+        max_retries=0,
+        harness_cooldown_seconds=0,
+        skip_completed=True,
+        retry_statuses=(),
+    )
+    preview = SimpleNamespace(
+        items=(preview_item,),
+        plan=SimpleNamespace(config=SimpleNamespace(batch=batch_settings)),
+    )
+    calls: list[str] = []
+
+    def fake_run_upfront(
+        *,
+        runnable_items: tuple[SimpleNamespace, ...],
+        batch_settings: plan.BatchSettings,
+        timeout_override: int | None,
+        max_workers: int,
+        progress: run.BatchProgress,
+        total_items: int,
+    ) -> None:
+        calls.append("upfront")
+        run._record_batch_result(
+            progress=progress,
+            total_items=total_items,
+            preview_item=runnable_items[0],
+            result=run.RunExecutionResult(
+                overall_status="success",
+                skipped=False,
+                output_dir=tmp_path / "case_0001",
+                exit_code=0,
+            ),
+        )
+
+    def fail_cooldown_scheduler(**kwargs: object) -> None:
+        raise AssertionError("cooldown scheduler should not run when cooldown is zero")
+
+    monkeypatch.setattr(run, "_run_runnable_items_upfront", fake_run_upfront)
+    monkeypatch.setattr(run, "_run_runnable_items_with_harness_cooldown", fail_cooldown_scheduler)
+
+    exit_code = run._run_batch(SimpleNamespace(timeout=None), preview)
+
+    assert exit_code == 0
+    assert calls == ["upfront"]

--- a/tests/experiments/test_main_agentic_run.py
+++ b/tests/experiments/test_main_agentic_run.py
@@ -70,11 +70,12 @@ def test_harness_cooldown_scheduler_waits_between_same_harness_runs(
     def fake_sleep(seconds: float) -> None:
         fake_now[0] += timedelta(seconds=seconds)
 
-    def fake_execute_run_item(
+    def fake_execute_run_item_attempt(
         preview_item: SimpleNamespace,
         *,
-        batch_settings: plan.BatchSettings,
         timeout_override: int | None,
+        attempt: int,
+        attempts: int,
     ) -> run.RunExecutionResult:
         starts[preview_item.item.case_id] = fake_now[0]
         return run.RunExecutionResult(
@@ -86,7 +87,7 @@ def test_harness_cooldown_scheduler_waits_between_same_harness_runs(
 
     monkeypatch.setattr(run, "_utc_now", fake_utc_now)
     monkeypatch.setattr(run.time, "sleep", fake_sleep)
-    monkeypatch.setattr(run, "_execute_run_item", fake_execute_run_item)
+    monkeypatch.setattr(run, "_execute_run_item_attempt", fake_execute_run_item_attempt)
 
     batch_settings = plan.BatchSettings(
         max_concurrency=2,
@@ -139,11 +140,12 @@ def test_harness_cooldown_scheduler_measures_from_finish_time(
     def fake_sleep(seconds: float) -> None:
         fake_now[0] += timedelta(seconds=seconds)
 
-    def fake_execute_run_item(
+    def fake_execute_run_item_attempt(
         preview_item: SimpleNamespace,
         *,
-        batch_settings: plan.BatchSettings,
         timeout_override: int | None,
+        attempt: int,
+        attempts: int,
     ) -> run.RunExecutionResult:
         starts[preview_item.item.case_id] = fake_now[0]
         fake_now[0] += durations[preview_item.item.case_id]
@@ -156,7 +158,7 @@ def test_harness_cooldown_scheduler_measures_from_finish_time(
 
     monkeypatch.setattr(run, "_utc_now", fake_utc_now)
     monkeypatch.setattr(run.time, "sleep", fake_sleep)
-    monkeypatch.setattr(run, "_execute_run_item", fake_execute_run_item)
+    monkeypatch.setattr(run, "_execute_run_item_attempt", fake_execute_run_item_attempt)
 
     batch_settings = plan.BatchSettings(
         max_concurrency=1,
@@ -188,6 +190,68 @@ def test_harness_cooldown_scheduler_measures_from_finish_time(
     assert starts["codex_second"] == (
         starts["codex_first"] + durations["codex_first"] + timedelta(seconds=30)
     )
+
+
+def test_harness_cooldown_scheduler_applies_cooldown_between_retries(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    fake_now = [datetime(2026, 4, 28, tzinfo=timezone.utc)]
+    starts: list[datetime] = []
+
+    def fake_utc_now() -> datetime:
+        return fake_now[0]
+
+    def fake_sleep(seconds: float) -> None:
+        fake_now[0] += timedelta(seconds=seconds)
+
+    def fake_execute_run_item_attempt(
+        preview_item: SimpleNamespace,
+        *,
+        timeout_override: int | None,
+        attempt: int,
+        attempts: int,
+    ) -> run.RunExecutionResult:
+        starts.append(fake_now[0])
+        fake_now[0] += timedelta(seconds=7 if attempt == 1 else 0)
+        return run.RunExecutionResult(
+            overall_status="runner_error" if attempt == 1 else "success",
+            skipped=False,
+            output_dir=tmp_path / f"attempt_{attempt}",
+            exit_code=0 if attempt == 2 else 1,
+        )
+
+    monkeypatch.setattr(run, "_utc_now", fake_utc_now)
+    monkeypatch.setattr(run.time, "sleep", fake_sleep)
+    monkeypatch.setattr(run, "_execute_run_item_attempt", fake_execute_run_item_attempt)
+
+    batch_settings = plan.BatchSettings(
+        max_concurrency=1,
+        max_retries=1,
+        harness_cooldown_seconds=30,
+        skip_completed=True,
+        retry_statuses=("runner_error",),
+    )
+    progress = run.BatchProgress(
+        results=[],
+        completed=0,
+        executed_count=0,
+        skipped_count=0,
+        status_counts={},
+    )
+
+    run._run_runnable_items_with_harness_cooldown(
+        runnable_items=(_preview_item("codex", "codex_retry"),),
+        batch_settings=batch_settings,
+        timeout_override=None,
+        max_workers=1,
+        progress=progress,
+        total_items=1,
+    )
+
+    assert starts[1] == starts[0] + timedelta(seconds=37)
+    assert progress.executed_count == 1
+    assert progress.status_counts == {"success": 1}
 
 
 def test_run_batch_preserves_upfront_submission_when_cooldown_is_zero(


### PR DESCRIPTION
## Summary

Resolves #91.

Adds optional per-harness cooldown support to `experiments/main_agentic` batch execution. The new `batch.harness_cooldown_seconds` setting defaults to `0`, preserving the existing upfront submission behavior. Nonzero cooldown uses a readiness-aware submission loop that tracks harness finish times, keeps sleeps outside worker threads, and lets ready runs from other harnesses fill available worker slots.

## Changes

- Added config parsing, validation, preview output, and CLI override plumbing for `harness_cooldown_seconds`.
- Updated `matrix.yaml` and `main_agentic` docs with the default and finish-to-next-start cooldown semantics.
- Reworked `_run_batch` around focused helpers for result accounting, skip results, ready-item selection, and cooldown-aware submission.
- Added deterministic tests for config parsing, override validation, zero-cooldown compatibility, finish-time spacing, and cross-harness fill behavior.

## Validation

- `uv run pytest -q tests/experiments/test_main_agentic_plan.py tests/experiments/test_main_agentic_run.py tests/experiments/test_main_solver_run.py`
- `uv run pytest -q tests/experiments`
- `uv run python experiments/main_agentic/plan.py --benchmark satnet --harness codex --case W10_2018 --max-concurrency 2 --harness-cooldown 1`
- `uv run python -m py_compile experiments/main_agentic/run.py experiments/main_agentic/plan.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-harness cooldown scheduling for batch execution with configurable delays between harness runs.
  * New `--harness-cooldown` CLI flag to override cooldown settings during planning and execution.

* **Documentation**
  * Updated documentation with new cooldown configuration options, validation rules, and usage examples.

* **Tests**
  * Added comprehensive test coverage for cooldown scheduling and batch orchestration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->