### PR TITLE
[codex] Add runtime build CI

### DIFF
--- a/.github/workflows/benchmark-repro.yml
+++ b/.github/workflows/benchmark-repro.yml
@@ -2,9 +2,25 @@ name: Benchmark Repro
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/benchmark-repro.yml"
+      - "benchmarks/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "scripts/check_finished_benchmark_repro.py"
+      - "scripts/validate_benchmark_contract.py"
+      - "tests/benchmarks/**"
   push:
     branches:
       - main
+    paths:
+      - ".github/workflows/benchmark-repro.yml"
+      - "benchmarks/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "scripts/check_finished_benchmark_repro.py"
+      - "scripts/validate_benchmark_contract.py"
+      - "tests/benchmarks/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/runtime-build.yml
+++ b/.github/workflows/runtime-build.yml
@@ -1,0 +1,73 @@
+name: Runtime Build
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/runtime-build.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "runtimes/**"
+      - "scripts/discover_runtime_matrix.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/runtime-build.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "runtimes/**"
+      - "scripts/discover_runtime_matrix.py"
+  workflow_dispatch:
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.runtime-matrix.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Sync environment
+        run: uv sync
+
+      - name: Discover runtime matrix
+        id: runtime-matrix
+        run: |
+          matrix="$(uv run python scripts/discover_runtime_matrix.py)"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build ${{ matrix.name }} runtime
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.build_context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          tags: ${{ matrix.image }}
+          load: true
+          push: false
+          cache-from: type=gha,scope=runtime-${{ matrix.name }}
+          cache-to: type=gha,scope=runtime-${{ matrix.name }},mode=max
+
+      - name: Smoke check ${{ matrix.name }} runtime
+        run: docker run --rm "${{ matrix.image }}" python --version

--- a/scripts/discover_runtime_matrix.py
+++ b/scripts/discover_runtime_matrix.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Discover Docker runtime build metadata for GitHub Actions."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNTIMES_DIR = REPO_ROOT / "runtimes"
+MANIFEST_NAME = "runtime.yaml"
+TOP_LEVEL_DOCKERFILE = "Dockerfile"
+
+
+class RuntimeDiscoveryError(ValueError):
+    """Raised when runtime metadata cannot be converted into a CI matrix."""
+
+
+@dataclass(frozen=True)
+class RuntimeMatrixEntry:
+    name: str
+    image: str
+    dockerfile: Path
+    build_context: Path
+    runtime_dir: Path
+
+    def as_matrix_item(self, repo_root: Path) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "image": self.image,
+            "dockerfile": _repo_relative_posix(self.dockerfile, repo_root),
+            "build_context": _repo_relative_posix(self.build_context, repo_root),
+            "runtime_dir": _repo_relative_posix(self.runtime_dir, repo_root),
+        }
+
+
+def _repo_relative_posix(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise RuntimeDiscoveryError(f"runtime manifest does not exist: {path}")
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise RuntimeDiscoveryError(f"{path}: failed to parse YAML: {exc}") from exc
+    except OSError as exc:
+        raise RuntimeDiscoveryError(f"{path}: failed to read manifest: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeDiscoveryError(f"{path}: runtime manifest must be a YAML mapping")
+    return payload
+
+
+def _require_non_empty_string(
+    payload: dict[str, Any],
+    key: str,
+    manifest_path: Path,
+) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise RuntimeDiscoveryError(
+            f"{manifest_path}: field {key!r} must be a non-empty string"
+        )
+    return value
+
+
+def _resolve_manifest_path(
+    runtime_dir: Path,
+    raw_value: str,
+    field: str,
+    manifest_path: Path,
+) -> Path:
+    candidate = (runtime_dir / raw_value).resolve(strict=False)
+    runtime_root = runtime_dir.resolve(strict=False)
+    if not candidate.is_relative_to(runtime_root):
+        raise RuntimeDiscoveryError(
+            f"{manifest_path}: field {field!r} must stay inside {runtime_dir}"
+        )
+    return candidate
+
+
+def load_runtime_manifest(runtime_dir: Path) -> RuntimeMatrixEntry:
+    manifest_path = runtime_dir / MANIFEST_NAME
+    payload = _load_yaml_mapping(manifest_path)
+
+    name = _require_non_empty_string(payload, "name", manifest_path)
+    image = _require_non_empty_string(payload, "image", manifest_path)
+    dockerfile = _resolve_manifest_path(
+        runtime_dir,
+        _require_non_empty_string(payload, "dockerfile", manifest_path),
+        "dockerfile",
+        manifest_path,
+    )
+    build_context = _resolve_manifest_path(
+        runtime_dir,
+        _require_non_empty_string(payload, "build_context", manifest_path),
+        "build_context",
+        manifest_path,
+    )
+
+    if not dockerfile.is_file():
+        raise RuntimeDiscoveryError(
+            f"{manifest_path}: dockerfile does not exist: {dockerfile}"
+        )
+    if not build_context.is_dir():
+        raise RuntimeDiscoveryError(
+            f"{manifest_path}: build_context must be an existing directory: {build_context}"
+        )
+
+    return RuntimeMatrixEntry(
+        name=name,
+        image=image,
+        dockerfile=dockerfile,
+        build_context=build_context,
+        runtime_dir=runtime_dir.resolve(),
+    )
+
+
+def discover_runtime_matrix(
+    runtimes_dir: Path = RUNTIMES_DIR,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, list[dict[str, str]]]:
+    if not runtimes_dir.is_dir():
+        raise RuntimeDiscoveryError(f"runtimes directory does not exist: {runtimes_dir}")
+
+    runtime_dirs = sorted(path for path in runtimes_dir.iterdir() if path.is_dir())
+    entries: list[RuntimeMatrixEntry] = []
+    errors: list[str] = []
+
+    for runtime_dir in runtime_dirs:
+        manifest_path = runtime_dir / MANIFEST_NAME
+        top_level_dockerfile = runtime_dir / TOP_LEVEL_DOCKERFILE
+        if top_level_dockerfile.is_file() and not manifest_path.is_file():
+            errors.append(f"{runtime_dir}: Dockerfile exists without runtime.yaml")
+            continue
+        if not manifest_path.exists():
+            continue
+        try:
+            entries.append(load_runtime_manifest(runtime_dir))
+        except RuntimeDiscoveryError as exc:
+            errors.append(str(exc))
+
+    seen_names: dict[str, Path] = {}
+    for entry in entries:
+        existing = seen_names.get(entry.name)
+        if existing is not None:
+            errors.append(
+                f"{entry.runtime_dir}: duplicate runtime name {entry.name!r}; "
+                f"already used by {existing}"
+            )
+        seen_names[entry.name] = entry.runtime_dir
+
+    if errors:
+        raise RuntimeDiscoveryError("\n".join(errors))
+
+    matrix_items = [
+        entry.as_matrix_item(repo_root)
+        for entry in sorted(
+            entries,
+            key=lambda item: (item.name, item.runtime_dir.as_posix()),
+        )
+    ]
+    return {"include": matrix_items}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Emit a GitHub Actions matrix for Docker runtimes."
+    )
+    parser.add_argument(
+        "--runtimes-dir",
+        type=Path,
+        default=RUNTIMES_DIR,
+        help="Directory containing runtime subdirectories.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        matrix = discover_runtime_matrix(args.runtimes_dir, REPO_ROOT)
+    except RuntimeDiscoveryError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(matrix, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/discover_runtime_matrix.py
+++ b/scripts/discover_runtime_matrix.py
@@ -37,7 +37,6 @@ class RuntimeMatrixEntry:
             "image": self.image,
             "dockerfile": _repo_relative_posix(self.dockerfile, repo_root),
             "build_context": _repo_relative_posix(self.build_context, repo_root),
-            "runtime_dir": _repo_relative_posix(self.runtime_dir, repo_root),
         }
 
 

--- a/tests/test_runtime_discovery.py
+++ b/tests/test_runtime_discovery.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import discover_runtime_matrix as runtime_discovery
+
+
+def _write_runtime_manifest(
+    runtime_dir: Path,
+    *,
+    name: str = "demo",
+    image: str = "astroreason-demo:latest",
+    dockerfile: str = "Dockerfile",
+    build_context: str = ".",
+) -> None:
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / "runtime.yaml").write_text(
+        f"name: {name}\n"
+        f"image: {image}\n"
+        f"dockerfile: {dockerfile}\n"
+        f"build_context: {build_context}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_dockerfile(runtime_dir: Path) -> None:
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+
+
+def test_discover_runtime_matrix_emits_compact_actions_shape(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    runtimes_dir = repo_root / "runtimes"
+    alpha = runtimes_dir / "alpha"
+    zeta = runtimes_dir / "zeta"
+    _write_runtime_manifest(zeta, name="zeta", image="astroreason-zeta:latest")
+    _write_dockerfile(zeta)
+    _write_runtime_manifest(alpha, name="alpha", image="astroreason-alpha:latest")
+    _write_dockerfile(alpha)
+
+    matrix = runtime_discovery.discover_runtime_matrix(runtimes_dir, repo_root)
+
+    assert matrix == {
+        "include": [
+            {
+                "name": "alpha",
+                "image": "astroreason-alpha:latest",
+                "dockerfile": "runtimes/alpha/Dockerfile",
+                "build_context": "runtimes/alpha",
+                "runtime_dir": "runtimes/alpha",
+            },
+            {
+                "name": "zeta",
+                "image": "astroreason-zeta:latest",
+                "dockerfile": "runtimes/zeta/Dockerfile",
+                "build_context": "runtimes/zeta",
+                "runtime_dir": "runtimes/zeta",
+            },
+        ]
+    }
+
+
+def test_discover_runtime_matrix_includes_current_base_runtime() -> None:
+    matrix = runtime_discovery.discover_runtime_matrix()
+
+    assert {
+        "name": "base",
+        "image": "astroreason-base:latest",
+        "dockerfile": "runtimes/base/Dockerfile",
+        "build_context": "runtimes/base",
+        "runtime_dir": "runtimes/base",
+    } in matrix["include"]
+
+
+def test_discovery_rejects_dockerfile_without_manifest(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / "runtimes" / "orphan"
+    _write_dockerfile(runtime_dir)
+
+    with pytest.raises(
+        runtime_discovery.RuntimeDiscoveryError,
+        match="without runtime.yaml",
+    ):
+        runtime_discovery.discover_runtime_matrix(tmp_path / "runtimes", tmp_path)
+
+
+def test_discovery_rejects_manifest_paths_that_escape_runtime_dir(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / "runtimes" / "escape"
+    _write_runtime_manifest(runtime_dir, dockerfile="../Dockerfile")
+    _write_dockerfile(tmp_path / "runtimes")
+
+    with pytest.raises(
+        runtime_discovery.RuntimeDiscoveryError,
+        match="must stay inside",
+    ):
+        runtime_discovery.discover_runtime_matrix(tmp_path / "runtimes", tmp_path)
+
+
+def test_discovery_rejects_missing_required_fields(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / "runtimes" / "missing"
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    (runtime_dir / "runtime.yaml").write_text(
+        "name: missing\n"
+        "dockerfile: Dockerfile\n"
+        "build_context: .\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(runtime_discovery.RuntimeDiscoveryError, match="'image'"):
+        runtime_discovery.discover_runtime_matrix(tmp_path / "runtimes", tmp_path)
+
+
+def test_discovery_rejects_duplicate_runtime_names(tmp_path: Path) -> None:
+    runtimes_dir = tmp_path / "runtimes"
+    first = runtimes_dir / "first"
+    second = runtimes_dir / "second"
+    _write_runtime_manifest(first, name="same")
+    _write_dockerfile(first)
+    _write_runtime_manifest(second, name="same", image="astroreason-same-2:latest")
+    _write_dockerfile(second)
+
+    with pytest.raises(
+        runtime_discovery.RuntimeDiscoveryError,
+        match="duplicate runtime name",
+    ):
+        runtime_discovery.discover_runtime_matrix(runtimes_dir, tmp_path)

--- a/tests/test_runtime_discovery.py
+++ b/tests/test_runtime_discovery.py
@@ -60,8 +60,14 @@ def test_discover_runtime_matrix_emits_compact_actions_shape(tmp_path: Path) -> 
     }
 
 
-def test_discover_runtime_matrix_includes_current_base_runtime() -> None:
-    matrix = runtime_discovery.discover_runtime_matrix()
+def test_discover_runtime_matrix_includes_base_runtime_from_manifest(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    runtimes_dir = repo_root / "runtimes"
+    base = runtimes_dir / "base"
+    _write_runtime_manifest(base, name="base", image="astroreason-base:latest")
+    _write_dockerfile(base)
+
+    matrix = runtime_discovery.discover_runtime_matrix(runtimes_dir, repo_root)
 
     assert {
         "name": "base",

--- a/tests/test_runtime_discovery.py
+++ b/tests/test_runtime_discovery.py
@@ -49,14 +49,12 @@ def test_discover_runtime_matrix_emits_compact_actions_shape(tmp_path: Path) -> 
                 "image": "astroreason-alpha:latest",
                 "dockerfile": "runtimes/alpha/Dockerfile",
                 "build_context": "runtimes/alpha",
-                "runtime_dir": "runtimes/alpha",
             },
             {
                 "name": "zeta",
                 "image": "astroreason-zeta:latest",
                 "dockerfile": "runtimes/zeta/Dockerfile",
                 "build_context": "runtimes/zeta",
-                "runtime_dir": "runtimes/zeta",
             },
         ]
     }
@@ -70,7 +68,6 @@ def test_discover_runtime_matrix_includes_current_base_runtime() -> None:
         "image": "astroreason-base:latest",
         "dockerfile": "runtimes/base/Dockerfile",
         "build_context": "runtimes/base",
-        "runtime_dir": "runtimes/base",
     } in matrix["include"]
 
 


### PR DESCRIPTION
## Summary

Resolves #145.

- Add a runtime discovery helper that validates `runtimes/*/runtime.yaml` and emits a GitHub Actions matrix.
- Add a Runtime Build workflow that discovers every runtime, builds each Docker image for `linux/amd64` with Buildx, loads it locally in the job, and smoke-checks `python --version`.
- Narrow Benchmark Repro triggers to benchmark-relevant paths so runtime-only and docs-only PRs do not run benchmark reproduction.

## Publishing

Runtime publishing is intentionally deferred. The new workflow uses `push: false`, so PR events do not publish images.

## Validation

- `uv run python scripts/discover_runtime_matrix.py`
- `uv run pytest tests/test_runtime_discovery.py`
- `uv run python -c "from pathlib import Path; import yaml; [yaml.safe_load(p.read_text(encoding='utf-8')) for p in [Path('.github/workflows/benchmark-repro.yml'), Path('.github/workflows/runtime-build.yml')]]; print('workflow YAML parsed')"`
- `uv run python scripts/check_finished_benchmark_repro.py`

## Local Docker Note

Docker was available locally, but the local installation does not include the Buildx plugin. I attempted the existing `runtimes/base/build.py` fallback; it reached the npm install layer and was stopped after several minutes without completing, so the runtime smoke check is left to the GitHub Actions Buildx workflow.