### PR TITLE
Add benchmark visualizers

### DIFF
--- a/benchmarks/regional_coverage/README.md
+++ b/benchmarks/regional_coverage/README.md
@@ -438,12 +438,12 @@ The visualizer is intended for benchmark inspection and fixture authoring.
 ```bash
 # 2D case overview PNG.
 uv run python -m benchmarks.regional_coverage.visualizer.run overview \
-    benchmarks/regional_coverage/dataset/cases/test/case_0001
+    --case-dir benchmarks/regional_coverage/dataset/cases/test/case_0001
 
 # Solution inspection bundle with 3D strip geometry HTML and region-scale PNGs.
 uv run python -m benchmarks.regional_coverage.visualizer.run inspect \
-    benchmarks/regional_coverage/dataset/cases/test/case_0001 \
-    path/to/solution.json
+    --case-dir benchmarks/regional_coverage/dataset/cases/test/case_0001 \
+    --solution-path path/to/solution.json
 ```
 
-Generated visualizer artifacts are written under `benchmarks/regional_coverage/visualizer/plots/`.
+The overview renders a small representative set of satellite ground tracks as a muted context layer so region geometry remains readable on multi-satellite cases. Use `--max-ground-tracks` to increase, reduce, or hide that layer. Generated visualizer artifacts are written under `benchmarks/regional_coverage/visualizer/plots/`.

--- a/benchmarks/regional_coverage/visualizer/run.py
+++ b/benchmarks/regional_coverage/visualizer/run.py
@@ -65,6 +65,7 @@ _SAMPLE_STATE_COLORS = {
     "covered_other": "#f59e0b",
     "uncovered": "#94a3b8",
 }
+_SATELLITE_TRACK_COLOR = "#64748b"
 _THEME = {
     "background": "#ffffff",
     "panel": "#f7f8fa",
@@ -135,7 +136,7 @@ def _apply_axes_theme(ax: plt.Axes, *, facecolor: str | None = None) -> None:
 def _load_world_texture() -> np.ndarray:
     global _WORLD_TEXTURE
     if _WORLD_TEXTURE is None:
-        for texture_name in ("blue_marble", "natural_earth_50m"):
+        for texture_name in ("natural_earth_50m", "blue_marble"):
             try:
                 image = load_earth_texture(texture_name)
             except Exception:
@@ -623,12 +624,19 @@ def _region_area_summary(case: Any) -> str:
 def _overview_summary_lines(case: Any, *, shown_ground_tracks: int) -> list[str]:
     total_samples = sum(len(region_grid.samples) for region_grid in case.region_grids.values())
     total_weight_m2 = sum(region_grid.total_weight_m2 for region_grid in case.region_grids.values())
+    horizon_hours = (
+        case.manifest.horizon_end - case.manifest.horizon_start
+    ).total_seconds() / 3600.0
     lines = [
         f"Case: {case.manifest.case_id}",
-        f"Horizon: {_utc_iso(case.manifest.horizon_start)} to {_utc_iso(case.manifest.horizon_end)}",
+        f"Horizon: {_utc_iso(case.manifest.horizon_start)}",
+        f"to {_utc_iso(case.manifest.horizon_end)}",
+        f"Duration: {horizon_hours:.1f} h",
         "",
-        f"Satellites ({len(case.satellites)}):",
-        *[f"  - {satellite_id}" for satellite_id in case.satellites],
+        f"Satellites: {len(case.satellites)}",
+        "Ground tracks:",
+        f"  shown: {shown_ground_tracks} / {len(case.satellites)}",
+        "  muted representative layer",
         "",
         f"Regions ({len(case.regions)}):",
     ]
@@ -642,7 +650,6 @@ def _overview_summary_lines(case: Any, *, shown_ground_tracks: int) -> list[str]
             f"Coverage samples: {total_samples}",
             f"Sample spacing: {case.manifest.sample_spacing_m:.0f} m",
             f"Total region area: {total_weight_m2 / 1_000_000.0:.1f} km^2",
-            f"Ground tracks shown: {shown_ground_tracks} / {len(case.satellites)}",
         ]
     )
     return lines
@@ -847,25 +854,41 @@ def _render_region_zoom_png(
     return out_path
 
 
+def _select_ground_track_items(
+    items: list[tuple[str, Any]],
+    *,
+    max_ground_tracks: int | None,
+) -> list[tuple[str, Any]]:
+    if max_ground_tracks is None or max_ground_tracks >= len(items):
+        return items
+    if max_ground_tracks <= 0:
+        return []
+    if max_ground_tracks == 1:
+        return [items[0]]
+
+    selected_indices = np.linspace(0, len(items) - 1, num=max_ground_tracks, dtype=int)
+    return [items[int(idx)] for idx in selected_indices]
+
+
 def render_overview(
     case_dir: str | Path,
     out_path: str | Path | None = None,
     *,
     ground_track_step_s: float = 300.0,
-    max_ground_tracks: int | None = None,
+    max_ground_tracks: int | None = 4,
 ) -> Path:
     _ensure_brahe_ready()
     case_path = Path(case_dir)
     case = load_case(case_path)
     propagators = _build_propagators(case)
     output_path = _overview_output_path(case_path, Path(out_path) if out_path is not None else None)
-    fig = plt.figure(figsize=(13.5, 7.5))
+    fig = plt.figure(figsize=(15, 8.5), constrained_layout=True)
     fig.patch.set_facecolor(_THEME["background"])
-    gs = fig.add_gridspec(1, 2, width_ratios=[2.4, 1.2])
+    gs = fig.add_gridspec(1, 2, width_ratios=[3.6, 1.2])
     ax_map = fig.add_subplot(gs[0, 0])
     ax_summary = fig.add_subplot(gs[0, 1])
 
-    _apply_axes_theme(ax_map, facecolor="#09121a")
+    _apply_axes_theme(ax_map)
     ax_map.set_xlim(-180.0, 180.0)
     ax_map.set_ylim(-90.0, 90.0)
     _draw_world_texture(ax_map)
@@ -878,14 +901,12 @@ def render_overview(
         fontweight="bold",
     )
 
-    satellite_items = sorted(propagators.items(), key=lambda item: item[0])
-    if max_ground_tracks is not None:
-        satellite_items = satellite_items[: max(0, max_ground_tracks)]
+    satellite_items = _select_ground_track_items(
+        sorted(propagators.items(), key=lambda item: item[0]),
+        max_ground_tracks=max_ground_tracks,
+    )
 
-    track_handles: list[Line2D] = []
-    for index, (satellite_id, propagator) in enumerate(satellite_items):
-        color = _COLOR_CYCLE[index % len(_COLOR_CYCLE)]
-        track_handles.append(Line2D([0], [0], color=color, linewidth=2.0, label=satellite_id))
+    for satellite_id, propagator in satellite_items:
         for lon_seg, lat_seg in _sample_ground_track_segments(
             propagator,
             case.manifest.horizon_start,
@@ -895,10 +916,10 @@ def render_overview(
             ax_map.plot(
                 lon_seg,
                 lat_seg,
-                color=color,
-                linewidth=1.4,
-                alpha=0.72,
-                zorder=2,
+                color=_SATELLITE_TRACK_COLOR,
+                linewidth=0.8,
+                alpha=0.36,
+                zorder=1,
             )
 
     region_handles: list[Line2D] = []
@@ -927,26 +948,15 @@ def render_overview(
             zorder=4,
         )
 
-    track_legend = ax_map.legend(
-        handles=track_handles,
-        title="Ground tracks",
-        loc="lower left",
-        bbox_to_anchor=(0.0, -0.26),
-        ncol=max(1, min(2, len(track_handles))),
-        fontsize=9,
-        title_fontsize=9,
-        frameon=False,
-    )
-    ax_map.add_artist(track_legend)
     ax_map.legend(
         handles=region_handles,
         title="Regions",
-        loc="lower right",
-        bbox_to_anchor=(1.0, -0.26),
+        loc="lower left",
         ncol=max(1, min(2, len(region_handles))),
         fontsize=9,
         title_fontsize=9,
-        frameon=False,
+        frameon=True,
+        framealpha=0.92,
     )
 
     ax_summary.axis("off")
@@ -963,8 +973,7 @@ def render_overview(
     )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.subplots_adjust(left=0.06, right=0.98, top=0.93, bottom=0.2, wspace=0.22)
-    fig.savefig(output_path, dpi=130)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
     plt.close(fig)
     return output_path
 
@@ -1143,7 +1152,11 @@ def main(argv: list[str] | None = None) -> int:
 
     overview_parser = subparsers.add_parser("overview", help="Render a case overview PNG.")
     overview_parser.description = "Render a 2D Earth-texture case overview PNG."
-    overview_parser.add_argument("case_dir", help="Path to dataset/cases/<case_id>")
+    overview_parser.add_argument(
+        "--case-dir",
+        required=True,
+        help="Path to dataset/cases/<case_id>",
+    )
     overview_parser.add_argument(
         "--out-path",
         type=Path,
@@ -1159,15 +1172,23 @@ def main(argv: list[str] | None = None) -> int:
     overview_parser.add_argument(
         "--max-ground-tracks",
         type=int,
-        default=None,
-        help="Optional cap on how many satellite ground tracks to draw, using satellite_id sort order",
+        default=4,
+        help="Maximum representative satellite tracks to draw; use 0 to hide tracks (default: 4)",
     )
 
     inspect_parser = subparsers.add_parser(
         "inspect", help="Render inspection HTML and manifest for one case and solution."
     )
-    inspect_parser.add_argument("case_dir", help="Path to dataset/cases/<case_id>")
-    inspect_parser.add_argument("solution_path", help="Path to solution JSON")
+    inspect_parser.add_argument(
+        "--case-dir",
+        required=True,
+        help="Path to dataset/cases/<case_id>",
+    )
+    inspect_parser.add_argument(
+        "--solution-path",
+        required=True,
+        help="Path to solution JSON",
+    )
     inspect_parser.add_argument(
         "--out-dir",
         type=Path,

--- a/benchmarks/relay_constellation/README.md
+++ b/benchmarks/relay_constellation/README.md
@@ -314,10 +314,7 @@ uv run python -m benchmarks.relay_constellation.visualizer.run overview \
   --case-dir benchmarks/relay_constellation/dataset/cases/test/case_0001
 ```
 
-```bash
-uv run python -m benchmarks.relay_constellation.visualizer.run connectivity \
-  --case-dir benchmarks/relay_constellation/dataset/cases/test/case_0001
-```
+This emits `ground_tracks.png` for the backbone constellation and `baseline_connectivity.png` for geometry-only backbone connectivity with infinite link concurrency and no added satellites.
 
 ```bash
 uv run python -m benchmarks.relay_constellation.visualizer.run solution \
@@ -325,10 +322,17 @@ uv run python -m benchmarks.relay_constellation.visualizer.run solution \
   --solution-path benchmarks/relay_constellation/dataset/example_solution.json
 ```
 
+This emits `ground_tracks.png` for the backbone plus added satellites and
+`scheduled_connectivity.png` for verifier-derived connectivity from the
+submitted actions. It also emits one detailed PNG per demanded window under
+`demand_windows/`, with route-color labels and the actual served route nodes.
+
 ## Tests
 
 Run the focused relay benchmark tests with:
 
 ```bash
-uv run pytest tests/benchmarks/test_relay_constellation_generator.py tests/benchmarks/test_relay_constellation_verifier.py
+uv run pytest tests/benchmarks/test_relay_constellation_generator.py \
+  tests/benchmarks/test_relay_constellation_verifier.py \
+  tests/benchmarks/test_relay_constellation_visualizer.py
 ```

--- a/benchmarks/relay_constellation/visualizer/__init__.py
+++ b/benchmarks/relay_constellation/visualizer/__init__.py
@@ -4,14 +4,17 @@ from .plot import (
     render_case_plots,
     render_connectivity_report,
     render_dataset_plots,
+    render_overview,
     render_overview_set,
 )
-from .solution import render_solution_report
+from .solution import render_solution, render_solution_report
 
 __all__ = [
     "render_case_plots",
     "render_connectivity_report",
     "render_dataset_plots",
+    "render_overview",
     "render_overview_set",
+    "render_solution",
     "render_solution_report",
 ]

--- a/benchmarks/relay_constellation/visualizer/geometry.py
+++ b/benchmarks/relay_constellation/visualizer/geometry.py
@@ -162,7 +162,10 @@ def _isl_feasible(
     return _segment_clear_of_earth(position_a_ecef_m, position_b_ecef_m), distance_m
 
 
-def _build_propagators(case: RelayCase) -> dict[str, brahe.NumericalOrbitPropagator]:
+def _build_propagators_for_satellites(
+    case: RelayCase,
+    satellites: dict[str, object],
+) -> dict[str, brahe.NumericalOrbitPropagator]:
     _ensure_brahe_ready()
     epoch = _datetime_to_epoch(case.manifest.epoch)
     horizon_end_epoch = _datetime_to_epoch(case.manifest.horizon_end)
@@ -170,7 +173,7 @@ def _build_propagators(case: RelayCase) -> dict[str, brahe.NumericalOrbitPropaga
         gravity=brahe.GravityConfiguration.spherical_harmonic(2, 0)
     )
     propagators: dict[str, brahe.NumericalOrbitPropagator] = {}
-    for satellite in case.backbone_satellites.values():
+    for satellite in satellites.values():
         propagator = brahe.NumericalOrbitPropagator.from_eci(
             epoch,
             satellite.state_eci_m_mps,
@@ -181,13 +184,25 @@ def _build_propagators(case: RelayCase) -> dict[str, brahe.NumericalOrbitPropaga
     return propagators
 
 
+def _build_propagators(case: RelayCase) -> dict[str, brahe.NumericalOrbitPropagator]:
+    return _build_propagators_for_satellites(case, case.backbone_satellites)
+
+
 def build_state_cache(case: RelayCase) -> tuple[list[datetime], dict[str, np.ndarray]]:
-    propagators = _build_propagators(case)
     sample_times = _sample_times(
         case.manifest.horizon_start,
         case.manifest.horizon_end,
         case.manifest.routing_step_s,
     )
+    return build_state_cache_for_satellites(case, case.backbone_satellites, sample_times)
+
+
+def build_state_cache_for_satellites(
+    case: RelayCase,
+    satellites: dict[str, object],
+    sample_times: list[datetime],
+) -> tuple[list[datetime], dict[str, np.ndarray]]:
+    propagators = _build_propagators_for_satellites(case, satellites)
     states_ecef_by_satellite: dict[str, np.ndarray] = {}
     for satellite_id, propagator in propagators.items():
         rows = np.zeros((len(sample_times), 3), dtype=float)
@@ -206,19 +221,11 @@ def build_state_cache_for_times(
     case: RelayCase,
     sample_times: list[datetime],
 ) -> tuple[list[datetime], dict[str, np.ndarray]]:
-    propagators = _build_propagators(case)
-    states_ecef_by_satellite: dict[str, np.ndarray] = {}
-    for satellite_id, propagator in propagators.items():
-        rows = np.zeros((len(sample_times), 3), dtype=float)
-        for index, instant in enumerate(sample_times):
-            epoch = _datetime_to_epoch(instant)
-            state_eci = np.asarray(propagator.state(epoch), dtype=float)
-            rows[index] = np.asarray(
-                brahe.position_eci_to_ecef(epoch, state_eci[:3]),
-                dtype=float,
-            )
-        states_ecef_by_satellite[satellite_id] = rows
-    return sample_times, states_ecef_by_satellite
+    return build_state_cache_for_satellites(
+        case,
+        case.backbone_satellites,
+        sample_times,
+    )
 
 
 def _shortest_path(

--- a/benchmarks/relay_constellation/visualizer/plot.py
+++ b/benchmarks/relay_constellation/visualizer/plot.py
@@ -19,6 +19,7 @@ matplotlib.use("Agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
+from brahe.plots.texture_utils import load_earth_texture
 from PIL import Image
 
 from .geometry import (
@@ -38,10 +39,10 @@ _VISUALIZER_DIR = Path(__file__).resolve().parent
 DEFAULT_PLOTS_DIR = _VISUALIZER_DIR / "plots"
 _TEXTURE_CACHE_DIR = _VISUALIZER_DIR / "cache" / "earth_textures"
 _PREFERRED_TEXTURE_FILENAMES = (
+    "natural_earth.tif",
     "world.topo.200410.3x5400x2700.png",
     "world.topo.200410.3x5400x2700.jpg",
     "blue_marble.jpg",
-    "natural_earth.tif",
 )
 _WORLD_TOPO_DIRECT_URLS = (
     "https://neo.gsfc.nasa.gov/archive/bluemarble/bmng/world_8km/world.topo.200410.3x5400x2700.png",
@@ -152,12 +153,26 @@ def resolve_texture_path(texture_path: Path | None = None) -> Path:
         if candidate.is_file() and _is_equirectangular_texture(candidate):
             return candidate
     try:
-        return _download_blue_marble_texture(_TEXTURE_CACHE_DIR)
-    except Exception:
         return _download_natural_earth_texture(_TEXTURE_CACHE_DIR)
+    except Exception:
+        return _download_blue_marble_texture(_TEXTURE_CACHE_DIR)
 
 
-def _load_texture_image(texture_path: Path) -> np.ndarray:
+def _load_texture_image(texture_path: Path | None = None) -> np.ndarray:
+    if texture_path is None:
+        for texture_name in ("natural_earth_50m", "blue_marble"):
+            try:
+                image = load_earth_texture(texture_name)
+            except Exception:
+                continue
+            if image is not None:
+                return np.asarray(image, dtype=np.uint8)
+        texture_path = resolve_texture_path(None)
+    else:
+        texture_path = Path(texture_path).resolve()
+        if not texture_path.is_file():
+            raise FileNotFoundError(f"Texture path does not exist: {texture_path}")
+
     image = Image.open(texture_path).convert("RGB")
     width, height = image.size
     max_width = 2048
@@ -208,8 +223,7 @@ def render_overview_png(
     states_ecef_by_satellite: dict[str, np.ndarray] | None = None,
 ) -> Path:
     demand = next(demand for demand in case.demands if demand.demand_id == demand_id)
-    actual_texture_path = resolve_texture_path(texture_path)
-    texture = _load_texture_image(actual_texture_path)
+    texture = _load_texture_image(texture_path)
 
     if sample_times is None or states_ecef_by_satellite is None:
         sample_times, states_ecef_by_satellite = build_state_cache(case)

--- a/benchmarks/relay_constellation/visualizer/plot.py
+++ b/benchmarks/relay_constellation/visualizer/plot.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from datetime import UTC, datetime
 import io
-import json
-import math
 from pathlib import Path
 import urllib.request
 import zipfile
@@ -17,6 +14,7 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.dates as mdates
+from matplotlib.patches import FancyArrowPatch
 import matplotlib.pyplot as plt
 import numpy as np
 from brahe.plots.texture_utils import load_earth_texture
@@ -52,15 +50,13 @@ _BLUE_MARBLE_DIRECT_URLS = (
 )
 _NATURAL_EARTH_ZIP_URL = "https://naciscdn.org/naturalearth/50m/raster/HYP_50M_SR_W.zip"
 _ROUTE_COLORS = matplotlib.colormaps.get_cmap("tab20")
+_GROUND_TRACK_MIN_STEP_S = 300
+_MAX_BACKBONE_GROUND_TRACKS = 3
+_MAX_ADDED_GROUND_TRACKS = 3
 
 
 def _utc_text(value: datetime) -> str:
     return value.astimezone(UTC).strftime("%m-%d %H:%M")
-
-
-def _serialize_json(path: Path, payload: dict[str, object]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def _download_bytes(url: str, *, timeout_s: float = 30.0) -> bytes:
@@ -211,6 +207,284 @@ def _sample_lonlat_segments(
     if not lons:
         return []
     return brahe.split_ground_track_at_antimeridian(lons, lats)
+
+
+def coarsen_ground_track_cache(
+    sample_times: list[datetime],
+    states_ecef_by_satellite: dict[str, np.ndarray],
+    *,
+    min_step_s: int = _GROUND_TRACK_MIN_STEP_S,
+) -> tuple[list[datetime], dict[str, np.ndarray]]:
+    """Downsample full-horizon state rows for context-only ground tracks."""
+    if len(sample_times) <= 1 or min_step_s <= 0:
+        return sample_times, states_ecef_by_satellite
+    selected_indices = [0]
+    last_time = sample_times[0]
+    for index, instant in enumerate(sample_times[1:], start=1):
+        if (instant - last_time).total_seconds() < min_step_s:
+            continue
+        selected_indices.append(index)
+        last_time = instant
+    index_array = np.asarray(selected_indices, dtype=int)
+    return (
+        [sample_times[index] for index in selected_indices],
+        {
+            satellite_id: rows[index_array]
+            for satellite_id, rows in states_ecef_by_satellite.items()
+        },
+    )
+
+
+def _select_evenly(values: list[str], limit: int) -> list[str]:
+    if limit <= 0 or len(values) <= limit:
+        return values
+    if limit == 1:
+        return [values[len(values) // 2]]
+    indices = np.linspace(0, len(values) - 1, limit)
+    return [values[int(round(index))] for index in indices]
+
+
+def _plot_endpoint_pair(
+    axis: plt.Axes,
+    source_lon: float,
+    source_lat: float,
+    destination_lon: float,
+    destination_lat: float,
+    *,
+    color: str,
+    linewidth: float,
+    alpha: float,
+) -> None:
+    arrow = FancyArrowPatch(
+        (source_lon, source_lat),
+        (destination_lon, destination_lat),
+        arrowstyle="-|>",
+        mutation_scale=14,
+        linewidth=linewidth,
+        linestyle="--",
+        color=color,
+        alpha=alpha,
+        shrinkA=9,
+        shrinkB=9,
+        zorder=2,
+    )
+    axis.add_patch(arrow)
+
+
+def render_ground_tracks_png(
+    case: RelayCase,
+    output_path: Path,
+    *,
+    sample_times: list[datetime],
+    states_ecef_by_satellite: dict[str, np.ndarray],
+    texture_path: Path | None = None,
+    added_satellite_ids: set[str] | None = None,
+    max_backbone_tracks: int = _MAX_BACKBONE_GROUND_TRACKS,
+    max_added_tracks: int = _MAX_ADDED_GROUND_TRACKS,
+    title: str | None = None,
+) -> Path:
+    """Render constellation ground tracks and demand endpoints."""
+    added_satellite_ids = added_satellite_ids or set()
+    texture = _load_texture_image(texture_path)
+
+    figure = plt.figure(figsize=(15, 8.5))
+    figure.patch.set_facecolor("#ffffff")
+    grid = figure.add_gridspec(1, 2, width_ratios=[3.2, 1.0], wspace=0.08)
+    axis = figure.add_subplot(grid[0, 0])
+    summary_axis = figure.add_subplot(grid[0, 1])
+
+    axis.set_facecolor("#09121a")
+    axis.imshow(
+        texture,
+        origin="upper",
+        extent=[-180.0, 180.0, -90.0, 90.0],
+        aspect="auto",
+        interpolation="bilinear",
+        zorder=0,
+        alpha=0.96,
+    )
+    axis.set_xlim(-180.0, 180.0)
+    axis.set_ylim(-90.0, 90.0)
+    axis.set_xlabel("Longitude (deg)")
+    axis.set_ylabel("Latitude (deg)")
+    axis.grid(True, color="#d5dbe3", linewidth=0.7, alpha=0.45)
+
+    pair_counts: dict[tuple[str, str], int] = {}
+    for demand in case.demands:
+        key = (demand.source_endpoint_id, demand.destination_endpoint_id)
+        pair_counts[key] = pair_counts.get(key, 0) + 1
+    active_endpoint_ids = {
+        endpoint_id
+        for pair in pair_counts
+        for endpoint_id in pair
+    }
+    for (source_id, destination_id), count in sorted(pair_counts.items()):
+        source = case.ground_endpoints[source_id]
+        destination = case.ground_endpoints[destination_id]
+        _plot_endpoint_pair(
+            axis,
+            source.longitude_deg,
+            source.latitude_deg,
+            destination.longitude_deg,
+            destination.latitude_deg,
+            color="#e11d48",
+            linewidth=min(2.5, 0.8 + 0.18 * count),
+            alpha=0.72,
+        )
+
+    backbone_track_ids = _select_evenly(
+        [
+            satellite_id
+            for satellite_id in sorted(states_ecef_by_satellite)
+            if satellite_id not in added_satellite_ids
+        ],
+        max_backbone_tracks,
+    )
+    added_track_ids = _select_evenly(
+        [
+            satellite_id
+            for satellite_id in sorted(states_ecef_by_satellite)
+            if satellite_id in added_satellite_ids
+        ],
+        max_added_tracks,
+    )
+    displayed_track_ids = backbone_track_ids + added_track_ids
+
+    for satellite_id in displayed_track_ids:
+        is_added = satellite_id in added_satellite_ids
+        color = "#dc6b19" if is_added else "#2563eb"
+        linewidth = 0.45 if is_added else 0.95
+        alpha = 0.22 if is_added else 0.5
+        segments = _sample_lonlat_segments(
+            sample_times,
+            states_ecef_by_satellite[satellite_id],
+            start_time=case.manifest.horizon_start,
+            end_time=case.manifest.horizon_end,
+        )
+        for lon_seg, lat_seg in segments:
+            axis.plot(
+                lon_seg,
+                lat_seg,
+                color=color,
+                linewidth=linewidth,
+                alpha=alpha,
+                zorder=3 if is_added else 2,
+            )
+
+    active_endpoints = [
+        endpoint
+        for endpoint in case.ground_endpoints.values()
+        if endpoint.endpoint_id in active_endpoint_ids
+    ]
+    unused_endpoints = [
+        endpoint
+        for endpoint in case.ground_endpoints.values()
+        if endpoint.endpoint_id not in active_endpoint_ids
+    ]
+    if active_endpoints:
+        axis.scatter(
+            [endpoint.longitude_deg for endpoint in active_endpoints],
+            [endpoint.latitude_deg for endpoint in active_endpoints],
+            color="#facc15",
+            s=58,
+            label="Demand endpoint",
+            edgecolors="#111827",
+            linewidths=0.7,
+            zorder=5,
+        )
+    if unused_endpoints:
+        axis.scatter(
+            [endpoint.longitude_deg for endpoint in unused_endpoints],
+            [endpoint.latitude_deg for endpoint in unused_endpoints],
+            facecolors="#f8fafc",
+            s=38,
+            label="Unused endpoint",
+            edgecolors="#64748b",
+            linewidths=1.0,
+            zorder=5,
+        )
+
+    legend_handles = [
+        plt.Line2D([0], [0], color="#2563eb", linewidth=1.5, label="Shown backbone track"),
+        plt.Line2D([0], [0], color="#e11d48", linewidth=1.5, linestyle="--", label="Demand direction"),
+        plt.Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="none",
+            markerfacecolor="#facc15",
+            markeredgecolor="#111827",
+            markersize=7,
+            label="Demand endpoint",
+        ),
+    ]
+    if added_satellite_ids:
+        legend_handles.insert(
+            1,
+            plt.Line2D([0], [0], color="#dc6b19", linewidth=2.0, label="Shown added track"),
+        )
+    if unused_endpoints:
+        legend_handles.append(
+            plt.Line2D(
+                [0],
+                [0],
+                marker="o",
+                color="none",
+                markerfacecolor="#f8fafc",
+                markeredgecolor="#64748b",
+                markersize=6,
+                label="Unused endpoint",
+            )
+        )
+    axis.legend(handles=legend_handles, loc="upper left", frameon=True)
+
+    summary_axis.axis("off")
+    horizon_hours = (
+        case.manifest.horizon_end - case.manifest.horizon_start
+    ).total_seconds() / 3600.0
+    backbone_count = len(states_ecef_by_satellite) - len(added_satellite_ids)
+    summary_lines = [
+        f"Case: {case.manifest.case_id}",
+        "",
+        f"Horizon: {horizon_hours:.1f} h",
+        f"Routing step: {case.manifest.routing_step_s} s",
+        "",
+        f"Backbone satellites: {backbone_count}",
+        f"Shown backbone tracks: {len(backbone_track_ids)}",
+        f"Added satellites: {len(added_satellite_ids)}",
+        f"Shown added tracks: {len(added_track_ids)}",
+        f"Ground endpoints: {len(case.ground_endpoints)}",
+        f"Unused endpoints: {len(unused_endpoints)}",
+        f"Demanded windows: {len(case.demands)}",
+        f"Endpoint pairs: {len(pair_counts)}",
+        "",
+        "Endpoint pairs:",
+    ]
+    for (source_id, destination_id), count in sorted(pair_counts.items())[:12]:
+        summary_lines.append(f"- {source_id} -> {destination_id}: {count}")
+    if len(pair_counts) > 12:
+        summary_lines.append(f"... ({len(pair_counts) - 12} more)")
+
+    summary_axis.text(
+        0.0,
+        1.0,
+        "\n".join(summary_lines),
+        ha="left",
+        va="top",
+        fontsize=9.2,
+        family="monospace",
+        color="#1f2933",
+    )
+
+    axis.set_title(
+        title or f"{case.manifest.case_id}: constellation ground tracks",
+        fontsize=14,
+        fontweight="bold",
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    figure.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(figure)
+    return output_path
 
 
 def render_overview_png(
@@ -435,7 +709,7 @@ def render_overview_set(
         )
         overview_paths.append(overview_path.name)
 
-    manifest = {
+    return {
         "case_id": case.manifest.case_id,
         "case_dir": str(case.case_dir),
         "overview_pngs": overview_paths,
@@ -443,8 +717,6 @@ def render_overview_set(
         "num_ground_endpoints": len(case.ground_endpoints),
         "num_demanded_windows": len(case.demands),
     }
-    _serialize_json(output_dir / "manifest.json", manifest)
-    return manifest
 
 
 def render_connectivity_png(
@@ -462,9 +734,9 @@ def render_connectivity_png(
     if not summaries:
         raise ValueError(f"{case.manifest.case_id} does not contain any endpoint pairs")
 
-    height = max(4.0, 1.8 + (1.4 * len(summaries)))
-    figure = plt.figure(figsize=(16, height))
-    grid = figure.add_gridspec(1, 2, width_ratios=[3.4, 1.6], wspace=0.15)
+    height = max(4.8, 1.4 + (0.78 * len(summaries)))
+    figure = plt.figure(figsize=(14, height))
+    grid = figure.add_gridspec(1, 2, width_ratios=[3.8, 1.15], wspace=0.10)
     axis = figure.add_subplot(grid[0, 0])
     text_axis = figure.add_subplot(grid[0, 1])
 
@@ -481,18 +753,23 @@ def render_connectivity_png(
                 left=mdates.date2num(window_start),
                 height=0.92,
                 color="#dbeafe",
-                alpha=0.45,
+                alpha=0.30,
             )
-        for interval in summary.route_intervals:
-            axis.barh(
-                y_base,
-                width=(interval.end_time - interval.start_time).total_seconds() / 86_400.0,
-                left=mdates.date2num(interval.start_time),
-                height=lane_height,
-                color=_route_color(interval.route_nodes),
-                edgecolor="white",
-                linewidth=0.5,
-            )
+            for interval in summary.route_intervals_overlapping_demands:
+                clipped_start = max(interval.start_time, window_start)
+                clipped_end = min(interval.end_time, window_end)
+                if clipped_end <= clipped_start:
+                    continue
+                axis.barh(
+                    y_base,
+                    width=(clipped_end - clipped_start).total_seconds() / 86_400.0,
+                    left=mdates.date2num(clipped_start),
+                    height=lane_height,
+                    color="#1d4ed8",
+                    edgecolor="none",
+                    linewidth=0.0,
+                    alpha=0.95,
+                )
 
     axis.set_ylim(-0.8, len(summaries) - 0.2)
     axis.set_yticks(range(len(summaries)))
@@ -507,39 +784,40 @@ def render_connectivity_png(
         f"{case.manifest.case_id}: baseline infinite-concurrency connectivity",
         fontsize=13,
     )
+    legend_handles = [
+        plt.Line2D([0], [0], color="#dbeafe", linewidth=8, label="Demanded window"),
+        plt.Line2D([0], [0], color="#1d4ed8", linewidth=8, label="Geometry-feasible route"),
+    ]
+    axis.legend(handles=legend_handles, loc="upper right", frameon=True)
 
     text_axis.axis("off")
     text_lines = [
-        "Requested-window route intervals",
+        "Backbone-only baseline",
+        "infinite concurrency",
         "",
+        "Pair availability:",
     ]
     for summary in summaries:
         if summary.requested_sample_count > 0:
             availability = summary.served_sample_count / summary.requested_sample_count
         else:
             availability = 0.0
-        text_lines.append(
-            f"{summary.pair_id}  availability={availability:.2f}"
-        )
-        intervals = summary.route_intervals_overlapping_demands
-        if not intervals:
-            text_lines.append("  no geometry-feasible route during requested windows")
-            text_lines.append("")
-            continue
-        for interval in intervals:
-            route_text = " -> ".join(interval.route_nodes)
-            text_lines.append(
-                f"  {_utc_text(interval.start_time)} - {_utc_text(interval.end_time)}"
-            )
-            text_lines.append(f"  {route_text}")
-        text_lines.append("")
+        text_lines.append(f"- {summary.pair_id}: {availability:.2f}")
+    text_lines.extend(
+        [
+            "",
+            f"Backbone satellites: {len(case.backbone_satellites)}",
+            f"Ground endpoints: {len(case.ground_endpoints)}",
+            f"Demand windows: {len(case.demands)}",
+        ]
+    )
     text_axis.text(
         0.0,
         1.0,
         "\n".join(text_lines),
         ha="left",
         va="top",
-        fontsize=8.8,
+        fontsize=9.0,
         family="monospace",
     )
 
@@ -567,7 +845,7 @@ def render_connectivity_report(
         sample_times=sample_times,
         states_ecef_by_satellite=states_ecef_by_satellite,
     )
-    manifest = {
+    return {
         "case_id": case.manifest.case_id,
         "case_dir": str(case.case_dir),
         "connectivity_png": output_path.name,
@@ -581,8 +859,64 @@ def render_connectivity_report(
             for summary in summaries
         ],
     }
-    _serialize_json(output_path.parent / "connectivity_manifest.json", manifest)
-    return manifest
+
+
+def render_overview(
+    case_dir: Path | str,
+    output_dir: Path | str,
+    *,
+    texture_path: Path | None = None,
+) -> dict[str, object]:
+    """Render the case-only overview images."""
+    case = load_case(case_dir)
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    sample_times, states_ecef_by_satellite = build_state_cache(case)
+    track_times, track_states = coarsen_ground_track_cache(
+        sample_times,
+        states_ecef_by_satellite,
+    )
+
+    ground_tracks_path = output_dir / "ground_tracks.png"
+    render_ground_tracks_png(
+        case,
+        ground_tracks_path,
+        sample_times=track_times,
+        states_ecef_by_satellite=track_states,
+        texture_path=texture_path,
+        title=f"{case.manifest.case_id}: backbone ground tracks",
+    )
+
+    baseline_connectivity_path = output_dir / "baseline_connectivity.png"
+    summaries = compute_connectivity_summaries(
+        case,
+        sample_times=sample_times,
+        states_ecef_by_satellite=states_ecef_by_satellite,
+    )
+    render_connectivity_png(
+        case,
+        baseline_connectivity_path,
+        sample_times=sample_times,
+        states_ecef_by_satellite=states_ecef_by_satellite,
+    )
+    return {
+        "case_id": case.manifest.case_id,
+        "case_dir": str(case.case_dir),
+        "ground_tracks_png": ground_tracks_path.name,
+        "baseline_connectivity_png": baseline_connectivity_path.name,
+        "num_backbone_satellites": len(case.backbone_satellites),
+        "num_ground_endpoints": len(case.ground_endpoints),
+        "num_demanded_windows": len(case.demands),
+        "endpoint_pairs": [
+            {
+                "pair_id": summary.pair_id,
+                "requested_sample_count": summary.requested_sample_count,
+                "served_sample_count": summary.served_sample_count,
+                "route_interval_count": len(summary.route_intervals),
+            }
+            for summary in summaries
+        ],
+    }
 
 
 def render_case_plots(
@@ -591,43 +925,7 @@ def render_case_plots(
     *,
     texture_path: Path | None = None,
 ) -> dict[str, object]:
-    case = load_case(case_dir)
-    output_dir = Path(output_dir).resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    sample_times, states_ecef_by_satellite = build_state_cache(case)
-
-    overview_paths: list[str] = []
-    for demand in representative_demands(case):
-        overview_path = output_dir / f"overview_{demand.demand_id}.png"
-        render_overview_png(
-            case,
-            demand.demand_id,
-            overview_path,
-            texture_path=texture_path,
-            sample_times=sample_times,
-            states_ecef_by_satellite=states_ecef_by_satellite,
-        )
-        overview_paths.append(overview_path.name)
-
-    connectivity_path = output_dir / "connectivity.png"
-    render_connectivity_png(
-        case,
-        connectivity_path,
-        sample_times=sample_times,
-        states_ecef_by_satellite=states_ecef_by_satellite,
-    )
-
-    manifest = {
-        "case_id": case.manifest.case_id,
-        "case_dir": str(case.case_dir),
-        "connectivity_png": connectivity_path.name,
-        "overview_pngs": overview_paths,
-        "num_backbone_satellites": len(case.backbone_satellites),
-        "num_ground_endpoints": len(case.ground_endpoints),
-        "num_demanded_windows": len(case.demands),
-    }
-    _serialize_json(output_dir / "manifest.json", manifest)
-    return manifest
+    return render_overview(case_dir, output_dir, texture_path=texture_path)
 
 
 def render_dataset_plots(
@@ -655,5 +953,4 @@ def render_dataset_plots(
                 texture_path=texture_path,
             )
         )
-    _serialize_json(output_dir / "index.json", {"cases": manifests})
     return manifests

--- a/benchmarks/relay_constellation/visualizer/run.py
+++ b/benchmarks/relay_constellation/visualizer/run.py
@@ -7,13 +7,9 @@ from pathlib import Path
 
 from .plot import (
     DEFAULT_PLOTS_DIR,
-    render_connectivity_report,
-    render_overview_set,
+    render_overview,
 )
-from .solution import render_solution_report
-
-
-DEFAULT_DATASET_DIR = Path(__file__).resolve().parents[1] / "dataset"
+from .solution import render_solution
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -24,7 +20,7 @@ def main(argv: list[str] | None = None) -> int:
 
     overview_parser = subparsers.add_parser(
         "overview",
-        help="Render per-demand 2D overview PNGs for one case.",
+        help="Render case-only backbone ground tracks and baseline connectivity PNGs.",
     )
     overview_parser.add_argument(
         "--case-dir",
@@ -43,25 +39,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional local Earth texture path to use instead of auto-downloading",
     )
 
-    connectivity_parser = subparsers.add_parser(
-        "connectivity",
-        help="Render the infinite-concurrency connectivity PNG for one case.",
-    )
-    connectivity_parser.add_argument(
-        "--case-dir",
-        required=True,
-        help="Path to dataset/cases/<case_id>",
-    )
-    connectivity_parser.add_argument(
-        "--out-path",
-        type=Path,
-        default=None,
-        help="Where to write connectivity.png (default: benchmarks/relay_constellation/visualizer/plots/<case_id>/connectivity.png)",
-    )
-
     solution_parser = subparsers.add_parser(
         "solution",
-        help="Render solution-inspection artifacts for one case and one solution.",
+        help="Render solution-aware ground tracks and scheduled connectivity PNGs.",
     )
     solution_parser.add_argument(
         "--case-dir",
@@ -77,7 +57,7 @@ def main(argv: list[str] | None = None) -> int:
         "--out-dir",
         type=Path,
         default=None,
-        help="Directory for solution artifacts (default: benchmarks/relay_constellation/visualizer/plots/<case_id>/solution/<solution_stem>)",
+        help="Directory for solution PNGs (default: benchmarks/relay_constellation/visualizer/plots/<case_id>/solution/<solution_stem>)",
     )
     solution_parser.add_argument(
         "--texture-path",
@@ -92,22 +72,14 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "overview":
         out_dir = args.out_dir or (default_case_root / "overview")
-        manifest = render_overview_set(
+        result = render_overview(
             case_dir,
             out_dir,
             texture_path=args.texture_path,
         )
         print(
-            f"Wrote {len(manifest['overview_pngs'])} overview PNGs to {out_dir.resolve()}"
-        )
-        return 0
-
-    if args.command == "connectivity":
-        out_path = args.out_path or (default_case_root / "connectivity.png")
-        manifest = render_connectivity_report(case_dir, out_path)
-        print(
-            f"Wrote connectivity PNG to {out_path.resolve()} "
-            f"for {len(manifest['endpoint_pairs'])} endpoint pairs"
+            f"Wrote {result['ground_tracks_png']} and "
+            f"{result['baseline_connectivity_png']} to {out_dir.resolve()}"
         )
         return 0
 
@@ -115,15 +87,16 @@ def main(argv: list[str] | None = None) -> int:
     out_dir = args.out_dir or (
         default_case_root / "solution" / solution_path.stem
     )
-    manifest = render_solution_report(
+    result = render_solution(
         case_dir,
         solution_path,
         out_dir,
         texture_path=args.texture_path,
     )
     print(
-        f"Wrote solution artifacts to {out_dir.resolve()} "
-        f"with {len(manifest['snapshot_pngs'])} snapshots"
+        f"Wrote {result['ground_tracks_png']} and "
+        f"{result['scheduled_connectivity_png']} plus "
+        f"{len(result['demand_window_pngs'])} demand-window PNGs to {out_dir.resolve()}"
     )
     return 0
 

--- a/benchmarks/relay_constellation/visualizer/solution.py
+++ b/benchmarks/relay_constellation/visualizer/solution.py
@@ -26,7 +26,6 @@ from .plot import (
     _load_texture_image,
     _route_color,
     _serialize_json,
-    resolve_texture_path,
 )
 
 
@@ -370,7 +369,6 @@ def _render_snapshot_png(
     *,
     texture_path: Path | None = None,
 ) -> Path:
-    texture_path = resolve_texture_path(texture_path)
     texture = _load_texture_image(texture_path)
     figure = plt.figure(figsize=(16, 8))
     grid = figure.add_gridspec(1, 2, width_ratios=[2.8, 1.2], wspace=0.08)

--- a/benchmarks/relay_constellation/visualizer/solution.py
+++ b/benchmarks/relay_constellation/visualizer/solution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
+import textwrap
 
 import brahe
 import matplotlib
@@ -22,10 +23,11 @@ from ..verifier.models import (
     SolutionAnalysis,
     ValidatedAction,
 )
+from .geometry import build_state_cache_for_satellites
 from .plot import (
-    _load_texture_image,
+    coarsen_ground_track_cache,
     _route_color,
-    _serialize_json,
+    render_ground_tracks_png,
 )
 
 
@@ -59,6 +61,14 @@ def _route_signature(allocation: SampleAllocation) -> tuple[tuple[str, tuple[str
         (route.demand_id, route.nodes)
         for route in allocation.served_routes
     )
+
+
+def _metric_text(value: object, *, digits: int = 3) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, int | float):
+        return f"{float(value):.{digits}f}"
+    return str(value)
 
 
 def _pick_snapshot_indices(analysis: SolutionAnalysis, *, max_snapshots: int = 6) -> list[int]:
@@ -154,6 +164,17 @@ def _route_intervals_by_demand(
     return collapsed
 
 
+def _route_color_legend(
+    intervals: list[tuple[int, int, tuple[str, ...]]],
+) -> list[tuple[str, tuple[str, ...]]]:
+    seen: dict[tuple[str, ...], str] = {}
+    for _, _, route_nodes in intervals:
+        if route_nodes in seen:
+            continue
+        seen[route_nodes] = f"R{len(seen) + 1}"
+    return [(label, route_nodes) for route_nodes, label in seen.items()]
+
+
 def _action_timeline_records(
     analysis: SolutionAnalysis,
 ) -> list[dict[str, object]]:
@@ -193,16 +214,15 @@ def _action_timeline_records(
     return records
 
 
-def _render_timeline_png(
+def _render_scheduled_connectivity_png(
     analysis: SolutionAnalysis,
     output_path: Path,
 ) -> Path:
     demand_lookup = _demand_lookup(analysis)
     route_intervals = _route_intervals_by_demand(analysis)
-    action_records = _action_timeline_records(analysis)
     demand_rows = sorted(demand_lookup)
-    total_rows = len(demand_rows) + len(action_records)
-    figure_height = max(7.0, 0.36 * total_rows + 2.5)
+    total_rows = len(demand_rows)
+    figure_height = max(5.0, 0.42 * total_rows + 2.5)
     figure = plt.figure(figsize=(18, figure_height))
     grid = figure.add_gridspec(1, 2, width_ratios=[4.0, 1.4], wspace=0.08)
     axis = figure.add_subplot(grid[0, 0])
@@ -214,11 +234,6 @@ def _render_timeline_png(
     demand_y = {
         demand_id: (len(demand_rows) - row_index - 1)
         for row_index, demand_id in enumerate(demand_rows)
-    }
-    action_y_start = len(demand_rows) + 1
-    action_y = {
-        record["action_index"]: action_y_start + row_index
-        for row_index, record in enumerate(action_records)
     }
 
     for demand_id in demand_rows:
@@ -251,32 +266,6 @@ def _render_timeline_png(
                 alpha=0.95,
             )
 
-    for record in action_records:
-        y = action_y[int(record["action_index"])]
-        color = "#4b7bec" if record["status"] == "valid" else "#dc2626"
-        axis.broken_barh(
-            [
-                (
-                    mdates.date2num(record["start_time"]),
-                    mdates.date2num(record["end_time"]) - mdates.date2num(record["start_time"]),
-                )
-            ],
-            (y - bar_height / 2.0, bar_height),
-            facecolors=color,
-            edgecolors="none",
-            alpha=0.9,
-        )
-        failure = record["failure"]
-        if isinstance(failure, ActionFailure) and failure.time is not None:
-            axis.axvline(
-                mdates.date2num(failure.time),
-                ymin=max(0.0, (y - 0.45) / max(1.0, total_rows + 2)),
-                ymax=min(1.0, (y + 0.45) / max(1.0, total_rows + 2)),
-                color="#991b1b",
-                linewidth=1.2,
-                alpha=0.95,
-            )
-
     yticks: list[float] = []
     ylabels: list[str] = []
     for demand_id in demand_rows:
@@ -285,16 +274,13 @@ def _render_timeline_png(
         yticks.append(demand_y[demand_id])
         service_text = "n/a" if service_fraction is None else f"{service_fraction:.2f}"
         ylabels.append(f"{demand_id} ({service_text})")
-    for record in action_records:
-        yticks.append(action_y[int(record["action_index"])])
-        ylabels.append(f"a{int(record['action_index']):03d} {record['label']}")
 
     axis.set_yticks(yticks)
     axis.set_yticklabels(ylabels, fontsize=8)
     axis.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d %H:%M"))
     axis.grid(True, axis="x", color="#d5dbe3", linewidth=0.7, alpha=0.7)
     axis.set_title(
-        f"{analysis.case.manifest.case_id}: solution timeline",
+        f"{analysis.case.manifest.case_id}: scheduled connectivity",
         fontsize=15,
         fontweight="bold",
     )
@@ -302,17 +288,16 @@ def _render_timeline_png(
 
     legend_handles = [
         Line2D([0], [0], color="#d5dbe3", linewidth=8, label="Demanded window"),
-        Line2D([0], [0], color="#4b7bec", linewidth=8, label="Valid action"),
-        Line2D([0], [0], color="#dc2626", linewidth=8, label="Invalid action"),
+        Line2D([0], [0], color="#1d4ed8", linewidth=8, label="Served routes"),
     ]
     axis.legend(handles=legend_handles, loc="upper right", frameon=True)
 
     summary_lines = [
         f"Valid: {analysis.result.valid}",
-        f"Service fraction: {analysis.result.metrics['service_fraction']:.3f}",
-        f"Worst demand service: {analysis.result.metrics['worst_demand_service_fraction']:.3f}",
-        f"Mean latency ms: {analysis.result.metrics['mean_latency_ms']}",
-        f"Latency p95 ms: {analysis.result.metrics['latency_p95_ms']}",
+        f"Service fraction: {_metric_text(analysis.result.metrics['service_fraction'])}",
+        f"Worst demand service: {_metric_text(analysis.result.metrics['worst_demand_service_fraction'])}",
+        f"Mean latency ms: {_metric_text(analysis.result.metrics['mean_latency_ms'])}",
+        f"Latency p95 ms: {_metric_text(analysis.result.metrics['latency_p95_ms'])}",
         f"Added satellites: {analysis.result.metrics['num_added_satellites']}",
         f"Demanded windows: {analysis.result.metrics['num_demanded_windows']}",
         f"Validated actions: {analysis.result.diagnostics.get('action_counts', {}).get('validated_actions', 0)}",
@@ -342,6 +327,152 @@ def _render_timeline_png(
     return output_path
 
 
+def _render_demand_window_png(
+    analysis: SolutionAnalysis,
+    demand_id: str,
+    intervals: list[tuple[int, int, tuple[str, ...]]],
+    output_path: Path,
+) -> Path:
+    demand = _demand_lookup(analysis)[demand_id]
+    metrics = analysis.result.metrics["per_demand"].get(demand_id, {})
+    route_legend = _route_color_legend(intervals)
+    displayed_route_legend = route_legend[:8]
+
+    duration_s = (demand.end_time - demand.start_time).total_seconds()
+    padding_s = max(600.0, duration_s * 0.25)
+    x_min = demand.start_time - timedelta(seconds=padding_s)
+    x_max = demand.end_time + timedelta(seconds=padding_s)
+
+    figure = plt.figure(figsize=(15, 4.8))
+    grid = figure.add_gridspec(1, 2, width_ratios=[3.4, 1.4], wspace=0.08)
+    axis = figure.add_subplot(grid[0, 0])
+    summary_axis = figure.add_subplot(grid[0, 1])
+    axis.set_facecolor("#f7f8fa")
+    summary_axis.axis("off")
+
+    axis.broken_barh(
+        [
+            (
+                mdates.date2num(demand.start_time),
+                mdates.date2num(demand.end_time) - mdates.date2num(demand.start_time),
+            )
+        ],
+        (-0.38, 0.76),
+        facecolors="#d5dbe3",
+        edgecolors="none",
+        alpha=0.75,
+        label="Demanded window",
+    )
+
+    for start_index, end_index, route_nodes in intervals:
+        start_time, end_time = _interval_datetimes(analysis, start_index, end_index)
+        clipped_start = max(start_time, demand.start_time)
+        clipped_end = min(end_time, demand.end_time)
+        if clipped_end <= clipped_start:
+            continue
+        axis.broken_barh(
+            [
+                (
+                    mdates.date2num(clipped_start),
+                    mdates.date2num(clipped_end) - mdates.date2num(clipped_start),
+                )
+            ],
+            (-0.30, 0.60),
+            facecolors=_route_color(route_nodes),
+            edgecolors="white",
+            linewidth=0.4,
+            alpha=0.96,
+        )
+
+    axis.set_xlim(mdates.date2num(x_min), mdates.date2num(x_max))
+    axis.set_ylim(-1.0, 1.0)
+    axis.set_yticks([])
+    axis.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d %H:%M"))
+    axis.grid(True, axis="x", color="#d5dbe3", linewidth=0.7, alpha=0.75)
+    axis.set_xlabel("UTC time")
+    axis.set_title(
+        (
+            f"{analysis.case.manifest.case_id}: {demand_id} "
+            f"{demand.source_endpoint_id} -> {demand.destination_endpoint_id}"
+        ),
+        fontsize=13,
+        fontweight="bold",
+    )
+
+    legend_handles = [
+        Line2D([0], [0], color="#d5dbe3", linewidth=9, label="Demanded window"),
+    ]
+    for label, route_nodes in displayed_route_legend:
+        legend_handles.append(
+            Line2D(
+                [0],
+                [0],
+                color=_route_color(route_nodes),
+                linewidth=9,
+                label=label,
+            )
+        )
+    if len(route_legend) > len(displayed_route_legend):
+        legend_handles.append(
+            Line2D([0], [0], color="#64748b", linewidth=9, label="other routes")
+        )
+    axis.legend(handles=legend_handles, loc="upper right", frameon=True)
+
+    summary_lines = [
+        f"Demand: {demand_id}",
+        f"Pair: {demand.source_endpoint_id} -> {demand.destination_endpoint_id}",
+        f"Weight: {_metric_text(demand.weight)}",
+        "",
+        f"Requested samples: {metrics.get('requested_sample_count', 'n/a')}",
+        f"Served samples: {metrics.get('served_sample_count', 'n/a')}",
+        f"Service fraction: {_metric_text(metrics.get('service_fraction'))}",
+        f"Mean latency ms: {_metric_text(metrics.get('mean_latency_ms'))}",
+        f"Latency p95 ms: {_metric_text(metrics.get('latency_p95_ms'))}",
+        "",
+        "Route colors:",
+    ]
+    if not route_legend:
+        summary_lines.append("- no served route")
+    for label, route_nodes in displayed_route_legend:
+        route_text = f"{label}: {' -> '.join(route_nodes)}"
+        wrapped = textwrap.wrap(
+            route_text,
+            width=58,
+            subsequent_indent="    ",
+            break_long_words=False,
+        )
+        summary_lines.extend(f"- {line}" if index == 0 else f"  {line}" for index, line in enumerate(wrapped))
+    if len(route_legend) > len(displayed_route_legend):
+        summary_lines.append(f"... ({len(route_legend) - len(displayed_route_legend)} more routes)")
+    summary_axis.text(
+        0.0,
+        1.0,
+        "\n".join(summary_lines),
+        ha="left",
+        va="top",
+        fontsize=8.4,
+        family="monospace",
+        color="#1f2933",
+        transform=summary_axis.transAxes,
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    figure.savefig(output_path, dpi=170, bbox_inches="tight")
+    plt.close(figure)
+    return output_path
+
+
+def _horizon_sample_times(analysis: SolutionAnalysis) -> list[datetime]:
+    sample_times: list[datetime] = []
+    current = analysis.case.manifest.horizon_start
+    step_s = max(analysis.case.manifest.routing_step_s, 300)
+    step = timedelta(seconds=step_s)
+    while current < analysis.case.manifest.horizon_end:
+        sample_times.append(current)
+        current = current + step
+    return sample_times
+
+
 def _node_lonlat(
     analysis: SolutionAnalysis,
     node_id: str,
@@ -369,6 +500,8 @@ def _render_snapshot_png(
     *,
     texture_path: Path | None = None,
 ) -> Path:
+    from .plot import _load_texture_image
+
     texture = _load_texture_image(texture_path)
     figure = plt.figure(figsize=(16, 8))
     grid = figure.add_gridspec(1, 2, width_ratios=[2.8, 1.2], wspace=0.08)
@@ -544,49 +677,74 @@ def render_solution_report(
     analysis = analyze_solution(
         case_path,
         solution_file,
-        include_demand_sample_positions=True,
+        include_demand_sample_positions=False,
     )
-    timeline_path = output_dir / "timeline.png"
-    _render_timeline_png(analysis, timeline_path)
 
-    snapshot_indices = _pick_snapshot_indices(analysis)
-    snapshots_dir = output_dir / "snapshots"
-    snapshot_files: list[str] = []
-    for sample_index in snapshot_indices:
-        snapshot_path = snapshots_dir / f"snapshot_{sample_index:04d}.png"
-        _render_snapshot_png(
-            analysis,
-            sample_index,
-            snapshot_path,
-            texture_path=texture_path,
-        )
-        snapshot_files.append(snapshot_path.name)
+    all_satellites = {
+        **analysis.case.backbone_satellites,
+        **analysis.solution.added_satellites,
+    }
+    sample_times = _horizon_sample_times(analysis)
+    sample_times, states_ecef_by_satellite = build_state_cache_for_satellites(
+        analysis.case,
+        all_satellites,
+        sample_times,
+    )
+    track_times, track_states = coarsen_ground_track_cache(
+        sample_times,
+        states_ecef_by_satellite,
+    )
+
+    ground_tracks_path = output_dir / "ground_tracks.png"
+    render_ground_tracks_png(
+        analysis.case,
+        ground_tracks_path,
+        sample_times=track_times,
+        states_ecef_by_satellite=track_states,
+        texture_path=texture_path,
+        added_satellite_ids=set(analysis.solution.added_satellites),
+        max_added_tracks=1,
+        title=f"{analysis.case.manifest.case_id}: backbone + added ground tracks",
+    )
+
+    scheduled_connectivity_path = output_dir / "scheduled_connectivity.png"
+    _render_scheduled_connectivity_png(analysis, scheduled_connectivity_path)
 
     route_intervals = _route_intervals_by_demand(analysis)
-    summary = {
+    demand_windows_dir = output_dir / "demand_windows"
+    demand_window_files: list[str] = []
+    for demand in sorted(analysis.case.demands, key=lambda row: row.demand_id):
+        demand_window_path = demand_windows_dir / f"{demand.demand_id}.png"
+        _render_demand_window_png(
+            analysis,
+            demand.demand_id,
+            route_intervals.get(demand.demand_id, []),
+            demand_window_path,
+        )
+        demand_window_files.append(str(demand_window_path.relative_to(output_dir)))
+
+    return {
         "case_id": analysis.case.manifest.case_id,
         "case_dir": str(case_path),
         "solution_path": str(solution_file),
-        "timeline_png": timeline_path.name,
-        "snapshot_pngs": snapshot_files,
-        "snapshot_sample_indices": snapshot_indices,
+        "ground_tracks_png": ground_tracks_path.name,
+        "scheduled_connectivity_png": scheduled_connectivity_path.name,
+        "demand_window_pngs": demand_window_files,
         "verifier_result": analysis.result.to_dict(),
         "action_failures": [failure.to_dict() for failure in analysis.action_failures],
-        "route_intervals_by_demand": {
-            demand_id: [
-                {
-                    "start_time": _interval_datetimes(analysis, start_index, end_index)[0]
-                    .isoformat()
-                    .replace("+00:00", "Z"),
-                    "end_time": _interval_datetimes(analysis, start_index, end_index)[1]
-                    .isoformat()
-                    .replace("+00:00", "Z"),
-                    "route_nodes": list(route_nodes),
-                }
-                for start_index, end_index, route_nodes in intervals
-            ]
-            for demand_id, intervals in route_intervals.items()
-        },
     }
-    _serialize_json(output_dir / "summary.json", summary)
-    return summary
+
+
+def render_solution(
+    case_dir: Path | str,
+    solution_path: Path | str,
+    output_dir: Path | str,
+    *,
+    texture_path: Path | None = None,
+) -> dict[str, object]:
+    return render_solution_report(
+        case_dir,
+        solution_path,
+        output_dir,
+        texture_path=texture_path,
+    )

--- a/benchmarks/revisit_constellation/README.md
+++ b/benchmarks/revisit_constellation/README.md
@@ -237,6 +237,30 @@ CLI entry:
 uv run python -m benchmarks.revisit_constellation.verifier.run <case_dir> <solution.json>
 ```
 
+## Visualization Usage
+
+The optional visualizer emits human-facing PNG plots.
+
+Render a case-only target distribution overview:
+
+```bash
+uv run python -m benchmarks.revisit_constellation.visualizer.run overview \
+  --case-dir benchmarks/revisit_constellation/dataset/cases/test/case_0001
+```
+
+Render solution-aware per-target action snapshots:
+
+```bash
+uv run python -m benchmarks.revisit_constellation.visualizer.run solution \
+  --case-dir benchmarks/revisit_constellation/dataset/cases/test/case_0001 \
+  --solution-path benchmarks/revisit_constellation/dataset/example_solution.json
+```
+
+The `overview` command writes `overview.png`. The `solution` command writes one
+PNG page per rendered observed target; each page shows a bounded set of
+observation snapshots with target-relevant satellite ground tracks and the
+active observing satellite highlighted.
+
 ## Canonical Benchmark Shape
 
 The repository structure is:

--- a/benchmarks/revisit_constellation/visualizer/__init__.py
+++ b/benchmarks/revisit_constellation/visualizer/__init__.py
@@ -1,0 +1,1 @@
+"""Optional revisit_constellation visualization helpers."""

--- a/benchmarks/revisit_constellation/visualizer/run.py
+++ b/benchmarks/revisit_constellation/visualizer/run.py
@@ -1,0 +1,558 @@
+"""Human-facing visualizer for the revisit_constellation benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import brahe
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+from brahe.plots.texture_utils import load_earth_texture
+from matplotlib.lines import Line2D
+
+from ..verifier import Action, Instance, Solution, Target, load_case, load_solution
+from ..verifier.engine import _build_propagators, _datetime_to_epoch, _ensure_brahe_ready
+
+
+_VISUALIZER_DIR = Path(__file__).resolve().parent
+_DEFAULT_OUTPUT_ROOT = _VISUALIZER_DIR / "plots"
+_WORLD_TEXTURE_EXTENT = (-180.0, 180.0, -90.0, 90.0)
+_WORLD_TEXTURE: np.ndarray | None = None
+_THEME = {
+    "background": "#ffffff",
+    "panel": "#f7f8fa",
+    "grid": "#d5dbe3",
+    "axis": "#39424e",
+    "text": "#1f2933",
+    "muted": "#52606d",
+    "target": "#ef4444",
+    "observer": "#06b6d4",
+    "other_satellite": "#334155",
+    "track": "#64748b",
+}
+
+
+def _utc_label(value: datetime) -> str:
+    return value.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%SZ")
+
+
+def _target_order(instance: Instance) -> list[Target]:
+    return list(instance.targets.values())
+
+
+def _solution_output_dir(
+    case_dir: Path, solution_path: Path, out_dir: str | Path | None
+) -> Path:
+    if out_dir is not None:
+        return Path(out_dir)
+    return _DEFAULT_OUTPUT_ROOT / case_dir.name / "solution" / solution_path.stem
+
+
+def _load_world_texture() -> np.ndarray | None:
+    global _WORLD_TEXTURE
+    if _WORLD_TEXTURE is None:
+        for texture_name in ("natural_earth_50m", "blue_marble"):
+            try:
+                image = load_earth_texture(texture_name)
+            except Exception:
+                continue
+            if image is not None:
+                _WORLD_TEXTURE = np.asarray(image)
+                break
+    return _WORLD_TEXTURE
+
+
+def _draw_world(ax: plt.Axes) -> None:
+    texture = _load_world_texture()
+    if texture is not None:
+        xmin, xmax, ymin, ymax = _WORLD_TEXTURE_EXTENT
+        ax.imshow(
+            texture,
+            origin="upper",
+            extent=[xmin, xmax, ymin, ymax],
+            aspect="auto",
+            interpolation="bilinear",
+            zorder=0,
+            alpha=0.92,
+        )
+    ax.set_xlim(-180.0, 180.0)
+    ax.set_ylim(-90.0, 90.0)
+    ax.set_xlabel("Longitude (deg)")
+    ax.set_ylabel("Latitude (deg)")
+    ax.grid(True, color=_THEME["grid"], linewidth=0.6, alpha=0.55)
+    ax.set_facecolor(_THEME["panel"])
+    ax.tick_params(colors=_THEME["muted"], labelsize=8)
+    for spine in ax.spines.values():
+        spine.set_color(_THEME["axis"])
+
+
+def _case_output_path(case_dir: Path, out_path: str | Path | None) -> Path:
+    if out_path is not None:
+        return Path(out_path)
+    return _DEFAULT_OUTPUT_ROOT / case_dir.name / "overview.png"
+
+
+def render_overview(case_dir: str | Path, out_path: str | Path | None = None) -> Path:
+    """Render case-only target distribution overview."""
+
+    case_path = Path(case_dir)
+    instance = load_case(case_path)
+    output_path = _case_output_path(case_path, out_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    targets = _target_order(instance)
+    longitudes = np.asarray([target.longitude_deg for target in targets], dtype=float)
+    latitudes = np.asarray([target.latitude_deg for target in targets], dtype=float)
+    revisit_hours = np.asarray(
+        [target.expected_revisit_period_hours for target in targets], dtype=float
+    )
+
+    fig, ax = plt.subplots(figsize=(11.5, 6.4), dpi=180)
+    fig.patch.set_facecolor(_THEME["background"])
+    _draw_world(ax)
+    scatter = ax.scatter(
+        longitudes,
+        latitudes,
+        c=revisit_hours,
+        cmap="plasma_r",
+        s=55,
+        edgecolors="#111827",
+        linewidths=0.55,
+        zorder=4,
+    )
+    ax.set_title(f"{case_path.name}: target distribution", fontweight="bold", pad=12)
+    colorbar = fig.colorbar(scatter, ax=ax, fraction=0.026, pad=0.025)
+    colorbar.set_label("Expected revisit period (hours)", color=_THEME["text"])
+    colorbar.ax.tick_params(colors=_THEME["muted"])
+
+    horizon_hours = instance.horizon_duration_sec / 3600.0
+    fig.text(
+        0.01,
+        0.015,
+        f"{len(targets)} targets | {horizon_hours:.1f}h horizon | "
+        f"up to {instance.max_num_satellites} satellites | "
+        f"altitude {instance.satellite_model.min_altitude_m / 1000:.0f}-"
+        f"{instance.satellite_model.max_altitude_m / 1000:.0f} km",
+        ha="left",
+        va="bottom",
+        fontsize=9,
+        color=_THEME["muted"],
+    )
+    fig.tight_layout(rect=(0, 0.04, 1, 1))
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def _observation_actions_by_target(solution: Solution) -> dict[str, list[Action]]:
+    actions_by_target: dict[str, list[Action]] = defaultdict(list)
+    for action in solution.actions:
+        if action.action_type != "observation" or action.target_id is None:
+            continue
+        actions_by_target[action.target_id].append(action)
+    for actions in actions_by_target.values():
+        actions.sort(key=lambda item: (item.start, item.end, item.satellite_id))
+    return actions_by_target
+
+
+def _satellite_ids_for_target(actions: list[Action]) -> list[str]:
+    return sorted({action.satellite_id for action in actions})
+
+
+def _satellite_lonlat(
+    propagator: brahe.NumericalOrbitPropagator, instant: datetime
+) -> tuple[float, float]:
+    epoch = _datetime_to_epoch(instant)
+    state_ecef = np.asarray(propagator.state_ecef(epoch), dtype=float).reshape(6)
+    lon_deg, lat_deg, _alt_m = brahe.position_ecef_to_geodetic(
+        state_ecef[:3], brahe.AngleFormat.DEGREES
+    )
+    return float(lon_deg), float(lat_deg)
+
+
+def _sample_ground_track_segments(
+    propagator: brahe.NumericalOrbitPropagator,
+    start: datetime,
+    end: datetime,
+    *,
+    step_s: float,
+) -> list[tuple[list[float], list[float]]]:
+    longitudes: list[float] = []
+    latitudes: list[float] = []
+    current = start
+    step = timedelta(seconds=step_s)
+    while current <= end:
+        lon_deg, lat_deg = _satellite_lonlat(propagator, current)
+        longitudes.append(lon_deg)
+        latitudes.append(lat_deg)
+        current += step
+    if not longitudes or current - step < end:
+        lon_deg, lat_deg = _satellite_lonlat(propagator, end)
+        longitudes.append(lon_deg)
+        latitudes.append(lat_deg)
+    return brahe.split_ground_track_at_antimeridian(longitudes, latitudes)
+
+
+def _action_midpoint(action: Action) -> datetime:
+    return action.start + (action.end - action.start) / 2
+
+
+def _track_window(
+    instance: Instance, midpoint: datetime, track_window_min: float
+) -> tuple[datetime, datetime]:
+    half_window = timedelta(minutes=track_window_min / 2.0)
+    start = max(instance.horizon_start, midpoint - half_window)
+    end = min(instance.horizon_end, midpoint + half_window)
+    return start, end
+
+
+def _target_page_path(output_dir: Path, target: Target, index: int) -> Path:
+    safe_id = "".join(
+        char if char.isalnum() or char in {"-", "_"} else "_" for char in target.target_id
+    )
+    return output_dir / f"target_{index:02d}_{safe_id}.png"
+
+
+def _plot_snapshot(
+    ax: plt.Axes,
+    *,
+    instance: Instance,
+    target: Target,
+    action: Action,
+    relevant_satellite_ids: list[str],
+    propagators: dict[str, brahe.NumericalOrbitPropagator],
+    track_window_min: float,
+    track_step_s: float,
+) -> None:
+    _draw_world(ax)
+    midpoint = _action_midpoint(action)
+    track_start, track_end = _track_window(instance, midpoint, track_window_min)
+
+    for satellite_id in relevant_satellite_ids:
+        propagator = propagators.get(satellite_id)
+        if propagator is None:
+            continue
+        is_observer = satellite_id == action.satellite_id
+        track_color = _THEME["observer"] if is_observer else _THEME["track"]
+        alpha = 0.88 if is_observer else 0.52
+        linewidth = 1.4 if is_observer else 0.85
+        for lons, lats in _sample_ground_track_segments(
+            propagator,
+            track_start,
+            track_end,
+            step_s=track_step_s,
+        ):
+            ax.plot(
+                lons,
+                lats,
+                color=track_color,
+                linewidth=linewidth,
+                alpha=alpha,
+                zorder=2,
+            )
+        lon_deg, lat_deg = _satellite_lonlat(propagator, midpoint)
+        marker = "o" if is_observer else "^"
+        size = 56 if is_observer else 34
+        face = _THEME["observer"] if is_observer else _THEME["other_satellite"]
+        ax.scatter(
+            [lon_deg],
+            [lat_deg],
+            s=size,
+            marker=marker,
+            color=face,
+            edgecolors="white",
+            linewidths=0.65,
+            zorder=5,
+        )
+
+    ax.scatter(
+        [target.longitude_deg],
+        [target.latitude_deg],
+        s=72,
+        marker="*",
+        color=_THEME["target"],
+        edgecolors="#111827",
+        linewidths=0.55,
+        zorder=6,
+    )
+    ax.set_title(
+        f"{_utc_label(midpoint)}\nobserver {action.satellite_id}",
+        fontsize=8.5,
+        color=_THEME["text"],
+    )
+
+
+def _snapshot_legend_handles() -> list[Line2D]:
+    return [
+        Line2D(
+            [0],
+            [0],
+            marker="*",
+            linestyle="none",
+            color="none",
+            markerfacecolor=_THEME["target"],
+            markeredgecolor="#111827",
+            markersize=9,
+            label="target",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            linestyle="none",
+            color="none",
+            markerfacecolor=_THEME["observer"],
+            markeredgecolor="white",
+            markersize=6,
+            label="observing satellite",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="^",
+            linestyle="none",
+            color="none",
+            markerfacecolor=_THEME["other_satellite"],
+            markeredgecolor="white",
+            markersize=6,
+            label="other observing satellite",
+        ),
+    ]
+
+
+def _selected_targets_with_actions(
+    instance: Instance, actions_by_target: dict[str, list[Action]], max_targets: int | None
+) -> list[Target]:
+    targets = [
+        target
+        for target in _target_order(instance)
+        if actions_by_target.get(target.target_id)
+    ]
+    if max_targets is None:
+        return targets
+    return targets[: max(0, max_targets)]
+
+
+def _filtered_solution_for_satellites(solution: Solution, satellite_ids: set[str]) -> Solution:
+    return Solution(
+        satellites={
+            satellite_id: satellite
+            for satellite_id, satellite in solution.satellites.items()
+            if satellite_id in satellite_ids
+        },
+        actions=[],
+    )
+
+
+def _target_max_gap_hours(instance: Instance, target: Target, actions: list[Action]) -> float:
+    midpoints = sorted({_action_midpoint(action) for action in actions})
+    times = [instance.horizon_start, *midpoints, instance.horizon_end]
+    return max(
+        (right - left).total_seconds() / 3600.0
+        for left, right in zip(times, times[1:])
+    )
+
+
+def render_solution(
+    case_dir: str | Path,
+    solution_path: str | Path,
+    out_dir: str | Path | None = None,
+    *,
+    max_targets: int | None = 8,
+    max_actions_per_target: int | None = 4,
+    track_window_min: float = 90.0,
+    track_step_s: float = 90.0,
+) -> list[Path]:
+    """Render per-target action snapshot pages for one solution."""
+
+    case_path = Path(case_dir)
+    solution_file = Path(solution_path)
+    instance = load_case(case_path)
+    solution = load_solution(solution_file)
+    actions_by_target = _observation_actions_by_target(solution)
+    targets = _selected_targets_with_actions(instance, actions_by_target, max_targets)
+    selected_satellite_ids = {
+        action.satellite_id
+        for target in targets
+        for action in actions_by_target[target.target_id]
+        if action.satellite_id in solution.satellites
+    }
+    _ensure_brahe_ready()
+    propagators = _build_propagators(
+        instance, _filtered_solution_for_satellites(solution, selected_satellite_ids)
+    )
+
+    output_dir = _solution_output_dir(case_path, solution_file, out_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+
+    for target_index, target in enumerate(targets, start=1):
+        actions = actions_by_target[target.target_id]
+        selected_actions = actions
+        if max_actions_per_target is not None:
+            selected_actions = actions[: max(0, max_actions_per_target)]
+        if not selected_actions:
+            continue
+        relevant_satellite_ids = _satellite_ids_for_target(actions)
+        ncols = min(2, len(selected_actions))
+        nrows = math.ceil(len(selected_actions) / ncols)
+        fig, axes = plt.subplots(
+            nrows,
+            ncols,
+            figsize=(6.4 * ncols, 4.2 * nrows + 0.7),
+            dpi=180,
+            squeeze=False,
+        )
+        fig.patch.set_facecolor(_THEME["background"])
+        for ax in axes.ravel()[len(selected_actions) :]:
+            ax.axis("off")
+        for ax, action in zip(axes.ravel(), selected_actions):
+            _plot_snapshot(
+                ax,
+                instance=instance,
+                target=target,
+                action=action,
+                relevant_satellite_ids=relevant_satellite_ids,
+                propagators=propagators,
+                track_window_min=track_window_min,
+                track_step_s=track_step_s,
+            )
+        axes.ravel()[0].legend(
+            handles=_snapshot_legend_handles(),
+            loc="lower left",
+            fontsize=7.2,
+            frameon=True,
+            framealpha=0.78,
+            facecolor="white",
+            edgecolor=_THEME["grid"],
+        )
+
+        fig.suptitle(
+            f"{target.target_id}: {target.name}",
+            fontsize=13,
+            fontweight="bold",
+            color=_THEME["text"],
+        )
+        max_gap_hours = _target_max_gap_hours(instance, target, actions)
+        footer = (
+            f"{len(actions)} observations by {len(relevant_satellite_ids)} satellites | "
+            f"expected revisit {target.expected_revisit_period_hours:.1f}h"
+        )
+        footer += f" | scheduled max gap {max_gap_hours:.1f}h"
+        fig.text(
+            0.01,
+            0.015,
+            footer,
+            ha="left",
+            va="bottom",
+            fontsize=9,
+            color=_THEME["muted"],
+        )
+        fig.tight_layout(rect=(0, 0.06, 1, 0.93))
+        output_path = _target_page_path(output_dir, target, target_index)
+        fig.savefig(output_path, bbox_inches="tight")
+        plt.close(fig)
+        written.append(output_path)
+
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render revisit_constellation case and solution plots."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    overview_parser = subparsers.add_parser(
+        "overview",
+        help="Render case-only target distribution overview.",
+    )
+    overview_parser.add_argument(
+        "--case-dir",
+        required=True,
+        help="Path to dataset/cases/<split>/<case_id>.",
+    )
+    overview_parser.add_argument(
+        "--out-path",
+        type=Path,
+        default=None,
+        help="Output PNG path (default: benchmarks/revisit_constellation/visualizer/plots/<case_id>/overview.png).",
+    )
+
+    solution_parser = subparsers.add_parser(
+        "solution",
+        help="Render per-target solution action snapshots.",
+    )
+    solution_parser.add_argument(
+        "--case-dir",
+        required=True,
+        help="Path to dataset/cases/<split>/<case_id>.",
+    )
+    solution_parser.add_argument(
+        "--solution-path",
+        required=True,
+        help="Path to a revisit_constellation solution JSON file.",
+    )
+    solution_parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Output directory (default: benchmarks/revisit_constellation/visualizer/plots/<case_id>/solution/<solution_stem>).",
+    )
+    solution_parser.add_argument(
+        "--max-targets",
+        type=int,
+        default=8,
+        help="Maximum observed targets to render. Use 0 to render none.",
+    )
+    solution_parser.add_argument(
+        "--max-actions-per-target",
+        type=int,
+        default=4,
+        help="Maximum snapshots per target image.",
+    )
+    solution_parser.add_argument(
+        "--track-window-min",
+        type=float,
+        default=90.0,
+        help="Minutes of local ground-track context around each snapshot.",
+    )
+    solution_parser.add_argument(
+        "--track-step-s",
+        type=float,
+        default=90.0,
+        help="Ground-track sampling interval in seconds.",
+    )
+
+    args = parser.parse_args(argv)
+    if args.command == "overview":
+        out_path = render_overview(args.case_dir, args.out_path)
+        print(f"Wrote {out_path.resolve()}")
+        return 0
+
+    paths = render_solution(
+        args.case_dir,
+        args.solution_path,
+        args.out_dir,
+        max_targets=args.max_targets,
+        max_actions_per_target=args.max_actions_per_target,
+        track_window_min=args.track_window_min,
+        track_step_s=args.track_step_s,
+    )
+    for path in paths:
+        print(f"Wrote {path.resolve()}")
+    if not paths:
+        print("No observed targets rendered")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/benchmarks/satnet/README.md
+++ b/benchmarks/satnet/README.md
@@ -274,6 +274,27 @@ Satisfied requests: 132
 VALID: total_hours=234.5678h, tracks=145
 ```
 
+## Visualization Usage
+
+The optional visualizer emits human-facing PNG plots. It does not create machine-readable sidecar artifacts.
+
+Render a case-only antenna/day opportunity heatmap:
+
+```bash
+uv run python -m benchmarks.satnet.visualizer.run availability \
+    --case-dir benchmarks/satnet/dataset/cases/test/W10_2018
+```
+
+Render solution-aware outcome plots:
+
+```bash
+uv run python -m benchmarks.satnet.visualizer.run schedule \
+    --case-dir benchmarks/satnet/dataset/cases/test/W10_2018 \
+    --solution-path tests/fixtures/satnet_mock_solutions/W10_2018_solution.json
+```
+
+The `availability` command writes `availability.png`. The `schedule` command writes `satisfaction.png` and `timeline.png`. Mission colors come from the `dataset/mission_color_map.json` file.
+
 ## Baseline Performance
 
 Published SatNet baselines report both total scheduled hours (`T_S`) and mission-level fairness metrics. These rows are citation-backed literature results, not outputs reproduced by this repository.

--- a/benchmarks/satnet/visualizer/__init__.py
+++ b/benchmarks/satnet/visualizer/__init__.py
@@ -1,0 +1,1 @@
+"""Optional SatNet visualization helpers."""

--- a/benchmarks/satnet/visualizer/run.py
+++ b/benchmarks/satnet/visualizer/run.py
@@ -1,0 +1,576 @@
+"""Human-facing visualizer for the SatNet benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
+
+from ..verifier import (
+    ALL_ANTENNAS,
+    Instance,
+    Request,
+    Solution,
+    Track,
+    load_case,
+    load_solution,
+    verify,
+)
+
+
+_VISUALIZER_DIR = Path(__file__).resolve().parent
+_BENCHMARK_DIR = _VISUALIZER_DIR.parent
+_DEFAULT_OUTPUT_ROOT = _VISUALIZER_DIR / "plots"
+_MISSION_COLOR_MAP_PATH = _BENCHMARK_DIR / "dataset" / "mission_color_map.json"
+_DAY_NAMES = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+_THEME = {
+    "background": "#ffffff",
+    "panel": "#f7f8fa",
+    "grid": "#d5dbe3",
+    "axis": "#39424e",
+    "text": "#1f2933",
+    "muted": "#52606d",
+    "maintenance": "#111827",
+}
+
+
+@dataclass(frozen=True)
+class LogicalTrack:
+    track_id: str
+    sc: int
+    resources: tuple[str, ...]
+    start_time: int
+    tracking_on: int
+    tracking_off: int
+    end_time: int
+
+
+def _to_datetime(timestamp_s: int) -> datetime:
+    return datetime.fromtimestamp(timestamp_s, tz=UTC)
+
+
+def _case_week_start(instance: Instance) -> datetime:
+    return datetime.fromisocalendar(int(instance.year), int(instance.week), 1).replace(
+        tzinfo=UTC
+    )
+
+
+def _case_week_end(instance: Instance) -> datetime:
+    return _case_week_start(instance) + timedelta(days=7)
+
+
+def _apply_axes_theme(ax: plt.Axes, *, grid_axis: str = "both") -> None:
+    ax.set_facecolor(_THEME["panel"])
+    ax.grid(True, axis=grid_axis, color=_THEME["grid"], alpha=0.75, linewidth=0.8)
+    ax.tick_params(colors=_THEME["muted"])
+    ax.xaxis.label.set_color(_THEME["text"])
+    ax.yaxis.label.set_color(_THEME["text"])
+    ax.title.set_color(_THEME["text"])
+    for spine in ax.spines.values():
+        spine.set_color(_THEME["axis"])
+
+
+def _load_mission_colors() -> dict[str, tuple[str, str]]:
+    if not _MISSION_COLOR_MAP_PATH.exists():
+        return {}
+    with _MISSION_COLOR_MAP_PATH.open("r", encoding="utf-8") as file_obj:
+        raw = json.load(file_obj)
+    colors: dict[str, tuple[str, str]] = {}
+    for mission_id, pair in raw.items():
+        if isinstance(pair, list) and len(pair) >= 2:
+            colors[str(mission_id)] = (str(pair[0]), str(pair[1]))
+    return colors
+
+
+def _fallback_color(mission_id: str) -> tuple[str, str]:
+    palette = plt.get_cmap("tab20")
+    index = sum((idx + 1) * ord(char) for idx, char in enumerate(mission_id)) % palette.N
+    fill = palette(index)
+    rgb = tuple(max(0.0, channel * 0.65) for channel in fill[:3])
+    edge = "#{:02x}{:02x}{:02x}".format(
+        int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255)
+    )
+    return matplotlib.colors.to_hex(fill), edge
+
+
+def _mission_color(
+    mission_id: str, mission_colors: dict[str, tuple[str, str]]
+) -> tuple[str, str]:
+    return mission_colors.get(str(mission_id), _fallback_color(str(mission_id)))
+
+
+def _mission_bar_color(
+    mission_id: str, mission_colors: dict[str, tuple[str, str]]
+) -> tuple[str, str]:
+    return _mission_color(mission_id, mission_colors)
+
+
+def _mission_timeline_color(
+    mission_id: str, mission_colors: dict[str, tuple[str, str]]
+) -> tuple[str, str]:
+    light_color, strong_color = _mission_color(mission_id, mission_colors)
+    return strong_color, light_color
+
+
+def _sorted_antennas(instance: Instance) -> list[str]:
+    antennas = set(ALL_ANTENNAS)
+    antennas.update(window.antenna for window in instance.maintenance)
+    for request in instance.requests.values():
+        for combo_key in request.resource_vp_dict:
+            antennas.update(combo_key.split("_"))
+    return sorted(antennas, key=lambda item: int(item.split("-")[-1]))
+
+
+def _iter_vp_antenna_intervals(request: Request) -> list[tuple[str, int, int]]:
+    intervals: list[tuple[str, int, int]] = []
+    for combo_key, vps in request.resource_vp_dict.items():
+        for antenna in combo_key.split("_"):
+            for start, end in vps:
+                intervals.append((antenna, int(start), int(end)))
+    return intervals
+
+
+def _overlaps(a0: int, a1: int, b0: int, b1: int) -> bool:
+    return not (a1 <= b0 or b1 <= a0)
+
+
+def _availability_counts(instance: Instance) -> tuple[list[str], np.ndarray]:
+    antennas = _sorted_antennas(instance)
+    antenna_index = {antenna: idx for idx, antenna in enumerate(antennas)}
+    counts = np.zeros((len(antennas), 7), dtype=int)
+    week_start = _case_week_start(instance)
+    day_edges = [int((week_start + timedelta(days=day)).timestamp()) for day in range(8)]
+
+    for request in instance.requests.values():
+        for antenna, vp_start, vp_end in _iter_vp_antenna_intervals(request):
+            if antenna not in antenna_index:
+                continue
+            for day in range(7):
+                if _overlaps(vp_start, vp_end, day_edges[day], day_edges[day + 1]):
+                    counts[antenna_index[antenna], day] += 1
+
+    return antennas, counts
+
+
+def _annotate_heatmap(ax: plt.Axes, counts: np.ndarray, cmap: matplotlib.colors.Colormap) -> None:
+    max_value = max(1, int(counts.max(initial=0)))
+    for row in range(counts.shape[0]):
+        for col in range(counts.shape[1]):
+            value = int(counts[row, col])
+            rgba = cmap(value / max_value)
+            luminance = 0.2126 * rgba[0] + 0.7152 * rgba[1] + 0.0722 * rgba[2]
+            color = "white" if luminance < 0.48 else "#172033"
+            ax.text(
+                col,
+                row,
+                str(value),
+                ha="center",
+                va="center",
+                color=color,
+                fontsize=9,
+            )
+
+
+def render_availability(case_dir: str | Path, out_path: str | Path | None = None) -> Path:
+    """Render a case-only antenna/day opportunity heatmap."""
+
+    case_path = Path(case_dir)
+    instance = load_case(case_path)
+    output_path = (
+        Path(out_path)
+        if out_path is not None
+        else _DEFAULT_OUTPUT_ROOT
+        / str(instance.case_id or case_path.name)
+        / "availability.png"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    antennas, counts = _availability_counts(instance)
+    fig_height = max(5.2, 0.34 * len(antennas) + 1.7)
+    fig, ax = plt.subplots(figsize=(9.5, fig_height), dpi=180)
+    fig.patch.set_facecolor(_THEME["background"])
+
+    cmap = plt.get_cmap("viridis_r")
+    image = ax.imshow(counts, cmap=cmap, aspect="auto")
+    ax.set_title(
+        f"{instance.case_id or case_path.name}: request opportunities by antenna and day",
+        pad=14,
+        fontsize=13,
+        fontweight="bold",
+    )
+    ax.set_xticks(range(7), _DAY_NAMES, rotation=0)
+    ax.set_yticks(range(len(antennas)), antennas)
+    ax.set_xlabel("")
+    ax.set_ylabel("")
+    ax.set_xticks(np.arange(-0.5, 7, 1), minor=True)
+    ax.set_yticks(np.arange(-0.5, len(antennas), 1), minor=True)
+    ax.grid(which="minor", color="#ffffff", linewidth=1.0)
+    ax.tick_params(which="minor", bottom=False, left=False)
+    _annotate_heatmap(ax, counts, cmap)
+    colorbar = fig.colorbar(image, ax=ax, fraction=0.025, pad=0.02)
+    colorbar.set_label("View-period opportunities", color=_THEME["text"])
+    colorbar.ax.tick_params(colors=_THEME["muted"])
+
+    fig.text(
+        0.01,
+        0.015,
+        "Each cell counts request view-period intervals touching that antenna/day; arrayed requests contribute to each antenna in the array.",
+        ha="left",
+        va="bottom",
+        fontsize=8.5,
+        color=_THEME["muted"],
+    )
+    fig.tight_layout(rect=(0, 0.04, 1, 1))
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def _logical_tracks(solution: Solution) -> list[LogicalTrack]:
+    grouped: dict[tuple[str, int, int, int, int], list[Track]] = defaultdict(list)
+    for track in solution.tracks:
+        grouped[
+            (
+                track.track_id,
+                track.start_time,
+                track.tracking_on,
+                track.tracking_off,
+                track.end_time,
+            )
+        ].append(track)
+
+    logical: list[LogicalTrack] = []
+    for (track_id, start, on, off, end), group in grouped.items():
+        resources = tuple(sorted({track.resource for track in group}))
+        sc = group[0].sc
+        logical.append(
+            LogicalTrack(
+                track_id=track_id,
+                sc=sc,
+                resources=resources,
+                start_time=start,
+                tracking_on=on,
+                tracking_off=off,
+                end_time=end,
+            )
+        )
+    return sorted(logical, key=lambda track: (track.start_time, track.track_id))
+
+
+def _solution_output_dir(
+    case_dir: Path, solution_path: Path, out_dir: str | Path | None
+) -> Path:
+    if out_dir is not None:
+        return Path(out_dir)
+    return _DEFAULT_OUTPUT_ROOT / case_dir.name / "schedule" / solution_path.stem
+
+
+def render_satisfaction(
+    case_dir: str | Path,
+    solution_path: str | Path,
+    out_path: str | Path | None = None,
+) -> Path:
+    """Render mission satisfaction bars for one case and solution."""
+
+    case_path = Path(case_dir)
+    solution_file = Path(solution_path)
+    instance = load_case(case_path)
+    solution = load_solution(solution_file)
+    result = verify(instance, solution)
+    mission_colors = _load_mission_colors()
+
+    output_path = Path(out_path) if out_path is not None else (
+        _solution_output_dir(case_path, solution_file, None) / "satisfaction.png"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    requested_hours_by_mission: dict[str, float] = defaultdict(float)
+    for request in instance.requests.values():
+        requested_hours_by_mission[str(request.subject)] += float(request.duration)
+
+    mission_ids = sorted(
+        requested_hours_by_mission,
+        key=lambda mission_id: (
+            1.0 - result.per_mission_u_i.get(mission_id, 0.0),
+            mission_id,
+        ),
+    )
+    satisfaction = [
+        100.0 * (1.0 - result.per_mission_u_i.get(mission_id, 0.0))
+        for mission_id in mission_ids
+    ]
+    y_positions = np.arange(len(mission_ids))
+    colors = [
+        _mission_bar_color(mission_id, mission_colors)[0] for mission_id in mission_ids
+    ]
+    edge_colors = [
+        _mission_bar_color(mission_id, mission_colors)[1] for mission_id in mission_ids
+    ]
+
+    fig_height = max(6.0, 0.26 * len(mission_ids) + 1.8)
+    fig, ax = plt.subplots(figsize=(10.5, fig_height), dpi=180)
+    fig.patch.set_facecolor(_THEME["background"])
+    _apply_axes_theme(ax, grid_axis="x")
+
+    ax.barh(y_positions, satisfaction, color=colors, edgecolor=edge_colors, linewidth=0.8)
+    ax.set_yticks(y_positions, mission_ids)
+    ax.set_xlim(0, 100)
+    ax.set_xlabel("Requested mission hours satisfied (%)")
+    ax.set_ylabel("Mission")
+    ax.set_title(
+        f"{instance.case_id or case_path.name}: mission satisfaction",
+        pad=12,
+        fontweight="bold",
+    )
+    for tick in [20, 40, 60, 80, 100]:
+        ax.axvline(tick, color="#111827", linestyle="--", linewidth=0.7, alpha=0.6)
+
+    status = "VALID" if result.is_valid else "INVALID"
+    requested_total = sum(requested_hours_by_mission.values())
+    summary = (
+        f"{status} solution | tracking {result.total_hours:.1f}h / requested {requested_total:.1f}h | "
+        f"satisfied requests {result.n_satisfied_requests}/{len(instance.requests)} | "
+        f"U_rms {result.u_rms:.3f} | U_max {result.u_max:.3f}"
+    )
+    fig.text(
+        0.01,
+        0.012,
+        summary,
+        ha="left",
+        va="bottom",
+        fontsize=9,
+        color=_THEME["muted"],
+    )
+    fig.tight_layout(rect=(0, 0.04, 1, 1))
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def _setup_timedelta(track: LogicalTrack) -> tuple[float, float, float, float]:
+    full_start = mdates.date2num(_to_datetime(track.start_time))
+    full_end = mdates.date2num(_to_datetime(track.end_time))
+    trx_start = mdates.date2num(_to_datetime(track.tracking_on))
+    trx_end = mdates.date2num(_to_datetime(track.tracking_off))
+    return full_start, full_end, trx_start, trx_end
+
+
+def render_timeline(
+    case_dir: str | Path,
+    solution_path: str | Path,
+    out_path: str | Path | None = None,
+) -> Path:
+    """Render an antenna timeline with solution tracks and maintenance windows."""
+
+    case_path = Path(case_dir)
+    solution_file = Path(solution_path)
+    instance = load_case(case_path)
+    solution = load_solution(solution_file)
+    mission_colors = _load_mission_colors()
+    logical_tracks = _logical_tracks(solution)
+
+    output_path = Path(out_path) if out_path is not None else (
+        _solution_output_dir(case_path, solution_file, None) / "timeline.png"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    antennas = _sorted_antennas(instance)
+    y_by_antenna = {antenna: idx for idx, antenna in enumerate(antennas)}
+    fig_height = max(6.5, 0.42 * len(antennas) + 2.2)
+    fig, ax = plt.subplots(figsize=(15.5, fig_height), dpi=180)
+    fig.patch.set_facecolor(_THEME["background"])
+    _apply_axes_theme(ax, grid_axis="x")
+
+    row_height = 0.72
+    for window in instance.maintenance:
+        if window.antenna not in y_by_antenna:
+            continue
+        y = y_by_antenna[window.antenna] - row_height / 2
+        start = mdates.date2num(_to_datetime(window.start_time))
+        end = mdates.date2num(_to_datetime(window.end_time))
+        ax.broken_barh(
+            [(start, end - start)],
+            (y, row_height),
+            facecolors=_THEME["maintenance"],
+            edgecolors="none",
+            alpha=0.96,
+            zorder=2,
+        )
+
+    for track in logical_tracks:
+        fill_color, edge_color = _mission_timeline_color(str(track.sc), mission_colors)
+        full_start, full_end, trx_start, trx_end = _setup_timedelta(track)
+        for antenna in track.resources:
+            if antenna not in y_by_antenna:
+                continue
+            y = y_by_antenna[antenna] - row_height / 2
+            ax.broken_barh(
+                [(full_start, full_end - full_start)],
+                (y, row_height),
+                facecolors=fill_color,
+                edgecolors="none",
+                alpha=0.16,
+                zorder=3,
+            )
+            ax.broken_barh(
+                [(trx_start, trx_end - trx_start)],
+                (y, row_height),
+                facecolors=fill_color,
+                edgecolors=edge_color,
+                linewidth=0.45,
+                alpha=0.95,
+                zorder=4,
+            )
+
+    week_start = _case_week_start(instance)
+    week_end = _case_week_end(instance)
+    ax.set_xlim(mdates.date2num(week_start), mdates.date2num(week_end))
+    ax.set_ylim(-0.8, len(antennas) - 0.2)
+    ax.set_yticks(range(len(antennas)), antennas)
+    ax.invert_yaxis()
+    ax.set_ylabel("Antenna")
+    ax.set_xlabel("UTC time")
+    ax.set_title(
+        f"{instance.case_id or case_path.name}: scheduled antenna timeline",
+        pad=12,
+        fontweight="bold",
+    )
+    ax.xaxis.set_major_locator(mdates.DayLocator(interval=1))
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d\n%a", tz=UTC))
+    ax.xaxis.set_minor_locator(mdates.HourLocator(interval=6))
+
+    unique_missions = sorted({str(track.sc) for track in logical_tracks})
+    busiest = sorted(
+        unique_missions,
+        key=lambda mission_id: sum(
+            track.tracking_off - track.tracking_on
+            for track in logical_tracks
+            if str(track.sc) == mission_id
+        ),
+        reverse=True,
+    )[:8]
+    handles = [Patch(facecolor=_THEME["maintenance"], label="maintenance")]
+    for mission_id in busiest:
+        fill_color, edge_color = _mission_timeline_color(mission_id, mission_colors)
+        handles.append(
+            Patch(facecolor=fill_color, edgecolor=edge_color, label=f"SC {mission_id}")
+        )
+    ax.legend(
+        handles=handles,
+        loc="upper left",
+        bbox_to_anchor=(1.01, 1.0),
+        frameon=False,
+        fontsize=8,
+        title="Color key",
+        title_fontsize=9,
+    )
+
+    arrayed_count = sum(1 for track in logical_tracks if len(track.resources) > 1)
+    footer = (
+        f"{len(logical_tracks)} logical tracks, {len(solution.tracks)} antenna rows; "
+        f"{arrayed_count} tracks use multiple antennas. Solid bars are tracking time; faint same-color shoulders are setup/teardown."
+    )
+    fig.text(0.01, 0.012, footer, ha="left", va="bottom", fontsize=9, color=_THEME["muted"])
+    fig.tight_layout(rect=(0, 0.04, 0.91, 1))
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def render_schedule(
+    case_dir: str | Path,
+    solution_path: str | Path,
+    out_dir: str | Path | None = None,
+) -> tuple[Path, Path]:
+    """Render the solution-aware SatNet visualizer bundle."""
+
+    case_path = Path(case_dir)
+    solution_file = Path(solution_path)
+    output_dir = _solution_output_dir(case_path, solution_file, out_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    satisfaction_path = render_satisfaction(
+        case_path, solution_file, output_dir / "satisfaction.png"
+    )
+    timeline_path = render_timeline(case_path, solution_file, output_dir / "timeline.png")
+    return satisfaction_path, timeline_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render SatNet case and solution plots.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    availability_parser = subparsers.add_parser(
+        "availability",
+        help="Render a case-only antenna/day opportunity heatmap.",
+    )
+    availability_parser.add_argument(
+        "--case-dir",
+        required=True,
+        help="Path to a canonical SatNet case directory.",
+    )
+    availability_parser.add_argument(
+        "--out-path",
+        type=Path,
+        default=None,
+        help="Output PNG path (default: benchmarks/satnet/visualizer/plots/<case_id>/availability.png).",
+    )
+
+    schedule_parser = subparsers.add_parser(
+        "schedule",
+        help="Render solution-aware satisfaction and antenna timeline plots.",
+    )
+    schedule_parser.add_argument(
+        "--case-dir",
+        required=True,
+        help="Path to a canonical SatNet case directory.",
+    )
+    schedule_parser.add_argument(
+        "--solution-path",
+        required=True,
+        help="Path to a SatNet solution JSON file.",
+    )
+    schedule_parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Output directory (default: benchmarks/satnet/visualizer/plots/<case_id>/schedule/<solution_stem>).",
+    )
+
+    args = parser.parse_args(argv)
+    if args.command == "availability":
+        out_path = render_availability(args.case_dir, args.out_path)
+        print(f"Wrote {out_path.resolve()}")
+        return 0
+
+    satisfaction_path, timeline_path = render_schedule(
+        args.case_dir,
+        args.solution_path,
+        args.out_dir,
+    )
+    print(f"Wrote {satisfaction_path.resolve()}")
+    print(f"Wrote {timeline_path.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/benchmarks/stereo_imaging/README.md
+++ b/benchmarks/stereo_imaging/README.md
@@ -345,13 +345,15 @@ The canonical generator writes cases under `dataset/cases/test/` and updates `da
 uv run python -m benchmarks.stereo_imaging.visualizer.run overview \
     --case-dir benchmarks/stereo_imaging/dataset/cases/test/case_0001
 
-# Batch ECEF geometry plots for all stereo candidates in a solution:
-uv run python -m benchmarks.stereo_imaging.visualizer.run batch \
+# Evaluated stereo product pages for a submitted solution:
+uv run python -m benchmarks.stereo_imaging.visualizer.run products \
     --case-dir benchmarks/stereo_imaging/dataset/cases/test/case_0001 \
     --solution-path path/to/solution.json
 ```
 
-The overview renders a small representative set of satellite ground tracks as a muted context layer so target geography remains readable on multi-satellite cases. Use `--max-ground-tracks` to increase, reduce, or hide that layer. Default outputs go to `benchmarks/stereo_imaging/visualizer/plots/<case_id>/`.
+The overview renders a small representative set of satellite ground tracks as a muted context layer so target geography remains readable on multi-satellite cases. Use `--max-ground-tracks` to increase, reduce, or hide that layer.
+
+The products command writes human/VLM-facing PNG pages under `benchmarks/stereo_imaging/visualizer/plots/<case_id>/products/` by default. Use `--max-products` and `--products-per-page` to choose how many evaluated pair/tri-stereo products to render. Each product row includes a target-facing Earth view, a target-local ground swath overlap plot, look geometry, and concise product metrics.
 
 ### Tests
 

--- a/benchmarks/stereo_imaging/README.md
+++ b/benchmarks/stereo_imaging/README.md
@@ -343,15 +343,15 @@ The canonical generator writes cases under `dataset/cases/test/` and updates `da
 ```bash
 # Case overview (ground tracks and target scatter map):
 uv run python -m benchmarks.stereo_imaging.visualizer.run overview \
-    benchmarks/stereo_imaging/dataset/cases/test/case_0001
+    --case-dir benchmarks/stereo_imaging/dataset/cases/test/case_0001
 
 # Batch ECEF geometry plots for all stereo candidates in a solution:
 uv run python -m benchmarks.stereo_imaging.visualizer.run batch \
-    benchmarks/stereo_imaging/dataset/cases/test/case_0001 \
-    path/to/solution.json
+    --case-dir benchmarks/stereo_imaging/dataset/cases/test/case_0001 \
+    --solution-path path/to/solution.json
 ```
 
-Default outputs go to `benchmarks/stereo_imaging/visualizer/plots/<case_id>/`.
+The overview renders a small representative set of satellite ground tracks as a muted context layer so target geography remains readable on multi-satellite cases. Use `--max-ground-tracks` to increase, reduce, or hide that layer. Default outputs go to `benchmarks/stereo_imaging/visualizer/plots/<case_id>/`.
 
 ### Tests
 

--- a/benchmarks/stereo_imaging/visualizer/__init__.py
+++ b/benchmarks/stereo_imaging/visualizer/__init__.py
@@ -1,5 +1,1 @@
 """Stereo imaging visualizer package."""
-
-from .run import main, render_batch, render_overview
-
-__all__ = ["main", "render_batch", "render_overview"]

--- a/benchmarks/stereo_imaging/visualizer/run.py
+++ b/benchmarks/stereo_imaging/visualizer/run.py
@@ -59,6 +59,7 @@ _OBS_COLORS = [
     "#ff9f1c",
     "#c77dff",
 ]
+_SATELLITE_TRACK_COLOR = "#64748b"
 
 _THEME = {
     "background": "#ffffff",
@@ -90,7 +91,7 @@ def _apply_axes_theme(ax: plt.Axes, *, facecolor: str | None = None) -> None:
 def _load_world_texture() -> np.ndarray:
     global _WORLD_TEXTURE
     if _WORLD_TEXTURE is None:
-        for texture_name in ("blue_marble", "natural_earth_50m"):
+        for texture_name in ("natural_earth_50m", "blue_marble"):
             try:
                 image = load_earth_texture(texture_name)
             except Exception:
@@ -293,24 +294,47 @@ def _target_ranges(targets: dict[str, Any]) -> dict[str, float]:
     }
 
 
+def _select_track_satellites(
+    satellites: dict[str, Any],
+    *,
+    max_ground_tracks: int | None,
+) -> list[str]:
+    satellite_ids = sorted(satellites)
+    if max_ground_tracks is None or max_ground_tracks >= len(satellite_ids):
+        return satellite_ids
+    if max_ground_tracks <= 0:
+        return []
+    if max_ground_tracks == 1:
+        return [satellite_ids[0]]
+
+    selected_indices = np.linspace(
+        0,
+        len(satellite_ids) - 1,
+        num=max_ground_tracks,
+        dtype=int,
+    )
+    return [satellite_ids[int(idx)] for idx in selected_indices]
+
+
 def render_overview(
     case_dir: str | Path,
     out_path: str | Path,
     *,
     ground_track_step_s: float,
+    max_ground_tracks: int | None = 4,
 ) -> Path:
     case_path = Path(case_dir)
     out_file = Path(out_path)
     mission, satellites, targets = load_case(case_path)
     sf_sats = _satellite_cache(satellites)
 
-    fig = plt.figure(figsize=(13, 7.5))
+    fig = plt.figure(figsize=(15, 8.5), constrained_layout=True)
     fig.patch.set_facecolor(_THEME["background"])
-    gs = fig.add_gridspec(1, 2, width_ratios=[2.4, 1.2])
+    gs = fig.add_gridspec(1, 2, width_ratios=[3.6, 1.2])
     ax_map = fig.add_subplot(gs[0, 0])
     ax_summary = fig.add_subplot(gs[0, 1])
 
-    _apply_axes_theme(ax_map, facecolor="#09121a")
+    _apply_axes_theme(ax_map)
     ax_map.set_xlim(-180.0, 180.0)
     ax_map.set_ylim(-90.0, 90.0)
     _draw_world_texture(ax_map)
@@ -323,26 +347,26 @@ def render_overview(
         fontweight="bold",
     )
 
-    sat_legend_handles: list[Line2D] = []
-    for sat_index, (sat_id, sf_sat) in enumerate(sf_sats.items()):
+    plotted_satellite_ids = _select_track_satellites(
+        satellites,
+        max_ground_tracks=max_ground_tracks,
+    )
+    for sat_id in plotted_satellite_ids:
+        sf_sat = sf_sats[sat_id]
         segments = _sample_track_segments(
             sf_sat,
             mission.horizon_start,
             mission.horizon_end,
             step_s=ground_track_step_s,
         )
-        color = _OBS_COLORS[sat_index % len(_OBS_COLORS)]
-        sat_legend_handles.append(
-            Line2D([0], [0], color=color, linewidth=2.0, label=sat_id)
-        )
-        for seg_idx, (lon_seg, lat_seg) in enumerate(segments):
+        for lon_seg, lat_seg in segments:
             ax_map.plot(
                 lon_seg,
                 lat_seg,
-                color=color,
-                linewidth=1.6,
-                alpha=0.95,
-                zorder=2,
+                color=_SATELLITE_TRACK_COLOR,
+                linewidth=0.8,
+                alpha=0.36,
+                zorder=1,
             )
 
     scene_legend_handles: list[Line2D] = []
@@ -366,43 +390,40 @@ def render_overview(
         ax_map.scatter(
             [target.longitude_deg for target in scene_targets],
             [target.latitude_deg for target in scene_targets],
-            s=28,
+            s=32,
             color=color,
             edgecolors="white",
-            linewidths=0.6,
+            linewidths=0.7,
             zorder=3,
         )
 
-    sat_legend = ax_map.legend(
-        handles=sat_legend_handles,
-        title="Ground tracks",
-        loc="lower left",
-        bbox_to_anchor=(0.0, -0.24),
-        ncol=max(1, min(2, len(sat_legend_handles))),
-        fontsize=9,
-        title_fontsize=9,
-        frameon=False,
-    )
-    ax_map.add_artist(sat_legend)
     ax_map.legend(
         handles=scene_legend_handles,
         title="Target scenes",
-        loc="lower right",
-        bbox_to_anchor=(1.0, -0.24),
+        loc="lower left",
         ncol=max(1, min(2, len(scene_legend_handles))),
         fontsize=9,
         title_fontsize=9,
-        frameon=False,
+        frameon=True,
+        framealpha=0.92,
     )
 
     counts = _scene_counts(targets)
     ranges = _target_ranges(targets)
+    horizon_hours = (
+        mission.horizon_end - mission.horizon_start
+    ).total_seconds() / 3600.0
     summary_lines = [
         f"Case: {case_path.name}",
-        f"Horizon: {_utc_iso(mission.horizon_start)} to {_utc_iso(mission.horizon_end)}",
+        f"Horizon: {_utc_iso(mission.horizon_start)}",
+        f"to {_utc_iso(mission.horizon_end)}",
+        f"Duration: {horizon_hours:.1f} h",
         "",
-        f"Satellites ({len(satellites)}):",
-        *[f"  - {sat_id}" for sat_id in satellites],
+        f"Satellites: {len(satellites)}",
+        "Ground tracks:",
+        f"  shown: {len(plotted_satellite_ids)}/{len(satellites)}",
+        "  muted representative layer",
+        f"  step: {ground_track_step_s:g}s",
         "",
         f"Targets: {len(targets)}",
         f"  urban_structured: {counts.get('urban_structured', 0)}",
@@ -430,8 +451,7 @@ def render_overview(
     )
 
     out_file.parent.mkdir(parents=True, exist_ok=True)
-    fig.subplots_adjust(left=0.06, right=0.98, top=0.93, bottom=0.18, wspace=0.22)
-    fig.savefig(out_file, dpi=130)
+    fig.savefig(out_file, dpi=180, bbox_inches="tight")
     plt.close(fig)
     return out_file
 
@@ -1044,7 +1064,11 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     overview_parser = subparsers.add_parser("overview", help="Render a case overview PNG.")
-    overview_parser.add_argument("case_dir", help="Path to dataset/cases/<case_id>")
+    overview_parser.add_argument(
+        "--case-dir",
+        required=True,
+        help="Path to dataset/cases/<case_id>",
+    )
     overview_parser.add_argument(
         "--out-path",
         type=Path,
@@ -1057,10 +1081,24 @@ def main(argv: list[str] | None = None) -> int:
         default=300.0,
         help="Satellite ground-track sampling step in seconds (default: 300)",
     )
+    overview_parser.add_argument(
+        "--max-ground-tracks",
+        type=int,
+        default=4,
+        help="Maximum representative satellite tracks to draw; use 0 to hide tracks (default: 4)",
+    )
 
     batch_parser = subparsers.add_parser("batch", help="Render pair and tri geometry snapshots.")
-    batch_parser.add_argument("case_dir", help="Path to dataset/cases/<case_id>")
-    batch_parser.add_argument("solution_path", help="Path to solution JSON")
+    batch_parser.add_argument(
+        "--case-dir",
+        required=True,
+        help="Path to dataset/cases/<case_id>",
+    )
+    batch_parser.add_argument(
+        "--solution-path",
+        required=True,
+        help="Path to solution JSON",
+    )
     batch_parser.add_argument(
         "--out-dir",
         type=Path,
@@ -1082,6 +1120,7 @@ def main(argv: list[str] | None = None) -> int:
             args.case_dir,
             out_path,
             ground_track_step_s=args.ground_track_step_s,
+            max_ground_tracks=args.max_ground_tracks,
         )
         print(f"Wrote overview image to {out_path}")
         return 0

--- a/benchmarks/stereo_imaging/visualizer/run.py
+++ b/benchmarks/stereo_imaging/visualizer/run.py
@@ -1,9 +1,9 @@
 """CLI entry point for the stereo_imaging visualizer."""
+# ruff: noqa: E402
 
 from __future__ import annotations
 
 import argparse
-import json
 import math
 from collections import Counter, defaultdict
 from datetime import UTC, datetime, timedelta
@@ -16,13 +16,13 @@ _BENCHMARK_DIR = _VISUALIZER_DIR.parent
 
 import brahe
 import matplotlib
-import plotly.graph_objects as go
 
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np
 from brahe.plots.texture_utils import load_earth_texture
+from matplotlib import colors as mpl_colors
 from matplotlib.lines import Line2D
 from matplotlib.patches import Circle, Polygon
 from skyfield.api import EarthSatellite
@@ -76,8 +76,11 @@ _THEME = {
 
 _DEFAULT_OUTPUT_ROOT = _VISUALIZER_DIR / "plots"
 _WORLD_TEXTURE_EXTENT = (-180.0, 180.0, -90.0, 90.0)
+_NATURAL_EARTH_10M_CACHE_PATH = (
+    Path(brahe.get_brahe_cache_dir()) / "textures" / "ne_10m_sr" / "NE1_HR_LC_SR_W.tif"
+)
 _WORLD_TEXTURE: np.ndarray | None = None
-_EARTH_TRACE_CACHE: dict[str, go.BaseTraceType] = {}
+_ORTHOGRAPHIC_GLOBE_CACHE: dict[tuple[float, float, float], np.ndarray] = {}
 
 
 def _apply_axes_theme(ax: plt.Axes, *, facecolor: str | None = None) -> None:
@@ -91,7 +94,10 @@ def _apply_axes_theme(ax: plt.Axes, *, facecolor: str | None = None) -> None:
 def _load_world_texture() -> np.ndarray:
     global _WORLD_TEXTURE
     if _WORLD_TEXTURE is None:
-        for texture_name in ("natural_earth_50m", "blue_marble"):
+        texture_names = ["natural_earth_50m", "blue_marble"]
+        if _NATURAL_EARTH_10M_CACHE_PATH.exists():
+            texture_names.insert(0, "natural_earth_10m")
+        for texture_name in texture_names:
             try:
                 image = load_earth_texture(texture_name)
             except Exception:
@@ -102,93 +108,6 @@ def _load_world_texture() -> np.ndarray:
     if _WORLD_TEXTURE is None:
         raise FileNotFoundError("No Brahe Earth texture is available")
     return _WORLD_TEXTURE
-
-
-def _earth_trace() -> go.BaseTraceType:
-    cached = _EARTH_TRACE_CACHE.get("default")
-    if cached is not None:
-        return cached
-
-    radius_m = float(brahe.R_EARTH)
-    try:
-        texture = _load_world_texture()
-    except FileNotFoundError:
-        u = np.linspace(0.0, 2.0 * math.pi, 50)
-        v = np.linspace(0.0, math.pi, 30)
-        x = radius_m * np.outer(np.cos(u), np.sin(v))
-        y = radius_m * np.outer(np.sin(u), np.sin(v))
-        z = radius_m * np.outer(np.ones(np.size(u)), np.cos(v))
-        trace = go.Surface(
-            x=x,
-            y=y,
-            z=z,
-            colorscale="Blues",
-            showscale=False,
-            opacity=0.9,
-            name="Earth",
-            hoverinfo="skip",
-        )
-        _EARTH_TRACE_CACHE["default"] = trace
-        return trace
-
-    n_lon = 120
-    n_lat = 60
-    lons = np.linspace(0.0, 2.0 * math.pi, n_lon)
-    lats = np.linspace(0.0, math.pi, n_lat)
-
-    vertices = []
-    for lat in lats:
-        for lon in lons:
-            x = radius_m * math.sin(lat) * math.cos(lon)
-            y = radius_m * math.sin(lat) * math.sin(lon)
-            z = radius_m * math.cos(lat)
-            vertices.append((x, y, z))
-    verts = np.asarray(vertices, dtype=float)
-
-    faces = []
-    for i in range(n_lat - 1):
-        for j in range(n_lon - 1):
-            v0 = i * n_lon + j
-            v1 = i * n_lon + (j + 1)
-            v2 = (i + 1) * n_lon + j
-            v3 = (i + 1) * n_lon + (j + 1)
-            faces.append((v0, v1, v2))
-            faces.append((v1, v3, v2))
-    face_array = np.asarray(faces, dtype=int)
-
-    img_h, img_w = texture.shape[:2]
-    face_colors: list[str] = []
-    for face in face_array:
-        avg = verts[face].mean(axis=0)
-        r = float(np.linalg.norm(avg))
-        if r <= 0.0:
-            tex_x = tex_y = 0
-        else:
-            lat = math.acos(max(-1.0, min(1.0, avg[2] / r)))
-            lon = math.atan2(avg[1], avg[0])
-            u_coord = (lon % (2.0 * math.pi)) / (2.0 * math.pi)
-            v_coord = lat / math.pi
-            tex_x = min(img_w - 1, max(0, int(u_coord * (img_w - 1))))
-            tex_y = min(img_h - 1, max(0, int(v_coord * (img_h - 1))))
-        rgb = texture[tex_y, tex_x, :3]
-        face_colors.append(f"rgb({int(rgb[0])},{int(rgb[1])},{int(rgb[2])})")
-
-    trace = go.Mesh3d(
-        x=verts[:, 0],
-        y=verts[:, 1],
-        z=verts[:, 2],
-        i=face_array[:, 0],
-        j=face_array[:, 1],
-        k=face_array[:, 2],
-        facecolor=face_colors,
-        showscale=False,
-        name="Earth",
-        hoverinfo="skip",
-        lighting=dict(ambient=0.65, diffuse=0.75, specular=0.15, roughness=0.85),
-        lightposition=dict(x=100000.0, y=100000.0, z=100000.0),
-    )
-    _EARTH_TRACE_CACHE["default"] = trace
-    return trace
 
 
 def _draw_world_texture(ax: plt.Axes) -> None:
@@ -231,9 +150,15 @@ def _utc_iso(value: datetime) -> str:
     return value.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _serialize_json(value: Any, path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+def _action_midpoint(action: Any) -> datetime:
+    return action.start + (action.end - action.start) / 2
+
+
+def _product_time_separation_s(actions: list[Any]) -> float:
+    if len(actions) < 2:
+        return 0.0
+    midpoints = [_action_midpoint(action) for action in actions]
+    return (max(midpoints) - min(midpoints)).total_seconds()
 
 
 def _satellite_cache(satellites: dict[str, Any]) -> dict[str, EarthSatellite]:
@@ -456,10 +381,13 @@ def render_overview(
     return out_file
 
 
-def _candidate_output_dir(case_path: Path, out_dir: str | Path | None) -> Path:
+def _products_output_dir(
+    case_path: Path,
+    out_dir: str | Path | None,
+) -> Path:
     if out_dir is not None:
         return Path(out_dir)
-    return _DEFAULT_OUTPUT_ROOT / case_path.name / "batch"
+    return _DEFAULT_OUTPUT_ROOT / case_path.name / "products"
 
 
 def _overview_output_path(case_path: Path, out_path: str | Path | None) -> Path:
@@ -495,18 +423,6 @@ def _derived_by_action_index(
             strict=True,
         )
     }
-
-
-def _candidate_groups(
-    actions: list[Any],
-    satellites: dict[str, Any],
-    targets: dict[str, Any],
-) -> list[tuple[tuple[str, str], list[int]]]:
-    groups: dict[tuple[str, str], list[int]] = defaultdict(list)
-    for idx in _known_action_indices(actions, satellites, targets):
-        action = actions[idx]
-        groups[(action.satellite_id, action.target_id)].append(idx)
-    return sorted(groups.items(), key=lambda item: (min(item[1]), item[0][0], item[0][1]))
 
 
 def _observation_cache(
@@ -576,21 +492,21 @@ def _polyline_buffer_polygon(polyline: list[tuple[float, float]], half_width_m: 
     normals: list[np.ndarray] = []
     points = [np.asarray(point, dtype=float) for point in polyline]
     for point_idx in range(len(points)):
-        candidate_normals: list[np.ndarray] = []
+        segment_normals: list[np.ndarray] = []
         if point_idx > 0:
             delta = points[point_idx] - points[point_idx - 1]
             if np.linalg.norm(delta) > 1.0e-9:
                 tangent = delta / np.linalg.norm(delta)
-                candidate_normals.append(np.array([-tangent[1], tangent[0]]))
+                segment_normals.append(np.array([-tangent[1], tangent[0]]))
         if point_idx < len(points) - 1:
             delta = points[point_idx + 1] - points[point_idx]
             if np.linalg.norm(delta) > 1.0e-9:
                 tangent = delta / np.linalg.norm(delta)
-                candidate_normals.append(np.array([-tangent[1], tangent[0]]))
-        if candidate_normals:
-            normal = np.sum(candidate_normals, axis=0)
+                segment_normals.append(np.array([-tangent[1], tangent[0]]))
+        if segment_normals:
+            normal = np.sum(segment_normals, axis=0)
             if np.linalg.norm(normal) < 1.0e-9:
-                normal = candidate_normals[0]
+                normal = segment_normals[0]
             normal = normal / np.linalg.norm(normal)
         else:
             normal = np.array([0.0, 1.0])
@@ -606,11 +522,11 @@ def _pair_metric_record(
     j: int,
     obs_cache: dict[int, dict[str, Any]],
     mission: Any,
+    stereo_mode: str,
 ) -> dict[str, Any]:
     oi = obs_cache[i]
     oj = obs_cache[j]
     target_def = oi["target_def"]
-    sat_def = oi["sat_def"]
     target_ecef = oi["target_ecef"]
 
     ui = (oi["sat_mid_ecef"] - target_ecef) / np.linalg.norm(oi["sat_mid_ecef"] - target_ecef)
@@ -637,13 +553,8 @@ def _pair_metric_record(
         ),
     )
     b_h_proxy = float(np.linalg.norm(oi["sat_mid_ecef"] - oj["sat_mid_ecef"])) / mean_alt
-    same_access = (
-        oi["derived"]["access_interval_id"] != "none"
-        and oi["derived"]["access_interval_id"] == oj["derived"]["access_interval_id"]
-    )
     valid = (
-        same_access
-        and overlap_fraction + 1.0e-6 >= mission.min_overlap_fraction
+        overlap_fraction + 1.0e-6 >= mission.min_overlap_fraction
         and mission.min_convergence_deg - 1.0e-6 <= gamma_deg <= mission.max_convergence_deg + 1.0e-6
         and pixel_scale_ratio <= mission.max_pixel_scale_ratio + 1.0e-6
     )
@@ -658,11 +569,12 @@ def _pair_metric_record(
     )
     return {
         "indices": (i, j),
+        "stereo_mode": stereo_mode,
+        "time_separation_s": _product_time_separation_s([oi["action"], oj["action"]]),
         "overlap_fraction": overlap_fraction,
         "gamma_deg": gamma_deg,
         "pixel_scale_ratio": pixel_scale_ratio,
         "b_h_proxy": b_h_proxy,
-        "same_access": same_access,
         "valid": valid,
         "score": q_pair_raw if valid else 0.0,
         "q_pair_raw": q_pair_raw,
@@ -674,6 +586,7 @@ def _tri_metric_record(
     obs_cache: dict[int, dict[str, Any]],
     pair_cache: dict[tuple[int, int], dict[str, Any]],
     mission: Any,
+    edge_modes: list[str],
 ) -> dict[str, Any]:
     obs = [obs_cache[idx] for idx in indices]
     target_def = obs[0]["target_def"]
@@ -695,10 +608,8 @@ def _tri_metric_record(
         <= mission.near_nadir_anchor_max_off_nadir_deg + 1.0e-6
         for entry in obs
     )
-    same_access = len({entry["derived"]["access_interval_id"] for entry in obs}) == 1 and obs[0]["derived"]["access_interval_id"] != "none"
     valid = (
-        same_access
-        and overlap_fraction + 1.0e-6 >= mission.min_overlap_fraction
+        overlap_fraction + 1.0e-6 >= mission.min_overlap_fraction
         and sum(1 for flag in pair_flags if flag) >= 2
         and anchor
     )
@@ -712,10 +623,11 @@ def _tri_metric_record(
     )
     return {
         "indices": indices,
+        "edge_modes": edge_modes,
+        "time_separation_s": _product_time_separation_s([entry["action"] for entry in obs]),
         "overlap_fraction": overlap_fraction,
         "pair_flags": pair_flags,
         "anchor": anchor,
-        "same_access": same_access,
         "valid": valid,
         "score": q_tri if valid else 0.0,
         "q_tri_raw": q_tri,
@@ -723,7 +635,7 @@ def _tri_metric_record(
     }
 
 
-def _candidate_extent(obs_entries: list[dict[str, Any]], aoi_radius_m: float) -> tuple[float, float, float, float]:
+def _product_extent(obs_entries: list[dict[str, Any]], aoi_radius_m: float) -> tuple[float, float, float, float]:
     xs = [0.0]
     ys = [0.0]
     padding = aoi_radius_m
@@ -739,7 +651,16 @@ def _candidate_extent(obs_entries: list[dict[str, Any]], aoi_radius_m: float) ->
     return xmin, xmax, ymin, ymax
 
 
-def _draw_observation_footprint(ax: plt.Axes, obs_entry: dict[str, Any], color: str, action_idx: int) -> None:
+def _draw_observation_footprint(
+    ax: plt.Axes,
+    obs_entry: dict[str, Any],
+    color: str,
+    action_idx: int,
+    obs_number: int,
+) -> None:
+    line_styles = ("-", "--", ":")
+    start_markers = ("s", "D", "P")
+    end_markers = ("^", "v", "X")
     polygon = _polyline_buffer_polygon(obs_entry["polyline_en"], obs_entry["half_width_m"])
     if polygon:
         ax.add_patch(
@@ -755,7 +676,33 @@ def _draw_observation_footprint(ax: plt.Axes, obs_entry: dict[str, Any], color: 
     if obs_entry["polyline_en"]:
         xs = [point[0] for point in obs_entry["polyline_en"]]
         ys = [point[1] for point in obs_entry["polyline_en"]]
-        ax.plot(xs, ys, color=color, linewidth=2.2)
+        ax.plot(
+            xs,
+            ys,
+            color=color,
+            linewidth=2.2,
+            linestyle=line_styles[obs_number % len(line_styles)],
+        )
+        ax.scatter(
+            [xs[0]],
+            [ys[0]],
+            color=color,
+            marker=start_markers[obs_number % len(start_markers)],
+            edgecolor="white",
+            linewidth=0.8,
+            s=34,
+            zorder=4,
+        )
+        ax.scatter(
+            [xs[-1]],
+            [ys[-1]],
+            color=color,
+            marker=end_markers[obs_number % len(end_markers)],
+            edgecolor="white",
+            linewidth=0.8,
+            s=42,
+            zorder=4,
+        )
         mid_idx = len(obs_entry["polyline_en"]) // 2
         ax.scatter([xs[mid_idx]], [ys[mid_idx]], color=color, s=28, zorder=4)
         ax.text(
@@ -770,296 +717,545 @@ def _draw_observation_footprint(ax: plt.Axes, obs_entry: dict[str, Any], color: 
         )
 
 
-def _render_candidate_figure(
+def _product_metric_lines(
     kind: str,
     metric_record: dict[str, Any],
     obs_entries: list[tuple[int, dict[str, Any]]],
-    out_path: Path,
-) -> None:
+) -> list[str]:
     target_def = obs_entries[0][1]["target_def"]
-    validity_color = _THEME["valid"] if metric_record["valid"] else _THEME["invalid"]
     access_ids = [entry["derived"]["access_interval_id"] for _, entry in obs_entries]
-    action_lines = [
-        f"#{action_idx}: {obs_entry['derived']['start_time']} -> {obs_entry['derived']['end_time']}"
-        for action_idx, obs_entry in obs_entries
-    ]
+    access_lines = _access_summary_lines(access_ids)
+    action_lines: list[str] = []
+    for action_idx, obs_entry in obs_entries:
+        action_lines.extend(
+            [
+                f"#{action_idx}: {obs_entry['action'].satellite_id}",
+                f"  {obs_entry['derived']['start_time']} to {obs_entry['derived']['end_time']}",
+            ]
+        )
     if kind == "pair":
-        metric_lines = [
+        return [
+            "PAIR product",
+            f"Target: {target_def.target_id}",
+            f"Scene: {target_def.scene_type}",
             f"Valid: {metric_record['valid']}",
-            f"Same access: {metric_record['same_access']}",
-            f"Access IDs: {', '.join(access_ids)}",
+            f"Mode: {metric_record['stereo_mode']}",
+            f"Time span: {metric_record['time_separation_s']:.1f} s",
+            *access_lines,
             f"Overlap: {metric_record['overlap_fraction']:.3f}",
             f"Convergence: {metric_record['gamma_deg']:.2f} deg",
             f"Pixel ratio: {metric_record['pixel_scale_ratio']:.3f}",
             f"B/H proxy: {metric_record['b_h_proxy']:.3f}",
             f"Score: {metric_record['score']:.3f}",
+            "",
+            *action_lines,
         ]
-    else:
-        metric_lines = [
-            f"Valid: {metric_record['valid']}",
-            f"Same access: {metric_record['same_access']}",
-            f"Access IDs: {', '.join(access_ids)}",
-            f"Common overlap: {metric_record['overlap_fraction']:.3f}",
-            f"Pair valids: {metric_record['pair_flags']}",
-            f"Anchor present: {metric_record['anchor']}",
-            f"Score: {metric_record['score']:.3f}",
-        ]
-    fig = go.Figure()
-    fig.add_trace(_earth_trace())
+    return [
+        "TRI product",
+        f"Target: {target_def.target_id}",
+        f"Scene: {target_def.scene_type}",
+        f"Valid: {metric_record['valid']}",
+        f"Time span: {metric_record['time_separation_s']:.1f} s",
+        f"Edge modes: {', '.join(metric_record['edge_modes'])}",
+        *access_lines,
+        f"Common overlap: {metric_record['overlap_fraction']:.3f}",
+        f"Pair valids: {metric_record['pair_flags']}",
+        f"Anchor present: {metric_record['anchor']}",
+        f"Score: {metric_record['score']:.3f}",
+        "",
+        *action_lines,
+    ]
 
+
+def _format_access_id(access_id: str) -> str:
+    parts = access_id.split("::")
+    if len(parts) == 3:
+        return f"{parts[0]} pass {parts[2]}"
+    return access_id
+
+
+def _access_summary_lines(access_ids: list[str]) -> list[str]:
+    unique_access_ids = list(dict.fromkeys(access_ids))
+    if len(unique_access_ids) == 1:
+        return [f"Access: {_format_access_id(unique_access_ids[0])} ({len(access_ids)} obs)"]
+    lines = ["Accesses:"]
+    lines.extend(f"  {_format_access_id(access_id)}" for access_id in unique_access_ids[:4])
+    if len(unique_access_ids) > 4:
+        lines.append(f"  ... +{len(unique_access_ids) - 4} more")
+    return lines
+
+
+def _submitted_pair_mode(
+    mission: Any,
+    first_entry: dict[str, Any],
+    second_entry: dict[str, Any],
+) -> str | None:
+    first_action = first_entry["action"]
+    second_action = second_entry["action"]
+    first_derived = first_entry["derived"]
+    second_derived = second_entry["derived"]
+    if first_action.target_id != second_action.target_id:
+        return None
+    if first_derived["access_interval_id"] == "none" or second_derived["access_interval_id"] == "none":
+        return None
+    separation_s = _product_time_separation_s([first_action, second_action])
+    if separation_s - 1.0e-6 > mission.max_stereo_pair_separation_s:
+        return None
+    if first_action.satellite_id == second_action.satellite_id:
+        if first_derived["access_interval_id"] != second_derived["access_interval_id"]:
+            return None
+        return "same_satellite_same_pass"
+    if not mission.allow_cross_satellite_stereo:
+        return None
+    return "cross_satellite"
+
+
+def _target_frame_axes(target_vec: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    up = target_vec / np.linalg.norm(target_vec)
+    east = np.cross(np.array([0.0, 0.0, 1.0]), up)
+    if float(np.linalg.norm(east)) < 1.0e-9:
+        east = np.array([0.0, 1.0, 0.0])
+    else:
+        east = east / np.linalg.norm(east)
+    north = np.cross(up, east)
+    north = north / np.linalg.norm(north)
+    return east, north, up
+
+
+def _rotate_ecef_to_target_frame(points: np.ndarray, target_vec: np.ndarray) -> np.ndarray:
+    east, north, up = _target_frame_axes(target_vec)
+    rotation = np.vstack([east, north, up])
+    return np.tensordot(rotation, points, axes=(1, 0))
+
+
+def _orthographic_globe_image(target_vec: np.ndarray, *, pixels: int = 900) -> np.ndarray:
+    target_unit = target_vec / np.linalg.norm(target_vec)
+    cache_key = tuple(round(float(value), 6) for value in target_unit)
+    cached = _ORTHOGRAPHIC_GLOBE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    texture = _load_world_texture()
+    if texture.max(initial=1) > 1:
+        texture = texture.astype(float) / 255.0
+    else:
+        texture = texture.astype(float)
+
+    coords = np.linspace(-1.0, 1.0, pixels)
+    xx, yy = np.meshgrid(coords, coords)
+    rr2 = xx * xx + yy * yy
+    mask = rr2 <= 1.0
+    zz = np.zeros_like(xx)
+    zz[mask] = np.sqrt(1.0 - rr2[mask])
+
+    east, north, up = _target_frame_axes(target_vec)
+    ecef_x = east[0] * xx + north[0] * yy + up[0] * zz
+    ecef_y = east[1] * xx + north[1] * yy + up[1] * zz
+    ecef_z = east[2] * xx + north[2] * yy + up[2] * zz
+    lon = np.arctan2(ecef_y, ecef_x)
+    lat = np.arcsin(np.clip(ecef_z, -1.0, 1.0))
+
+    tex_h, tex_w = texture.shape[:2]
+    tex_x = ((lon + math.pi) / (2.0 * math.pi) * (tex_w - 1)).astype(int)
+    tex_y = ((math.pi / 2.0 - lat) / math.pi * (tex_h - 1)).astype(int)
+    globe = np.ones((pixels, pixels, 4), dtype=float)
+    globe[:, :, :3] = mpl_colors.to_rgb("#eef3f7")
+    globe[:, :, 3] = 0.0
+    globe[mask, :3] = texture[tex_y[mask], tex_x[mask], :3]
+    globe[mask, 3] = 1.0
+    _ORTHOGRAPHIC_GLOBE_CACHE[cache_key] = globe
+    return globe
+
+
+def _draw_product_3d(
+    ax: plt.Axes,
+    kind: str,
+    metric_record: dict[str, Any],
+    obs_entries: list[tuple[int, dict[str, Any]]],
+) -> None:
+    target_def = obs_entries[0][1]["target_def"]
     target_vec = np.asarray(obs_entries[0][1]["target_ecef"], dtype=float)
-    fig.add_trace(
-        go.Scatter3d(
-            x=[target_vec[0]],
-            y=[target_vec[1]],
-            z=[target_vec[2]],
-            mode="markers+text",
-            name="Target",
-            text=[target_def.target_id],
-            textposition="top center",
-            marker=dict(size=7, color="#ffffff", line=dict(color="#111827", width=2)),
-            hovertemplate=(
-                f"Target: {target_def.target_id}<br>"
-                f"Scene: {target_def.scene_type}<br>"
-                f"Lat/Lon: {target_def.latitude_deg:.4f}, {target_def.longitude_deg:.4f}<br>"
-                f"AOI radius: {target_def.aoi_radius_m:.1f} m<br>"
-                f"Elevation: {target_def.elevation_ref_m:.1f} m"
-                "<extra></extra>"
-            ),
-        )
+    radius_m = float(brahe.R_EARTH)
+    ax.imshow(
+        _orthographic_globe_image(target_vec),
+        extent=[-1.0, 1.0, -1.0, 1.0],
+        origin="upper",
+        interpolation="bilinear",
+        zorder=0,
+    )
+    ax.scatter(
+        [0.0],
+        [0.0],
+        s=38,
+        color="#ffffff",
+        edgecolor="#111827",
+        linewidth=1.0,
+        zorder=5,
+    )
+    ax.text(
+        0.022,
+        0.022,
+        f" {target_def.target_id}",
+        color=_THEME["text"],
+        fontsize=7.2,
+        zorder=6,
     )
 
-    extents = [float(np.linalg.norm(target_vec))]
     for obs_number, (action_idx, obs_entry) in enumerate(obs_entries):
         color = _OBS_COLORS[obs_number % len(_OBS_COLORS)]
         sat_vec = np.asarray(obs_entry["sat_mid_ecef"], dtype=float)
-        extents.append(float(np.linalg.norm(sat_vec)))
-        hover = (
-            f"Action #{action_idx}<br>"
-            f"Satellite: {obs_entry['action'].satellite_id}<br>"
-            f"Target: {obs_entry['action'].target_id}<br>"
-            f"Midpoint: {_utc_iso(obs_entry['mid_time'])}<br>"
-            f"Off-nadir: {obs_entry['derived']['boresight_off_nadir_deg']:.2f} deg<br>"
-            f"Azimuth: {obs_entry['derived']['boresight_azimuth_deg']:.2f} deg<br>"
-            f"Effective pixel scale: {obs_entry['derived']['effective_pixel_scale_m']:.2f} m<br>"
-            f"Access interval: {obs_entry['derived']['access_interval_id']}"
-            "<extra></extra>"
+        sat_xyz = _rotate_ecef_to_target_frame(sat_vec.reshape(3, 1), target_vec).reshape(3)
+        sat_x = float(sat_xyz[0] / radius_m)
+        sat_y = float(sat_xyz[1] / radius_m)
+        ax.plot(
+            [sat_x, 0.0],
+            [sat_y, 0.0],
+            color=color,
+            linewidth=0.9,
+            alpha=0.72,
+            zorder=3,
         )
-        fig.add_trace(
-            go.Scatter3d(
-                x=[sat_vec[0]],
-                y=[sat_vec[1]],
-                z=[sat_vec[2]],
-                mode="markers+text",
-                name=f"Obs #{action_idx}",
-                text=[f"#{action_idx}"],
-                textposition="top center",
-                marker=dict(size=5, color=color, line=dict(color="#ffffff", width=1)),
-                hovertemplate=hover,
-            )
-        )
-        fig.add_trace(
-            go.Scatter3d(
-                x=[sat_vec[0], target_vec[0]],
-                y=[sat_vec[1], target_vec[1]],
-                z=[sat_vec[2], target_vec[2]],
-                mode="lines",
-                name=f"Ray #{action_idx}",
-                line=dict(color=color, width=6),
-                hoverinfo="skip",
-                showlegend=False,
-            )
+        ax.scatter(
+            [sat_x],
+            [sat_y],
+            s=14,
+            color=color,
+            edgecolor="#ffffff",
+            linewidth=0.45,
+            zorder=4,
         )
 
-    axis_limit = max(extents) * 1.1
-    metrics_text = "<br>".join(
-        [
-            f"<b>{kind.upper()} candidate</b>",
-            f"Target: {target_def.target_id}",
-            f"Scene: {target_def.scene_type}",
-            f"Valid: <span style='color:{validity_color}'>{metric_record['valid']}</span>",
-            f"Same access: {metric_record['same_access']}",
-            f"Access IDs: {', '.join(access_ids)}",
-            *metric_lines[2:],
-            "",
-            "<b>Observations</b>",
-            *action_lines,
+    ax.set_xlim(-0.3, 0.3)
+    ax.set_ylim(-0.3, 0.3)
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_axis_off()
+    ax.set_facecolor("#eef3f7")
+    validity = "valid" if metric_record["valid"] else "invalid"
+    ax.set_title(f"{kind.upper()} target-facing Earth view ({validity})", color=_THEME["text"], fontsize=9, pad=2)
+
+
+def _draw_product_local_view(
+    ax: plt.Axes,
+    kind: str,
+    metric_record: dict[str, Any],
+    obs_entries: list[tuple[int, dict[str, Any]]],
+) -> None:
+    target_def = obs_entries[0][1]["target_def"]
+    obs_only = [entry for _, entry in obs_entries]
+    _apply_axes_theme(ax, facecolor="#fbfcfe")
+    ax.add_patch(
+        Circle(
+            (0.0, 0.0),
+            target_def.aoi_radius_m,
+            facecolor="#f8fafc",
+            edgecolor=_THEME["target"],
+            linewidth=1.0,
+            alpha=0.85,
+        )
+    )
+    ax.scatter([0.0], [0.0], marker="x", color=_THEME["target"], s=30, zorder=5)
+    for obs_number, (action_idx, obs_entry) in enumerate(obs_entries):
+        _draw_observation_footprint(
+            ax,
+            obs_entry,
+            _OBS_COLORS[obs_number % len(_OBS_COLORS)],
+            action_idx,
+            obs_number,
+        )
+
+    xmin, xmax, ymin, ymax = _product_extent(obs_only, target_def.aoi_radius_m)
+    ax.set_xlim(xmin, xmax)
+    ax.set_ylim(ymin, ymax)
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("East (m)", color=_THEME["text"], fontsize=8)
+    ax.set_ylabel("North (m)", color=_THEME["text"], fontsize=8)
+    ax.tick_params(labelsize=7)
+    validity = "valid" if metric_record["valid"] else "invalid"
+    ax.set_title(f"Ground swath overlap ({validity})", color=_THEME["text"], fontsize=9, pad=2)
+    ax.text(
+        0.5,
+        -0.22,
+        "AOI circle; colored bands = image swaths; lines = boresight paths",
+        transform=ax.transAxes,
+        va="top",
+        ha="center",
+        fontsize=6.8,
+        color=_THEME["muted"],
+    )
+
+
+def _draw_product_look_view(
+    ax: plt.Axes,
+    kind: str,
+    metric_record: dict[str, Any],
+    obs_entries: list[tuple[int, dict[str, Any]]],
+) -> None:
+    target_def = obs_entries[0][1]["target_def"]
+    _apply_axes_theme(ax, facecolor="#fbfcfe")
+    ax.scatter([0.0], [0.0], marker="x", color=_THEME["target"], s=34, zorder=5)
+
+    max_radius = target_def.aoi_radius_m
+    for obs_number, (action_idx, obs_entry) in enumerate(obs_entries):
+        color = _OBS_COLORS[obs_number % len(_OBS_COLORS)]
+        sat_enz = np.asarray(obs_entry["sat_mid_enz"], dtype=float)
+        east_m = float(sat_enz[0])
+        north_m = float(sat_enz[1])
+        up_m = float(sat_enz[2])
+        max_radius = max(max_radius, math.hypot(east_m, north_m))
+        ax.plot([0.0, east_m], [0.0, north_m], color=color, linewidth=1.5, alpha=0.85)
+        ax.scatter([east_m], [north_m], color=color, edgecolor="white", linewidth=0.8, s=34, zorder=4)
+        ax.text(
+            east_m,
+            north_m,
+            f" #{action_idx}\nel {obs_entry['elevation_deg']:.1f} deg\nup {up_m / 1000.0:.0f} km",
+            color=color,
+            fontsize=7,
+            ha="left",
+            va="bottom",
+        )
+
+    lim = max_radius * 1.15 if max_radius > 0.0 else 1.0
+    ax.set_xlim(-lim, lim)
+    ax.set_ylim(-lim, lim)
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("East from target (m)", color=_THEME["text"], fontsize=8)
+    ax.set_ylabel("North from target (m)", color=_THEME["text"], fontsize=8)
+    ax.tick_params(labelsize=7)
+    validity = "valid" if metric_record["valid"] else "invalid"
+    ax.set_title(f"{kind.upper()} look geometry ({validity})", color=_THEME["text"], fontsize=9, pad=2)
+
+
+def _product_sort_key(product: dict[str, Any]) -> tuple[bool, float, float, bool]:
+    metric_record = product["metric_record"]
+    raw_score = float(
+        metric_record.get("q_tri_raw", metric_record.get("q_pair_raw", metric_record.get("score", 0.0)))
+    )
+    return (
+        bool(metric_record["valid"]),
+        float(metric_record.get("score", 0.0)),
+        raw_score,
+        product["kind"] == "tri",
+    )
+
+
+def _collect_product_records(
+    actions: list[Any],
+    satellites: dict[str, Any],
+    targets: dict[str, Any],
+    mission: Any,
+    obs_cache: dict[int, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    pair_cache: dict[tuple[int, int], dict[str, Any]] = {}
+    products: list[dict[str, Any]] = []
+    by_target: dict[str, list[int]] = defaultdict(list)
+    for action_idx, obs_entry in obs_cache.items():
+        by_target[obs_entry["action"].target_id].append(action_idx)
+
+    for _target_id, action_indices in sorted(by_target.items()):
+        action_indices = sorted(action_indices)
+        for pair in combinations(action_indices, 2):
+            stereo_mode = _submitted_pair_mode(mission, obs_cache[pair[0]], obs_cache[pair[1]])
+            if stereo_mode is None:
+                continue
+            pair_record = _pair_metric_record(pair[0], pair[1], obs_cache, mission, stereo_mode)
+            pair_cache[tuple(sorted(pair))] = pair_record
+            products.append(
+                {
+                    "kind": "pair",
+                    "metric_record": pair_record,
+                    "obs_entries": [(pair[0], obs_cache[pair[0]]), (pair[1], obs_cache[pair[1]])],
+                }
+            )
+
+        for tri in combinations(action_indices, 3):
+            edge_modes: list[str] = []
+            tri_pair_records: dict[tuple[int, int], dict[str, Any]] = {}
+            for edge in combinations(tri, 2):
+                edge_key = tuple(sorted(edge))
+                stereo_mode = _submitted_pair_mode(mission, obs_cache[edge[0]], obs_cache[edge[1]])
+                if stereo_mode is None:
+                    break
+                edge_modes.append(stereo_mode)
+                if edge_key not in pair_cache:
+                    pair_cache[edge_key] = _pair_metric_record(edge[0], edge[1], obs_cache, mission, stereo_mode)
+                tri_pair_records[edge_key] = pair_cache[edge_key]
+            if len(edge_modes) != 3:
+                continue
+            tri_record = _tri_metric_record(tuple(tri), obs_cache, tri_pair_records, mission, edge_modes)
+            products.append(
+                {
+                    "kind": "tri",
+                    "metric_record": tri_record,
+                    "obs_entries": [
+                        (tri[0], obs_cache[tri[0]]),
+                        (tri[1], obs_cache[tri[1]]),
+                        (tri[2], obs_cache[tri[2]]),
+                    ],
+                }
+            )
+
+    return sorted(products, key=_product_sort_key, reverse=True)
+
+
+def _render_product_pages(
+    products: list[dict[str, Any]],
+    output_dir: Path,
+    *,
+    case_path: Path,
+    solution_file: Path,
+    report: Any,
+    max_products: int | None,
+    products_per_page: int,
+) -> list[Path]:
+    shown_products = products if max_products is None else products[: max(0, max_products)]
+    products_per_page = max(1, products_per_page)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for stale_path in output_dir.glob("products_*.png"):
+        stale_path.unlink(missing_ok=True)
+
+    if not shown_products:
+        pages: list[list[dict[str, Any]]] = [[]]
+    else:
+        pages = [
+            shown_products[start : start + products_per_page]
+            for start in range(0, len(shown_products), products_per_page)
         ]
-    )
 
-    fig.update_layout(
-        title=dict(
-            text=f"{kind.upper()} ECEF view: {target_def.target_id}",
-            x=0.03,
-            xanchor="left",
-        ),
-        scene=dict(
-            domain=dict(x=[0.0, 0.72], y=[0.0, 1.0]),
-            xaxis=dict(
-                title="ECEF X (m)",
-                showbackground=False,
-                showgrid=False,
-                zeroline=False,
-                range=[-axis_limit, axis_limit],
+    output_paths: list[Path] = []
+    for page_idx, page_products in enumerate(pages, start=1):
+        n_rows = max(1, len(page_products))
+        fig_height = 1.2 + 3.1 * n_rows
+        fig = plt.figure(figsize=(18, fig_height), constrained_layout=True)
+        fig.patch.set_facecolor(_THEME["background"])
+        gs = fig.add_gridspec(
+            n_rows + 1,
+            4,
+            height_ratios=[0.38, *([1.0] * n_rows)],
+            width_ratios=[1.05, 1.05, 1.05, 1.25],
+        )
+
+        ax_header = fig.add_subplot(gs[0, :])
+        ax_header.axis("off")
+        ax_header.text(
+            0.0,
+            0.95,
+            f"Stereo imaging evaluated products: {case_path.name}",
+            va="top",
+            ha="left",
+            fontsize=14,
+            fontweight="bold",
+            color=_THEME["text"],
+        )
+        ax_header.text(
+            0.0,
+            0.35,
+            (
+                f"Solution: {solution_file.name}  |  Verifier valid: {report.valid}  |  "
+                f"Products shown: {len(shown_products)}/{len(products)}  |  Page {page_idx}/{len(pages)}"
             ),
-            yaxis=dict(
-                title="ECEF Y (m)",
-                showbackground=False,
-                showgrid=False,
-                zeroline=False,
-                range=[-axis_limit, axis_limit],
-            ),
-            zaxis=dict(
-                title="ECEF Z (m)",
-                showbackground=False,
-                showgrid=False,
-                zeroline=False,
-                range=[-axis_limit, axis_limit],
-            ),
-            aspectmode="cube",
-            camera=dict(eye=dict(x=1.5, y=1.5, z=1.1)),
-            bgcolor="#0b1220",
-        ),
-        paper_bgcolor="#ffffff",
-        plot_bgcolor="#ffffff",
-        margin=dict(l=10, r=280, t=60, b=10),
-        legend=dict(
-            x=0.01,
-            y=0.98,
-            bgcolor="rgba(255,255,255,0.8)",
-        ),
-        annotations=[
-            dict(
-                x=1.02,
-                y=0.98,
-                xref="paper",
-                yref="paper",
-                xanchor="left",
-                yanchor="top",
-                align="left",
-                showarrow=False,
-                bordercolor=validity_color,
-                borderwidth=2,
-                borderpad=8,
-                bgcolor="#fbfcfe",
-                font=dict(size=12, color=_THEME["text"]),
-                text=metrics_text,
+            va="top",
+            ha="left",
+            fontsize=10,
+            color=_THEME["muted"],
+        )
+
+        if not page_products:
+            ax_empty = fig.add_subplot(gs[1, :])
+            ax_empty.axis("off")
+            ax_empty.text(
+                0.5,
+                0.5,
+                "No evaluated pair or tri-stereo products found in this solution.",
+                ha="center",
+                va="center",
+                fontsize=12,
+                color=_THEME["muted"],
             )
-        ],
-    )
+        else:
+            for row_idx, product in enumerate(page_products, start=1):
+                kind = product["kind"]
+                metric_record = product["metric_record"]
+                obs_entries = product["obs_entries"]
+                ax_3d = fig.add_subplot(gs[row_idx, 0])
+                _draw_product_3d(ax_3d, kind, metric_record, obs_entries)
 
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.write_html(out_path, include_plotlyjs="directory", full_html=True)
+                ax_local = fig.add_subplot(gs[row_idx, 1])
+                _draw_product_local_view(ax_local, kind, metric_record, obs_entries)
+
+                ax_look = fig.add_subplot(gs[row_idx, 2])
+                _draw_product_look_view(ax_look, kind, metric_record, obs_entries)
+
+                ax_text = fig.add_subplot(gs[row_idx, 3])
+                ax_text.axis("off")
+                validity_color = _THEME["valid"] if metric_record["valid"] else _THEME["invalid"]
+                ax_text.text(
+                    0.0,
+                    1.0,
+                    "\n".join(_product_metric_lines(kind, metric_record, obs_entries)),
+                    va="top",
+                    ha="left",
+                    fontsize=8.2,
+                    color=_THEME["text"],
+                    family="monospace",
+                    linespacing=1.25,
+                    bbox=dict(
+                        boxstyle="round,pad=0.45",
+                        facecolor="#fbfcfe",
+                        edgecolor=validity_color,
+                        linewidth=1.2,
+                    ),
+                )
+
+        out_path = output_dir / f"products_{page_idx:03d}.png"
+        fig.savefig(out_path, dpi=160, bbox_inches="tight")
+        plt.close(fig)
+        output_paths.append(out_path)
+    return output_paths
 
 
-def render_batch(
+def render_products(
     case_dir: str | Path,
     solution_path: str | Path,
     out_dir: str | Path | None = None,
     *,
-    limit: int | None = None,
-) -> Path:
+    max_products: int | None = 24,
+    products_per_page: int = 4,
+) -> list[Path]:
     case_path = Path(case_dir)
     solution_file = Path(solution_path)
     mission, satellites, targets = load_case(case_path)
     actions = load_solution_actions(solution_file, case_path.name)
     report = verify_solution(case_path, solution_file)
-    output_dir = _candidate_output_dir(case_path, out_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    for pattern in ("pair__*.png", "tri__*.png", "pair__*.html", "tri__*.html"):
-        for stale_path in output_dir.glob(pattern):
+    output_dir = _products_output_dir(case_path, out_dir)
+
+    legacy_output_dir = _DEFAULT_OUTPUT_ROOT / case_path.name / "batch"
+    cleanup_dirs = {output_dir, legacy_output_dir}
+    for cleanup_dir in cleanup_dirs:
+        for pattern in ("pair__*.png", "tri__*.png", "pair__*.html", "tri__*.html"):
+            for stale_path in cleanup_dir.glob(pattern):
+                stale_path.unlink(missing_ok=True)
+        for stale_path in (cleanup_dir / "manifest.json", cleanup_dir / "plotly.min.js"):
             stale_path.unlink(missing_ok=True)
-    (output_dir / "manifest.json").unlink(missing_ok=True)
 
     derived_by_idx = _derived_by_action_index(report, actions, satellites, targets)
     sf_sats = _satellite_cache(satellites)
     target_ecef = {target_id: _target_ecef_m(target) for target_id, target in targets.items()}
     obs_cache = _observation_cache(actions, derived_by_idx, satellites, targets, sf_sats, target_ecef)
-
-    pair_cache: dict[tuple[int, int], dict[str, Any]] = {}
-    manifest_items: list[dict[str, Any]] = []
-    render_count = 0
-
-    for (_group_key, action_indices) in _candidate_groups(actions, satellites, targets):
-        for pair in combinations(action_indices, 2):
-            if limit is not None and render_count >= limit:
-                break
-            pair_record = _pair_metric_record(pair[0], pair[1], obs_cache, mission)
-            pair_cache[tuple(sorted(pair))] = pair_record
-            out_path = output_dir / (
-                f"pair__{actions[pair[0]].satellite_id}__{actions[pair[0]].target_id}__"
-                f"{pair[0]}_{pair[1]}.html"
-            )
-            _render_candidate_figure(
-                "pair",
-                pair_record,
-                [(pair[0], obs_cache[pair[0]]), (pair[1], obs_cache[pair[1]])],
-                out_path,
-            )
-            manifest_items.append(
-                {
-                    "kind": "pair",
-                    "action_indices": [pair[0], pair[1]],
-                    "satellite_id": actions[pair[0]].satellite_id,
-                    "target_id": actions[pair[0]].target_id,
-                    "access_interval_ids": [
-                        obs_cache[pair[0]]["derived"]["access_interval_id"],
-                        obs_cache[pair[1]]["derived"]["access_interval_id"],
-                    ],
-                    "valid": pair_record["valid"],
-                    "score": pair_record["score"],
-                    "output_path": str(out_path),
-                }
-            )
-            render_count += 1
-        if limit is not None and render_count >= limit:
-            break
-        for tri in combinations(action_indices, 3):
-            if limit is not None and render_count >= limit:
-                break
-            tri_record = _tri_metric_record(tuple(tri), obs_cache, pair_cache, mission)
-            out_path = output_dir / (
-                f"tri__{actions[tri[0]].satellite_id}__{actions[tri[0]].target_id}__"
-                f"{tri[0]}_{tri[1]}_{tri[2]}.html"
-            )
-            _render_candidate_figure(
-                "tri",
-                tri_record,
-                [(tri[0], obs_cache[tri[0]]), (tri[1], obs_cache[tri[1]]), (tri[2], obs_cache[tri[2]])],
-                out_path,
-            )
-            manifest_items.append(
-                {
-                    "kind": "tri",
-                    "action_indices": list(tri),
-                    "satellite_id": actions[tri[0]].satellite_id,
-                    "target_id": actions[tri[0]].target_id,
-                    "access_interval_ids": [obs_cache[idx]["derived"]["access_interval_id"] for idx in tri],
-                    "valid": tri_record["valid"],
-                    "score": tri_record["score"],
-                    "output_path": str(out_path),
-                }
-            )
-            render_count += 1
-        if limit is not None and render_count >= limit:
-            break
-
-    manifest = {
-        "case_id": case_path.name,
-        "solution_path": str(solution_file),
-        "verifier_valid": report.valid,
-        "verifier_violations": report.violations,
-        "rendered_pairs": sum(1 for item in manifest_items if item["kind"] == "pair"),
-        "rendered_tris": sum(1 for item in manifest_items if item["kind"] == "tri"),
-        "items": manifest_items,
-    }
-    _serialize_json(manifest, output_dir / "manifest.json")
-    return output_dir
+    products = _collect_product_records(actions, satellites, targets, mission, obs_cache)
+    return _render_product_pages(
+        products,
+        output_dir,
+        case_path=case_path,
+        solution_file=solution_file,
+        report=report,
+        max_products=max_products,
+        products_per_page=products_per_page,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Stereo imaging visualizer with overview and batch geometry rendering.",
+        description="Stereo imaging visualizer with overview and evaluated-product rendering.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -1088,29 +1284,38 @@ def main(argv: list[str] | None = None) -> int:
         help="Maximum representative satellite tracks to draw; use 0 to hide tracks (default: 4)",
     )
 
-    batch_parser = subparsers.add_parser("batch", help="Render pair and tri geometry snapshots.")
-    batch_parser.add_argument(
-        "--case-dir",
-        required=True,
-        help="Path to dataset/cases/<case_id>",
-    )
-    batch_parser.add_argument(
-        "--solution-path",
-        required=True,
-        help="Path to solution JSON",
-    )
-    batch_parser.add_argument(
-        "--out-dir",
-        type=Path,
-        default=None,
-        help="Directory for batch HTML outputs (default: benchmarks/stereo_imaging/visualizer/plots/<case>/batch)",
-    )
-    batch_parser.add_argument(
-        "--limit",
-        type=int,
-        default=None,
-        help="Optional cap on total rendered images",
-    )
+    def add_products_args(command_parser: argparse.ArgumentParser) -> None:
+        command_parser.add_argument(
+            "--case-dir",
+            required=True,
+            help="Path to dataset/cases/<case_id>",
+        )
+        command_parser.add_argument(
+            "--solution-path",
+            required=True,
+            help="Path to solution JSON",
+        )
+        command_parser.add_argument(
+            "--out-dir",
+            type=Path,
+            default=None,
+            help="Directory for products_*.png pages (default: benchmarks/stereo_imaging/visualizer/plots/<case>/products)",
+        )
+        command_parser.add_argument(
+            "--max-products",
+            type=int,
+            default=24,
+            help="Maximum evaluated products to render across all pages (default: 24)",
+        )
+        command_parser.add_argument(
+            "--products-per-page",
+            type=int,
+            default=4,
+            help="Maximum evaluated products per PNG page (default: 4)",
+        )
+
+    products_parser = subparsers.add_parser("products", help="Render evaluated stereo product PNG pages.")
+    add_products_args(products_parser)
 
     args = parser.parse_args(argv)
 
@@ -1125,13 +1330,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Wrote overview image to {out_path}")
         return 0
 
-    output_dir = render_batch(
+    output_paths = render_products(
         args.case_dir,
         args.solution_path,
         args.out_dir,
-        limit=args.limit,
+        max_products=args.max_products,
+        products_per_page=args.products_per_page,
     )
-    print(f"Wrote batch outputs to {output_dir}")
+    print(f"Wrote {len(output_paths)} product image page(s) to {output_paths[0].parent}")
     return 0
 
 

--- a/docs/benchmark_contract.md
+++ b/docs/benchmark_contract.md
@@ -43,6 +43,15 @@ Benchmark entrypoint invocation follows the file layout:
 
 Do not support both invocation styles for the same entrypoint. (This is part of the public contract, but the contract validator currently selects the first matching entrypoint and does not error when both are present.) Do not add bootstrap hacks (`sys.path` surgery, fake runtime packages) solely to make a nested `run.py` work as a direct path script.
 
+Visualizers are optional inspection tools. When a benchmark provides one, prefer named input flags for consistency:
+
+```bash
+python -m benchmarks.<name>.visualizer.run <command> --case-dir <case_dir>
+python -m benchmarks.<name>.visualizer.run <command> --case-dir <case_dir> --solution-path <solution_path>
+```
+
+Do not make visualizer availability or a benchmark-wide visualizer command matrix a required CI gate.
+
 ## Dataset Contract
 
 The canonical dataset layout for finished benchmarks is:

--- a/docs/benchmark_contract.md
+++ b/docs/benchmark_contract.md
@@ -43,14 +43,12 @@ Benchmark entrypoint invocation follows the file layout:
 
 Do not support both invocation styles for the same entrypoint. (This is part of the public contract, but the contract validator currently selects the first matching entrypoint and does not error when both are present.) Do not add bootstrap hacks (`sys.path` surgery, fake runtime packages) solely to make a nested `run.py` work as a direct path script.
 
-Visualizers are optional inspection tools. When a benchmark provides one, prefer named input flags for consistency:
+Visualizers are optional inspection tools for humans and VLMs. They should emit plots, images, or videos rather than machine-readable sidecar artifacts. When a benchmark provides one, prefer named input flags for consistency:
 
 ```bash
 python -m benchmarks.<name>.visualizer.run <command> --case-dir <case_dir>
 python -m benchmarks.<name>.visualizer.run <command> --case-dir <case_dir> --solution-path <solution_path>
 ```
-
-Do not make visualizer availability or a benchmark-wide visualizer command matrix a required CI gate.
 
 ## Dataset Contract
 

--- a/tests/benchmarks/test_regional_coverage_visualizer.py
+++ b/tests/benchmarks/test_regional_coverage_visualizer.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 import json
 
-from benchmarks.regional_coverage.visualizer.run import render_inspection, render_overview
+from benchmarks.regional_coverage.visualizer.run import (
+    _select_ground_track_items,
+    render_inspection,
+    render_overview,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -30,6 +34,21 @@ def test_render_overview_writes_html(tmp_path: Path) -> None:
     assert written == out_path
     assert out_path.is_file()
     assert out_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_select_ground_track_items_spreads_representatives() -> None:
+    items = [(f"sat_{idx:02d}", object()) for idx in range(1, 12)]
+
+    selected = _select_ground_track_items(items, max_ground_tracks=4)
+
+    assert [sat_id for sat_id, _ in selected] == ["sat_01", "sat_04", "sat_07", "sat_11"]
+
+
+def test_select_ground_track_items_can_hide_or_show_all_tracks() -> None:
+    items = [(f"sat_{idx:02d}", object()) for idx in range(1, 4)]
+
+    assert _select_ground_track_items(items, max_ground_tracks=0) == []
+    assert _select_ground_track_items(items, max_ground_tracks=None) == items
 
 
 def test_render_inspection_example_solution_writes_summary_and_manifest(tmp_path: Path) -> None:

--- a/tests/benchmarks/test_relay_constellation_visualizer.py
+++ b/tests/benchmarks/test_relay_constellation_visualizer.py
@@ -1,0 +1,74 @@
+"""Smoke tests for the relay_constellation visualizer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image
+
+from benchmarks.relay_constellation.visualizer.plot import render_overview
+from benchmarks.relay_constellation.visualizer.run import main
+from benchmarks.relay_constellation.visualizer.solution import render_solution
+
+
+FIXTURE_DIR = Path("tests/fixtures/relay_constellation/full_service_valid")
+
+
+def _texture_path(tmp_path: Path) -> Path:
+    path = tmp_path / "earth.png"
+    Image.new("RGB", (720, 360), color=(128, 172, 205)).save(path)
+    return path
+
+
+def test_render_overview_writes_two_pngs_only(tmp_path: Path) -> None:
+    out_dir = tmp_path / "overview"
+    result = render_overview(
+        FIXTURE_DIR,
+        out_dir,
+        texture_path=_texture_path(tmp_path),
+    )
+
+    assert result["ground_tracks_png"] == "ground_tracks.png"
+    assert result["baseline_connectivity_png"] == "baseline_connectivity.png"
+    assert (out_dir / "ground_tracks.png").is_file()
+    assert (out_dir / "baseline_connectivity.png").is_file()
+    assert not (out_dir / "manifest.json").exists()
+    assert not (out_dir / "connectivity_manifest.json").exists()
+
+
+def test_render_solution_writes_pngs_only(tmp_path: Path) -> None:
+    out_dir = tmp_path / "solution"
+    result = render_solution(
+        FIXTURE_DIR,
+        FIXTURE_DIR / "solution.json",
+        out_dir,
+        texture_path=_texture_path(tmp_path),
+    )
+
+    assert result["ground_tracks_png"] == "ground_tracks.png"
+    assert result["scheduled_connectivity_png"] == "scheduled_connectivity.png"
+    assert result["demand_window_pngs"] == ["demand_windows/demand_001.png"]
+    assert (out_dir / "ground_tracks.png").is_file()
+    assert (out_dir / "scheduled_connectivity.png").is_file()
+    assert (out_dir / "demand_windows" / "demand_001.png").is_file()
+    assert not (out_dir / "summary.json").exists()
+    assert not (out_dir / "snapshots").exists()
+
+
+def test_visualizer_cli_uses_named_flags(tmp_path: Path) -> None:
+    out_dir = tmp_path / "cli"
+
+    assert main(
+        [
+            "overview",
+            "--case-dir",
+            str(FIXTURE_DIR),
+            "--out-dir",
+            str(out_dir),
+            "--texture-path",
+            str(_texture_path(tmp_path)),
+        ]
+    ) == 0
+
+    assert (out_dir / "ground_tracks.png").is_file()
+    assert (out_dir / "baseline_connectivity.png").is_file()

--- a/tests/benchmarks/test_revisit_constellation_visualizer.py
+++ b/tests/benchmarks/test_revisit_constellation_visualizer.py
@@ -1,0 +1,71 @@
+"""Smoke tests for the revisit_constellation visualizer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+from benchmarks.revisit_constellation.visualizer.run import (
+    render_overview,
+    render_solution,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "revisit_constellation"
+CASE_DIR = FIXTURE_DIR / "single_observation_valid"
+SOLUTION_PATH = CASE_DIR / "solution.json"
+
+
+def _assert_png(path: Path) -> None:
+    assert path.is_file()
+    assert path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_render_overview_writes_png(tmp_path: Path) -> None:
+    out_path = tmp_path / "overview.png"
+
+    written = render_overview(CASE_DIR, out_path)
+
+    assert written == out_path
+    _assert_png(out_path)
+
+
+def test_render_solution_writes_target_pages(tmp_path: Path) -> None:
+    written = render_solution(
+        CASE_DIR,
+        SOLUTION_PATH,
+        tmp_path,
+        max_targets=1,
+        max_actions_per_target=1,
+        track_window_min=10.0,
+        track_step_s=120.0,
+    )
+
+    assert len(written) == 1
+    assert written[0].name.startswith("target_01_t1")
+    _assert_png(written[0])
+
+
+def test_visualizer_cli_named_flags(tmp_path: Path) -> None:
+    out_path = tmp_path / "overview.png"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "benchmarks.revisit_constellation.visualizer.run",
+            "overview",
+            "--case-dir",
+            str(CASE_DIR),
+            "--out-path",
+            str(out_path),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    _assert_png(out_path)

--- a/tests/benchmarks/test_satnet_visualizer.py
+++ b/tests/benchmarks/test_satnet_visualizer.py
@@ -1,0 +1,75 @@
+"""Smoke tests for the SatNet visualizer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+from benchmarks.satnet.visualizer.run import (
+    _availability_counts,
+    render_availability,
+    render_schedule,
+)
+from benchmarks.satnet.verifier import load_case
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CASE_DIR = REPO_ROOT / "benchmarks" / "satnet" / "dataset" / "cases" / "test" / "W10_2018"
+SOLUTION_PATH = REPO_ROOT / "tests" / "fixtures" / "satnet_mock_solutions" / "W10_2018_solution.json"
+
+
+def _assert_png(path: Path) -> None:
+    assert path.is_file()
+    assert path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_availability_counts_match_expected_shape() -> None:
+    instance = load_case(CASE_DIR)
+
+    antennas, counts = _availability_counts(instance)
+
+    assert counts.shape == (len(antennas), 7)
+    assert "DSS-34" in antennas
+    assert counts.sum() > 0
+
+
+def test_render_availability_writes_png(tmp_path: Path) -> None:
+    out_path = tmp_path / "availability.png"
+
+    written = render_availability(CASE_DIR, out_path)
+
+    assert written == out_path
+    _assert_png(out_path)
+
+
+def test_render_schedule_writes_satisfaction_and_timeline(tmp_path: Path) -> None:
+    satisfaction_path, timeline_path = render_schedule(CASE_DIR, SOLUTION_PATH, tmp_path)
+
+    assert satisfaction_path.name == "satisfaction.png"
+    assert timeline_path.name == "timeline.png"
+    _assert_png(satisfaction_path)
+    _assert_png(timeline_path)
+
+
+def test_visualizer_cli_named_flags(tmp_path: Path) -> None:
+    availability_path = tmp_path / "availability.png"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "benchmarks.satnet.visualizer.run",
+            "availability",
+            "--case-dir",
+            str(CASE_DIR),
+            "--out-path",
+            str(availability_path),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    _assert_png(availability_path)

--- a/tests/benchmarks/test_stereo_imaging_visualizer.py
+++ b/tests/benchmarks/test_stereo_imaging_visualizer.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from benchmarks.stereo_imaging.visualizer.run import _select_track_satellites
+from pathlib import Path
+
+from benchmarks.stereo_imaging.visualizer.run import (
+    _DEFAULT_OUTPUT_ROOT,
+    _access_summary_lines,
+    _products_output_dir,
+    _select_track_satellites,
+)
 
 
 def test_select_track_satellites_spreads_representatives() -> None:
@@ -22,3 +29,18 @@ def test_select_track_satellites_can_hide_or_show_all_tracks() -> None:
         "sat_02",
         "sat_03",
     ]
+
+
+def test_products_output_defaults_to_page_directory() -> None:
+    assert _products_output_dir(Path("/cases/case_0001"), None) == _DEFAULT_OUTPUT_ROOT / "case_0001" / "products"
+    assert _products_output_dir(Path("/cases/case_0001"), Path("/tmp/out")) == Path("/tmp/out")
+
+
+def test_access_summary_lines_keep_text_compact() -> None:
+    assert _access_summary_lines(
+        [
+            "sat_dubaisat_1::urban_heyuan_30::0",
+            "sat_dubaisat_1::urban_heyuan_30::0",
+            "sat_dubaisat_1::urban_heyuan_30::0",
+        ]
+    ) == ["Access: sat_dubaisat_1 pass 0 (3 obs)"]

--- a/tests/benchmarks/test_stereo_imaging_visualizer.py
+++ b/tests/benchmarks/test_stereo_imaging_visualizer.py
@@ -1,0 +1,24 @@
+"""Small regressions for the stereo_imaging visualizer."""
+
+from __future__ import annotations
+
+from benchmarks.stereo_imaging.visualizer.run import _select_track_satellites
+
+
+def test_select_track_satellites_spreads_representatives() -> None:
+    satellites = {f"sat_{idx:02d}": object() for idx in range(1, 12)}
+
+    selected = _select_track_satellites(satellites, max_ground_tracks=4)
+
+    assert selected == ["sat_01", "sat_04", "sat_07", "sat_11"]
+
+
+def test_select_track_satellites_can_hide_or_show_all_tracks() -> None:
+    satellites = {f"sat_{idx:02d}": object() for idx in range(1, 4)}
+
+    assert _select_track_satellites(satellites, max_ground_tracks=0) == []
+    assert _select_track_satellites(satellites, max_ground_tracks=None) == [
+        "sat_01",
+        "sat_02",
+        "sat_03",
+    ]


### PR DESCRIPTION
## Summary

Closes #15.

This PR adds and refines human-facing benchmark visualizers for the visualizer push we scoped for issue #15:

- standardizes optional visualizer CLIs around named `--case-dir` / `--solution-path` flags where touched
- improves satellite ground-track rendering and Earth textures for existing visualizers
- adds solution-aware Stereo Imaging product plots without machine-readable sidecars
- adds SatNet availability, satisfaction, and timeline plots
- adds Revisit Constellation overview and solution/action plots
- refactors Relay Constellation visualizer into case-only overview plots and solution-aware scheduled connectivity plots
- removes relay visualizer JSON sidecar outputs and keeps artifacts human/VLM-facing PNGs

Further visualizer additions or refinements should be handled as follow-up issues and separate PRs.

## Validation

Focused checks run during development included:

- `uv run ruff check benchmarks/relay_constellation/visualizer tests/benchmarks/test_relay_constellation_visualizer.py`
- `uv run pytest tests/benchmarks/test_relay_constellation_visualizer.py`
- broader relay verifier + visualizer test pass: `18 passed`
- focused visualizer tests for the added/refined benchmark visualizers as each benchmark was implemented
- manual rendering/inspection of representative real dataset visualizer outputs for Stereo Imaging, SatNet, Revisit Constellation, and Relay Constellation