### PR TITLE
[codex] Prune unused relay endpoints

### DIFF
--- a/benchmarks/relay_constellation/README.md
+++ b/benchmarks/relay_constellation/README.md
@@ -83,6 +83,8 @@ Important fields:
 ### `network.json`
 
 `network.json` contains the immutable relay backbone and ground endpoints.
+Generated cases publish only ground endpoints that participate in at least one demanded window;
+endpoint IDs are renumbered after pruning so they remain compact and deterministic.
 
 - `backbone_satellites[]`
   - `satellite_id`

--- a/benchmarks/relay_constellation/dataset/cases/test/case_0001/demands.json
+++ b/benchmarks/relay_constellation/dataset/cases/test/case_0001/demands.json
@@ -2,17 +2,17 @@
   "demanded_windows": [
     {
       "demand_id": "demand_005",
-      "destination_endpoint_id": "ground_005",
+      "destination_endpoint_id": "ground_004",
       "end_time": "2026-01-03T05:25:00Z",
-      "source_endpoint_id": "ground_004",
+      "source_endpoint_id": "ground_003",
       "start_time": "2026-01-03T04:40:00Z",
       "weight": 1.0
     },
     {
       "demand_id": "demand_006",
-      "destination_endpoint_id": "ground_005",
+      "destination_endpoint_id": "ground_004",
       "end_time": "2026-01-03T15:25:00Z",
-      "source_endpoint_id": "ground_004",
+      "source_endpoint_id": "ground_003",
       "start_time": "2026-01-03T14:55:00Z",
       "weight": 1.0
     },
@@ -26,7 +26,7 @@
     },
     {
       "demand_id": "demand_001",
-      "destination_endpoint_id": "ground_004",
+      "destination_endpoint_id": "ground_003",
       "end_time": "2026-01-03T23:05:00Z",
       "source_endpoint_id": "ground_001",
       "start_time": "2026-01-03T21:35:00Z",
@@ -34,7 +34,7 @@
     },
     {
       "demand_id": "demand_004",
-      "destination_endpoint_id": "ground_005",
+      "destination_endpoint_id": "ground_004",
       "end_time": "2026-01-04T07:00:00Z",
       "source_endpoint_id": "ground_002",
       "start_time": "2026-01-04T06:00:00Z",
@@ -42,7 +42,7 @@
     },
     {
       "demand_id": "demand_003",
-      "destination_endpoint_id": "ground_005",
+      "destination_endpoint_id": "ground_004",
       "end_time": "2026-01-04T20:30:00Z",
       "source_endpoint_id": "ground_002",
       "start_time": "2026-01-04T19:45:00Z",

--- a/benchmarks/relay_constellation/dataset/cases/test/case_0001/network.json
+++ b/benchmarks/relay_constellation/dataset/cases/test/case_0001/network.json
@@ -89,22 +89,15 @@
       "min_elevation_deg": 10.0
     },
     {
-      "altitude_m": 10.0,
-      "endpoint_id": "ground_003",
-      "latitude_deg": 40.7128,
-      "longitude_deg": -74.006,
-      "min_elevation_deg": 10.0
-    },
-    {
       "altitude_m": 520.0,
-      "endpoint_id": "ground_004",
+      "endpoint_id": "ground_003",
       "latitude_deg": -33.4489,
       "longitude_deg": -70.6693,
       "min_elevation_deg": 10.0
     },
     {
       "altitude_m": 58.0,
-      "endpoint_id": "ground_005",
+      "endpoint_id": "ground_004",
       "latitude_deg": -33.8688,
       "longitude_deg": 151.2093,
       "min_elevation_deg": 10.0

--- a/benchmarks/relay_constellation/dataset/cases/test/case_0003/demands.json
+++ b/benchmarks/relay_constellation/dataset/cases/test/case_0003/demands.json
@@ -2,7 +2,7 @@
   "demanded_windows": [
     {
       "demand_id": "demand_004",
-      "destination_endpoint_id": "ground_006",
+      "destination_endpoint_id": "ground_005",
       "end_time": "2026-01-02T12:35:00Z",
       "source_endpoint_id": "ground_002",
       "start_time": "2026-01-02T11:50:00Z",
@@ -18,7 +18,7 @@
     },
     {
       "demand_id": "demand_001",
-      "destination_endpoint_id": "ground_005",
+      "destination_endpoint_id": "ground_004",
       "end_time": "2026-01-03T13:40:00Z",
       "source_endpoint_id": "ground_001",
       "start_time": "2026-01-03T12:40:00Z",
@@ -26,7 +26,7 @@
     },
     {
       "demand_id": "demand_002",
-      "destination_endpoint_id": "ground_005",
+      "destination_endpoint_id": "ground_004",
       "end_time": "2026-01-03T18:35:00Z",
       "source_endpoint_id": "ground_001",
       "start_time": "2026-01-03T17:35:00Z",
@@ -34,7 +34,7 @@
     },
     {
       "demand_id": "demand_005",
-      "destination_endpoint_id": "ground_006",
+      "destination_endpoint_id": "ground_005",
       "end_time": "2026-01-04T06:55:00Z",
       "source_endpoint_id": "ground_002",
       "start_time": "2026-01-04T05:25:00Z",

--- a/benchmarks/relay_constellation/dataset/cases/test/case_0003/network.json
+++ b/benchmarks/relay_constellation/dataset/cases/test/case_0003/network.json
@@ -96,22 +96,15 @@
       "min_elevation_deg": 10.0
     },
     {
-      "altitude_m": 2240.0,
-      "endpoint_id": "ground_004",
-      "latitude_deg": 19.4326,
-      "longitude_deg": -99.1332,
-      "min_elevation_deg": 10.0
-    },
-    {
       "altitude_m": 14.0,
-      "endpoint_id": "ground_005",
+      "endpoint_id": "ground_004",
       "latitude_deg": 19.076,
       "longitude_deg": 72.8777,
       "min_elevation_deg": 10.0
     },
     {
       "altitude_m": 61.0,
-      "endpoint_id": "ground_006",
+      "endpoint_id": "ground_005",
       "latitude_deg": 64.1466,
       "longitude_deg": -21.9426,
       "min_elevation_deg": 10.0

--- a/benchmarks/relay_constellation/dataset/cases/test/case_0004/demands.json
+++ b/benchmarks/relay_constellation/dataset/cases/test/case_0004/demands.json
@@ -2,7 +2,7 @@
   "demanded_windows": [
     {
       "demand_id": "demand_006",
-      "destination_endpoint_id": "ground_004",
+      "destination_endpoint_id": "ground_003",
       "end_time": "2026-01-03T08:50:00Z",
       "source_endpoint_id": "ground_001",
       "start_time": "2026-01-03T06:50:00Z",
@@ -10,7 +10,7 @@
     },
     {
       "demand_id": "demand_002",
-      "destination_endpoint_id": "ground_003",
+      "destination_endpoint_id": "ground_002",
       "end_time": "2026-01-04T06:50:00Z",
       "source_endpoint_id": "ground_001",
       "start_time": "2026-01-04T05:50:00Z",
@@ -18,7 +18,7 @@
     },
     {
       "demand_id": "demand_005",
-      "destination_endpoint_id": "ground_004",
+      "destination_endpoint_id": "ground_003",
       "end_time": "2026-01-04T09:45:00Z",
       "source_endpoint_id": "ground_001",
       "start_time": "2026-01-04T07:45:00Z",
@@ -26,15 +26,15 @@
     },
     {
       "demand_id": "demand_003",
-      "destination_endpoint_id": "ground_004",
+      "destination_endpoint_id": "ground_003",
       "end_time": "2026-01-04T12:00:00Z",
-      "source_endpoint_id": "ground_003",
+      "source_endpoint_id": "ground_002",
       "start_time": "2026-01-04T11:15:00Z",
       "weight": 1.0
     },
     {
       "demand_id": "demand_001",
-      "destination_endpoint_id": "ground_003",
+      "destination_endpoint_id": "ground_002",
       "end_time": "2026-01-04T12:50:00Z",
       "source_endpoint_id": "ground_001",
       "start_time": "2026-01-04T11:35:00Z",
@@ -42,9 +42,9 @@
     },
     {
       "demand_id": "demand_004",
-      "destination_endpoint_id": "ground_004",
+      "destination_endpoint_id": "ground_003",
       "end_time": "2026-01-05T00:15:00Z",
-      "source_endpoint_id": "ground_003",
+      "source_endpoint_id": "ground_002",
       "start_time": "2026-01-04T23:00:00Z",
       "weight": 1.0
     }

--- a/benchmarks/relay_constellation/dataset/cases/test/case_0004/network.json
+++ b/benchmarks/relay_constellation/dataset/cases/test/case_0004/network.json
@@ -82,31 +82,17 @@
       "min_elevation_deg": 10.0
     },
     {
-      "altitude_m": 1753.0,
-      "endpoint_id": "ground_002",
-      "latitude_deg": -26.2041,
-      "longitude_deg": 28.0473,
-      "min_elevation_deg": 10.0
-    },
-    {
       "altitude_m": 667.0,
-      "endpoint_id": "ground_003",
+      "endpoint_id": "ground_002",
       "latitude_deg": 40.4168,
       "longitude_deg": -3.7038,
       "min_elevation_deg": 10.0
     },
     {
       "altitude_m": 1795.0,
-      "endpoint_id": "ground_004",
+      "endpoint_id": "ground_003",
       "latitude_deg": -1.2921,
       "longitude_deg": 36.8219,
-      "min_elevation_deg": 10.0
-    },
-    {
-      "altitude_m": 23.0,
-      "endpoint_id": "ground_005",
-      "latitude_deg": 59.9139,
-      "longitude_deg": 10.7522,
       "min_elevation_deg": 10.0
     }
   ]

--- a/benchmarks/relay_constellation/dataset/index.json
+++ b/benchmarks/relay_constellation/dataset/index.json
@@ -8,7 +8,7 @@
       "num_backbone_satellites": 8,
       "num_demanded_windows": 6,
       "num_endpoint_pairs": 4,
-      "num_ground_endpoints": 5,
+      "num_ground_endpoints": 4,
       "path": "cases/test/case_0001",
       "split": "test"
     },
@@ -30,7 +30,7 @@
       "num_backbone_satellites": 8,
       "num_demanded_windows": 5,
       "num_endpoint_pairs": 3,
-      "num_ground_endpoints": 6,
+      "num_ground_endpoints": 5,
       "path": "cases/test/case_0003",
       "split": "test"
     },
@@ -41,7 +41,7 @@
       "num_backbone_satellites": 8,
       "num_demanded_windows": 6,
       "num_endpoint_pairs": 3,
-      "num_ground_endpoints": 5,
+      "num_ground_endpoints": 3,
       "path": "cases/test/case_0004",
       "split": "test"
     },

--- a/benchmarks/relay_constellation/generator/build.py
+++ b/benchmarks/relay_constellation/generator/build.py
@@ -582,6 +582,48 @@ def _sample_demand_windows(
     return demands
 
 
+def _prune_and_renumber_endpoints(
+    endpoints: list[EndpointRecord],
+    demands: list[DemandWindow],
+) -> tuple[list[EndpointRecord], list[DemandWindow]]:
+    used_endpoint_ids = {
+        endpoint_id
+        for demand in demands
+        for endpoint_id in (demand.source_endpoint_id, demand.destination_endpoint_id)
+    }
+    endpoint_id_map = {
+        endpoint.endpoint_id: f"ground_{index:03d}"
+        for index, endpoint in enumerate(
+            (endpoint for endpoint in endpoints if endpoint.endpoint_id in used_endpoint_ids),
+            start=1,
+        )
+    }
+    pruned_endpoints = [
+        EndpointRecord(
+            endpoint_id=endpoint_id_map[endpoint.endpoint_id],
+            latitude_deg=endpoint.latitude_deg,
+            longitude_deg=endpoint.longitude_deg,
+            altitude_m=endpoint.altitude_m,
+            min_elevation_deg=endpoint.min_elevation_deg,
+            ecef_position_m=endpoint.ecef_position_m,
+        )
+        for endpoint in endpoints
+        if endpoint.endpoint_id in endpoint_id_map
+    ]
+    remapped_demands = [
+        DemandWindow(
+            demand_id=demand.demand_id,
+            source_endpoint_id=endpoint_id_map[demand.source_endpoint_id],
+            destination_endpoint_id=endpoint_id_map[demand.destination_endpoint_id],
+            start=demand.start,
+            end=demand.end,
+            weight=demand.weight,
+        )
+        for demand in demands
+    ]
+    return pruned_endpoints, remapped_demands
+
+
 def _case_manifest(
     case_id: str,
     seed: int,
@@ -734,6 +776,7 @@ def _build_case(
         _require_mapping(split_config.get("demands"), f"splits.{split_name}.demands"),
         window_start_grid_min,
     )
+    endpoints, demands = _prune_and_renumber_endpoints(endpoints, demands)
 
     manifest = _case_manifest(
         case_id=case_id,

--- a/tests/benchmarks/test_relay_constellation_generator.py
+++ b/tests/benchmarks/test_relay_constellation_generator.py
@@ -112,3 +112,24 @@ def test_main_builds_split_aware_dataset(
     assert index["example_smoke_case"] == "test/case_0001"
     assert index["cases"][0]["split"] == "test"
     assert index["cases"][0]["path"] == "cases/test/case_0001"
+    network = json.loads(
+        (output_dir / "cases" / "test" / "case_0001" / "network.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    demands = json.loads(
+        (output_dir / "cases" / "test" / "case_0001" / "demands.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    endpoint_ids = [endpoint["endpoint_id"] for endpoint in network["ground_endpoints"]]
+    used_endpoint_ids = {
+        endpoint_id
+        for demand in demands["demanded_windows"]
+        for endpoint_id in (
+            demand["source_endpoint_id"],
+            demand["destination_endpoint_id"],
+        )
+    }
+    assert endpoint_ids == [f"ground_{index:03d}" for index in range(1, len(endpoint_ids) + 1)]
+    assert set(endpoint_ids) == used_endpoint_ids


### PR DESCRIPTION
## Summary

- prune generated relay ground endpoints down to endpoints referenced by demanded windows
- renumber emitted endpoint IDs deterministically and rewrite demand endpoint references
- regenerate the committed relay_constellation dataset and document the endpoint policy
- add a generator invariant test that every emitted endpoint is used

Closes #151.

## Validation

- `uv run pytest tests/benchmarks/test_relay_constellation_generator.py`
- `uv run pytest tests/benchmarks/test_relay_constellation_verifier.py`
- `uv run python - <<'PY' ...` regenerated-case endpoint invariant scan
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset generation now automatically filters unused endpoints and renumbers them sequentially to maintain consistency.

* **Documentation**
  * Updated documentation to describe the endpoint filtering behavior.

* **Tests**
  * Added validation to ensure all endpoints in generated datasets are properly referenced and numbered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->